### PR TITLE
[ADD] l10n_ar_afipws: show friendly message when AFIP webservice for Padron is not available

### DIFF
--- a/l10n_ar_afipws/__manifest__.py
+++ b/l10n_ar_afipws/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Modulo Base para los Web Services de AFIP',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',
@@ -21,6 +21,7 @@
         'views/afipws_connection_view.xml',
         'security/ir.model.access.csv',
         'security/security.xml',
+        'data/ir.actions.url_data.xml',
     ],
     'demo': [
         'demo/certificate_demo.xml',

--- a/l10n_ar_afipws/data/ir.actions.url_data.xml
+++ b/l10n_ar_afipws/data/ir.actions.url_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="action_afip_padron" model="ir.actions.act_url">
+        <field name="name">AFIP - Consulta Constancia Padron</field>
+        <field name="url">https://seti.afip.gob.ar/padron-puc-constancia-internet/ConsultaConstanciaAction.do</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/l10n_ar_afipws/models/afipws_connection.py
+++ b/l10n_ar_afipws/models/afipws_connection.py
@@ -3,7 +3,7 @@
 # directory
 ##############################################################################
 from odoo import fields, models, api, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, RedirectWarning
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -155,7 +155,18 @@ class AfipwsConnection(models.Model):
         wsdl = self.afip_ws_url
 
         # connect to the webservice and call to the test method
-        ws.Conectar("", wsdl or "", "")
+        try:
+            ws.Conectar("", wsdl or "", "")
+        except Exception as error:
+            if 'xml.parsers.expat.ExpatError: mismatched tag' in repr(error) or \
+               'Conexión reinicializada por la máquina remota' in repr(error) or \
+               "module 'httplib2' has no attribute 'SSLHandshakeError'" in repr(error):
+                action = self.env.ref('l10n_ar_afipws.action_afip_padron')
+                msg = _('It seems like AFIP service is not available.\nPlease try again later or try manually')
+                raise RedirectWarning(msg, action.id, _('Go and find data manually'))
+            raise UserError(
+                'There was a connection problem to AFIP. Contact your Odoo Provider. Error\n\n%s' % repr(error))
+
         cuit = self.company_id.cuit_required()
         ws.Cuit = cuit
         ws.Token = self.token


### PR DESCRIPTION
* manage error when we are not able to connect to the webservice
* show readirect with page were the padron can be manually checked
* add another common connection errors