### PR TITLE
[9.0][ADD] account_bank_statement_import

### DIFF
--- a/l10n_ar_account_bank_statement_import_csv/README.rst
+++ b/l10n_ar_account_bank_statement_import_csv/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================================
+Argentinian Bank Statement CSV Templates
+========================================
+
+Includes CSV Bank Statement Templates for Banks of Argentina
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.adhoc.com.ar/
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* ADHOC SA: `Icon <http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png>`_.
+
+Contributors
+------------
+
+* Iván Todorovich <ivan.todorovich@gmail.com>
+
+Maintainer
+----------
+
+.. image:: http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png
+   :alt: Odoo Community Association
+   :target: https://www.adhoc.com.ar
+
+This module is maintained by the ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_account_bank_statement_import_csv/__init__.py
+++ b/l10n_ar_account_bank_statement_import_csv/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).

--- a/l10n_ar_account_bank_statement_import_csv/__openerp__.py
+++ b/l10n_ar_account_bank_statement_import_csv/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Bank Statements CSV Templates de Argentina',
+    'version': '9.0.0.0.0',
+    'license': 'AGPL-3',
+    'author': 'Odoo Community Association (OCA), Ivan Todorovich',
+    'website': 'https://github.com/OCA/bank-statement-import',
+    'category': 'Banking addons',
+    'depends': [
+        'account_bank_statement_import_csv',
+    ],
+    'data': [
+        'data/account_bank_statement_import_csv_templates.xml',
+    ],
+}

--- a/l10n_ar_account_bank_statement_import_csv/data/account_bank_statement_import_csv_templates.xml
+++ b/l10n_ar_account_bank_statement_import_csv/data/account_bank_statement_import_csv_templates.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record model="account.bank.statement.import.csv.template" id="Galicia">
+            <field name="name">Banco Galicia y de Buenos Aires S.A.</field>
+            <field name="encoding">latin1</field>
+            <field name="separator">;</field>
+            <field name="quoting">"</field>
+            <field name="error_handling">ignore_date</field>
+            <field name="headers">True</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_1">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="field">name</field>
+            <field name="type">header</field>
+            <field name="col_header">Descripción</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_2">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="field">date</field>
+            <field name="type">header</field>
+            <field name="col_header">Fecha</field>
+            <field name="date_format">%d/%m/%Y</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_3">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="type">header</field>
+            <field name="col_header">Observaciones Cliente</field>
+            <field name="field">note</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_4">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="type">expr</field>
+            <field name="expr">safe_float(col('Créditos')) - safe_float(col('Débitos'))</field>
+            <field name="field">amount</field>
+            <field name="replace_comma">True</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_5">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="type">expr</field>
+            <field name="expr">col('Leyendas Adicionales1') if col('Concepto').startswith('917193') else None</field>
+            <field name="field">partner_name</field>
+        </record>
+
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_6">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="type">expr</field>
+            <field name="field">ref</field>
+            <field name="expr">
+                '\r\n'.join([ line for line in [
+                    col('Origen'),
+                    col('Número de Terminal'),
+                    col('Número de Comprobante'),
+                    col('Leyendas Adicionales1'),
+                    col('Leyendas Adicionales2'),
+                    col('Leyendas Adicionales3'),
+                    col('Leyendas Adicionales4')
+                ] if line ])
+            </field>
+        </record>
+
+        <!-- Compatibility with l10n_ar_account_bank_statement_import_partner_main_id_number -->
+        <!-- Extracts CUIT from incoming transfers, sets Banco Galicia's cuits on Taxes and Comissions -->
+        <record model="account.bank.statement.import.csv.template.line" id="Galicia_7">
+            <field name="template_id" eval="ref('Galicia')" />
+            <field name="type">expr</field>
+            <field name="expr">
+                ('30500001735' if col('Grupo de Conceptos') in ['901 - Impuestos', '808 - Comisiones'] else None) or (col('Leyendas Adicionales2') if col('Concepto').startswith('917193') else None)
+            </field>
+            <field name="field">other</field>
+            <field name="custom_field">partner_main_id_number</field>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_ar_account_bank_statement_import_partner_main_id_number/README.rst
+++ b/l10n_ar_account_bank_statement_import_partner_main_id_number/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============================================
+Account Bank Statement Import Main ID Number
+============================================
+
+This modules tries to link main_id_number from partners when importing bank statements.
+The transaction line has to define a `partner_main_id_number` key.
+It depends on `l10n_ar_partner`.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.adhoc.com.ar/
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* ADHOC SA: `Icon <http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png>`_.
+
+Contributors
+------------
+
+* Iván Todorovich <ivan.todorovich@gmail.com>
+
+Maintainer
+----------
+
+.. image:: http://fotos.subefotos.com/83fed853c1e15a8023b86b2b22d6145bo.png
+   :alt: Odoo Community Association
+   :target: https://www.adhoc.com.ar
+
+This module is maintained by the ADHOC SA.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_account_bank_statement_import_partner_main_id_number/__init__.py
+++ b/l10n_ar_account_bank_statement_import_partner_main_id_number/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/l10n_ar_account_bank_statement_import_partner_main_id_number/__openerp__.py
+++ b/l10n_ar_account_bank_statement_import_partner_main_id_number/__openerp__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Bank Statements Import Partner Main ID Number',
+    'version': '9.0.0.0.0',
+    'license': 'AGPL-3',
+    'author': 'Odoo Community Association (OCA), Ivan Todorovich',
+    'website': 'https://github.com/OCA/bank-statement-import',
+    'category': 'Banking addons',
+    'depends': [
+    	'l10n_ar_partner',
+        'account_bank_statement_import',
+    ],
+}

