### PR TITLE
[8.0][IMP] Padron Title Case

### DIFF
--- a/l10n_ar_padron_afip/__openerp__.py
+++ b/l10n_ar_padron_afip/__openerp__.py
@@ -45,5 +45,5 @@
     'installable': True,
     'name': 'Padron AFIP Argentino',
     'test': [],
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.3.0',
 }

--- a/l10n_ar_padron_afip/wizard/res_partner_update_from_padron_wizard.py
+++ b/l10n_ar_padron_afip/wizard/res_partner_update_from_padron_wizard.py
@@ -111,6 +111,11 @@ class res_partner_update_from_padron_wizard(models.TransientModel):
     update_constancia = fields.Boolean(
         default=True,
     )
+    title_case = fields.Boolean(
+        string='Title Case',
+        help='Converts retreived text fields to Title Case.',
+        default=True,
+    )
     field_to_update_ids = fields.Many2many(
         'ir.model.fields',
         'res_partner_update_fields',
@@ -137,6 +142,8 @@ class res_partner_update_from_padron_wizard(models.TransientModel):
                 old_value = getattr(partner, key)
                 if new_value == '':
                     new_value = False
+                if self.title_case and key in ('name', 'city', 'street'):
+                    new_value = new_value and new_value.title()
                 if key in ('impuestos_padron', 'actividades_padron'):
                     old_value = old_value.ids
                 elif key == 'state_id':

--- a/l10n_ar_padron_afip/wizard/res_partner_update_from_padron_wizard_view.xml
+++ b/l10n_ar_padron_afip/wizard/res_partner_update_from_padron_wizard_view.xml
@@ -62,6 +62,7 @@
                         <group attrs="{'invisible': [('state', 'not in', ('option',))]}">
                             <field name="field_to_update_ids" widget="many2many_tags" options="{'no_create': True}" />
                             <field name="update_constancia"/>
+                            <field name="title_case"/>
                         </group>
                         <group attrs="{'invisible': [('state', 'in', ('option', 'finished'))]}" col="1">
                             <field name="partner_id" attrs="{'required': [('state', '=', 'selection')]}"/>


### PR DESCRIPTION
Agrega una opción para convertir los valores recuperados a Title Case.
Está activada por defecto, pero si eso es un problema se puede dejar desactivado.
