### PR TITLE
[11][FIX] l10n_ar_afipws_fe: use real last id from AFIP instead of Odoo invoice id

### DIFF
--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -772,10 +772,12 @@ print "Observaciones:", wscdc.Obs
                     ws.AutorizarComprobante()
                     vto = ws.Vencimiento
                 elif afip_ws == 'wsfex':
-                    ws.Authorize(inv.id)
+                    last_id = ws.GetLastID()
+                    ws.Authorize(last_id+1)
                     vto = ws.FchVencCAE
                 elif afip_ws == 'wsbfe':
-                    ws.Authorize(inv.id)
+                    last_id = ws.GetLastID()
+                    ws.Authorize(last_id+1)
                     vto = ws.Vencimiento
             except SoapFault as fault:
                 msg = 'Falla SOAP %s: %s' % (


### PR DESCRIPTION
ticket 24439

This is required to avoid reprocess invoices in AFIP in demo environment and in environments where the AFIP POS has been used to generate invoices in another systems different from Odoo.