### PR TITLE
IMP Signature: SHA256 - Key size: 2048

### DIFF
--- a/l10n_ar_afipws/models/afipws_certificate_alias.py
+++ b/l10n_ar_afipws/models/afipws_certificate_alias.py
@@ -150,7 +150,7 @@ class afipws_certificate_alias(models.Model):
         return True
 
     @api.one
-    def generate_key(self, key_length=1024):
+    def generate_key(self, key_length=2048):
         """
         """
         # TODO reemplazar todo esto por las funciones nativas de pyafipws
@@ -193,7 +193,7 @@ class afipws_certificate_alias(models.Model):
             k = crypto.load_privatekey(crypto.FILETYPE_PEM, self.key)
             self.key = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
             req.set_pubkey(k)
-            req.sign(k, 'sha1')
+            req.sign(k, 'sha256')
             csr = crypto.dump_certificate_request(crypto.FILETYPE_PEM, req)
             vals = {
                 'csr': csr,


### PR DESCRIPTION
Cuando solicito un certificado de homologación para factura electrónica en la AFIP aparece el siguiente mensaje de error:

```
La longitud de clave pública debe ser estar comprendida entre 2048 y 8192 bits
```

Esto se debe que a partir del 01/11/2016 se renovarán los certificados SSL utilizados por los Webservices de AFIP. Los nuevos certificados utilizarán el Algoritmo de encripción SHA-2.

[Más información](http://www.afip.gob.ar/ws/comoAfectaElCambio.asp)

Cambiando el key_size y la firma del PR se genera un certificado que es aceptado correctamente por el servicio de certificados de homologación de la AFIP (WSASS - Autogestión Certificados Homologación).
