### PR TITLE
[12][FIX] l10n_ar_afipws_fe: only take into account the invoice that are not of type section or note when sending information about the lines to the AFIP webservices.

### DIFF
--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -712,7 +712,7 @@ print "Observaciones:", wscdc.Obs
             # analize line items - invoice detail
             # wsfe do not require detail
             if afip_ws != 'wsfe':
-                for line in inv.invoice_line_ids:
+                for line in inv.invoice_line_ids.filtered(lambda x: not x.display_type):
                     codigo = line.product_id.default_code
                     # unidad de referencia del producto si se comercializa
                     # en una unidad distinta a la de consumo


### PR DESCRIPTION
ticket 22088