--- a/l10n_ar_account_bank_statement_import_partner_main_id_number/models/__init__.py
+++ b/l10n_ar_account_bank_statement_import_partner_main_id_number/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import account_bank_statement_import

--- a/l10n_ar_account_bank_statement_import_partner_main_id_number/models/account_bank_statement_import.py
+++ b/l10n_ar_account_bank_statement_import_partner_main_id_number/models/account_bank_statement_import.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2018 Ivan Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class AccountBankStatementImport(models.TransientModel):
+    _inherit = 'account.bank.statement.import'
+
+    def _complete_stmts_vals(self, stmts_vals, journal, account_number):
+        stmts_vals = super(AccountBankStatementImport, self)._complete_stmts_vals(stmts_vals, journal, account_number)
+        for st_vals in stmts_vals:
+            for line_vals in st_vals['transactions']:
+                if not line_vals.get('partner_id'):
+                    # Find the partner by using his main_id_number
+                    identifying_string = line_vals.pop('partner_main_id_number')
+                    if identifying_string:
+                        partner = self.env['res.partner'].search([('main_id_number', '=', identifying_string)])
+                        if len(partner) == 1:
+                            line_vals['partner_id'] = partner.id
+        return stmts_vals


### PR DESCRIPTION
**l10n_ar_account_bank_statement_import_partner_main_id_number**
Utiliza el campo `main_id_number` para vincular el partner a las lineas del extracto, en el asistente de improtación de extractos bancarios.

**l10n_ar_account_bank_statement_import_csv**
Incluye 'templates' estándar de los bancos de Argentina.
Por el momento sólo incluye el de Banco Galicia, que es el que utilizo yo.. pero sirve de ejemplo para incorporar el de otros bancos.

El template esta armado para leer la versión "Ampliada" de Galicia Office

Related https://github.com/ingadhoc/account-financial-tools/pull/123

![image](https://user-images.githubusercontent.com/1914185/44962161-aba78000-aef2-11e8-9fa9-9dac7a2f37bd.png)


![image](https://user-images.githubusercontent.com/1914185/44961897-16ef5300-aeef-11e8-84bf-52ec1e4e0999.png)

![image](https://user-images.githubusercontent.com/1914185/44961902-31293100-aeef-11e8-9c15-d22f8a11d6cd.png)

![image](https://user-images.githubusercontent.com/1914185/44961908-443c0100-aeef-11e8-8c15-fa0c214fa485.png)

![image](https://user-images.githubusercontent.com/1914185/44961919-751c3600-aeef-11e8-9e4b-07d0d9e49faf.png)

