### PR TITLE
[FIX] l10n_ar_afipws_fe: fix date handling

### DIFF
--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Factura Electrónica Argentina",
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.2.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',

--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -681,7 +681,7 @@ print "Observaciones:", wscdc.Obs
                         CbteAsoc.point_of_sale_number,
                         CbteAsoc.invoice_number,
                         self.company_id.cuit,
-                        afip_ws != 'wsmtxca' and self.date.replace("-", "") or self.date,
+                        afip_ws != 'wsmtxca' and self.date.strftime('%Y%m%d') or self.date.strftime('%Y-%m-%d'),
                     )
 
             # analize line items - invoice detail


### PR DESCRIPTION
The date field was string so we was using a replace to convert data to be used by the WS.
Now the field is a date type, so we do the proper format conversion for expected string that contains the date.