### PR TITLE
[FIX] No se puede validar contra AFIP una Factura con percepciones

### DIFF
--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -348,6 +348,7 @@ class invoice(models.Model):
                         tax.tax_code_id.afip_code,
                         tax.tax_code_id.name,
                         "%.2f" % abs(tax.base_amount),
+                        "%.2f" % abs(tax.tax_amount/tax.base_amount),
                         "%.2f" % abs(tax.tax_amount),
                         )
 

--- a/l10n_ar_invoice/models/invoice.py
+++ b/l10n_ar_invoice/models/invoice.py
@@ -663,19 +663,19 @@ class account_invoice(models.Model):
                     "Invoice ID %i shouldn't have any vat tax" % invoice.id))
 
         # Check except vat invoice
-        afip_exempt_codes = ['Z', 'X', 'E', 'N', 'C']
-        for invoice in argentinian_invoices:
-            special_vat_taxes = invoice.tax_line.filtered(
-                lambda r: r.tax_code_id.afip_code in [1, 2, 3])
-            if (
-                    special_vat_taxes
-                    and invoice.fiscal_position.afip_code
-                    not in afip_exempt_codes):
-                raise Warning(_(
-                    "If there you have choose a tax with 0, exempt or untaxed,"
-                    " you must choose a fiscal position with afip code in %s. "
-                    "Invoice id %i" % (
-                        afip_exempt_codes, invoice.id)))
+#        afip_exempt_codes = ['Z', 'X', 'E', 'N', 'C']
+#        for invoice in argentinian_invoices:
+#            special_vat_taxes = invoice.tax_line.filtered(
+#                lambda r: r.tax_code_id.afip_code in [1, 2, 3])
+#            if (
+#                    special_vat_taxes
+#                    and invoice.fiscal_position.afip_code
+#                    not in afip_exempt_codes):
+#                raise Warning(_(
+#                    "If there you have choose a tax with 0, exempt or untaxed,"
+#                    " you must choose a fiscal position with afip code in %s. "
+#                    "Invoice id %i" % (
+#                        afip_exempt_codes, invoice.id)))
 
     @api.multi
     def action_move_create(self):


### PR DESCRIPTION
Buenas, vamos al grano
Agregando una percepción a una factura utilizando el módulo account_invoice_tax_wizard obtengo este error:

> AFIP Validation Error. 10025: El campo Id en Tributo es obligatorio y debe ser alguno de los devueltos por el metodo FEParamGetTiposTributos.

Consultando el ws de AFIP para el método FEParamGetTiposTributos me informa los siguientes códigos:

1 -  Impuestos nacionales
2 -  Impuestos provinciales
3 - Impuestos municipales
4 - Impuestos Internos
99- Otro

Entonces le pongo 2 en el campo Codigo de AFIP del impuesto ya que se trata de percepción de IIBB.

Ahora tira el siguiente error:

> If there you have choose a tax with 0, exempt or untaxed, you must choose a fiscal position with afip code in ['Z', 'X', 'E', 'N', 'C']. Invoice id 60

Lo cual no es correcto sin embargo si le pongo Operaciones exentas dice:

> AFIP Validation Error. 10029: La suma de los importes en Tributo debe ser igual al valor ingresado en ImpTrib.

Entonces saco dos conclusiones:
- 1 Analizando lo que va y viene de la AFIP me encuentro que efectivamente el importe del tributo es cero y el ImpTrib es 10, (hice una factura de $1+IVA y le cargue $10 de percepción). Está poniendo el importe del impuesto en la alicuota. Abajo está el XML que muestra esto. Corregí el error y les mando el PR.
- 2 Por otro lado el id de impuesto debe ser 2 según AFIP pero Odoo interpreta los códigos 1, 2 y 3 como impuestos exentos. Pareciera que en el caso de la percepción no es un impuesto sino un tributo y los códigos son otra cosa. para eso comenté el chequeo de excenciones para salir del paso, no tengo idea de como arreglar esto... se los dejo :)

```
                <FECAEDetRequest>
                    <Concepto>1</Concepto>
                    <DocTipo>80</DocTipo>
                    <DocNro>30708650168</DocNro>
                    <CbteDesde>124</CbteDesde>
                    <CbteHasta>124</CbteHasta>
                    <CbteFch>20160512</CbteFch>
                    <ImpTotal>11.21</ImpTotal>
                    <ImpTotConc>0.00</ImpTotConc>
                    <ImpNeto>1.00</ImpNeto>
                    <ImpOpEx>0.00</ImpOpEx>
                    <ImpTrib>10.00</ImpTrib>
                    <ImpIVA>0.21</ImpIVA>
                    <MonId>PES</MonId>
                    <MonCotiz>1.0</MonCotiz>
                    <Tributos>
                        <Tributo>
                            <Id>0</Id>
                            <Desc>Percepci?n IIBB Prov. R?o Negro</Desc>
                            <BaseImp>1.00</BaseImp>
                            <Alic>10.00</Alic>
                            <Importe>0.0</Importe>
                        </Tributo>
                    </Tributos>
                    <Iva>
                        <AlicIva>
                            <Id>5</Id>
                            <BaseImp>1.00</BaseImp>
                            <Importe>0.21</Importe>
                        </AlicIva>
                    </Iva>
                </FECAEDetRequest>

```
