### PR TITLE
[FIX] l10n_ar_account: proper compare document numbers in vendor bills

### DIFF
--- a/l10n_ar_account/__manifest__.py
+++ b/l10n_ar_account/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Módulo base de Contabilidad Argentina",
-    'version': '11.0.1.26.0',
+    'version': '11.0.1.27.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA,Moldeo Interactive,Odoo Community Association (OCA)',

--- a/l10n_ar_account/data/base_validator_data.xml
+++ b/l10n_ar_account/data/base_validator_data.xml
@@ -22,6 +22,8 @@ if value:
             failed=True
         elif len(number) >8 or not number.isdigit():
             failed=True
+        if len(pos) == 5 and pos[0] == '0':
+            pos = pos[1:]
         value = '{:>04s}-{:>08s}'.format(pos, number)
         parts = [pos, number]
         ]]></field>


### PR DESCRIPTION
task 22643

When creating vendor bills, it was considering this two numbers as different but actually are the same invoice number

* 01234-00000001
+ 1234-00000001

To avoid this we remove the zero to the left always if the pos number > 4.