### PR TITLE
Agrego a los issuer de documentos tipo "M" a los responsables incriptos

### DIFF
--- a/l10n_ar_invoice/data/afip.document_letter.csv
+++ b/l10n_ar_invoice/data/afip.document_letter.csv
@@ -2,6 +2,6 @@ id,name,issuer_ids/id,receptor_ids/id,vat_discriminated
 dl_a,A,res_IVARI,"res_IVARNI,res_IVARI",True
 dl_b,B,res_IVARI,"res_CF,res_RM,res_IVANR,res_IVAE",False
 dl_c,C,"res_IVANR,res_RM,res_IVARNI,res_IVAE","res_RM,res_IVARI,res_IVARNI,res_IVANR,res_CF,res_IVAE",False
-dl_m,M,,,True
+dl_m,M,res_IVARI,"res_IVARNI,res_IVARI",True
 dl_e,E,"res_IVARI,res_RM",res_EXT,False
 dl_x,X,"res_IVARI,res_IVANR,res_RM,res_IVARNI,res_IVAE","res_IVARI,res_IVANR,res_RM,res_IVARNI,res_IVAE",True


### PR DESCRIPTION
(y receptores responsables incriptos y no inscriptos).

Este commit resolvería la emisión de facturas M por parte de los responsables
inscriptos que han sido autorizados a emisión de este tipo de comprobantes
según la res de AFIP 3749
