### PR TITLE
[FIX] l10n_ar_account: fix incompatibility issue with multicompany

### DIFF
--- a/l10n_ar_account/__manifest__.py
+++ b/l10n_ar_account/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Módulo base de Contabilidad Argentina",
-    'version': '11.0.1.25.0',
+    'version': '11.0.1.26.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA,Moldeo Interactive,Odoo Community Association (OCA)',

--- a/l10n_ar_account/models/account_invoice.py
+++ b/l10n_ar_account/models/account_invoice.py
@@ -32,6 +32,7 @@ class AccountInvoice(models.Model):
         store=True,
         readonly=True,
         auto_join=True,
+        compute_sudo=True,
     )
     # IMPORANTE: si llegamos a implementar el campo computado no usar
     # cotizacion de la moneda ya que esta puede cambiar y ademas, si facturamos


### PR DESCRIPTION
- Add compute_sudo=True to state_id because in cases that user is placed in one company, tries to update partner's info from AFIP's census, and partner has invoices on other company, the writing operations are failing because of permissions.