### PR TITLE
[ADD] l10n_ar_afipws_fe: new field ncm code for product templates

### DIFF
--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Factura Electrónica Argentina",
-    'version': '11.0.1.4.0',
+    'version': '11.0.1.5.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',
@@ -30,6 +30,7 @@
         'views/product_uom_view.xml',
         'views/res_currency_view.xml',
         'views/menuitem.xml',
+        'views/product_template_view.xml',
     ],
     'demo': [
         # 'demo/account_journal_expo_demo.yml',

--- a/l10n_ar_afipws_fe/models/__init__.py
+++ b/l10n_ar_afipws_fe/models/__init__.py
@@ -9,3 +9,4 @@ from . import journal
 from . import product_uom
 from . import res_currency
 from . import res_company
+from . import product_template

--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -708,7 +708,7 @@ print "Observaciones:", wscdc.Obs
             # wsfe do not require detail
             if afip_ws != 'wsfe':
                 for line in inv.invoice_line_ids:
-                    codigo = line.product_id.default_code
+                    codigo = line.product_id.product_tmpl_id.l10n_ar_ncm_code or line.product_id.default_code
                     # unidad de referencia del producto si se comercializa
                     # en una unidad distinta a la de consumo
                     # uom is not mandatory, if no UOM we use "unit"

--- a/l10n_ar_afipws_fe/models/product_template.py
+++ b/l10n_ar_afipws_fe/models/product_template.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    l10n_ar_ncm_code = fields.Char('NCM Code', copy=False, help='Code according to the Common Nomenclator of MERCOSUR')

--- a/l10n_ar_afipws_fe/views/product_template_view.xml
+++ b/l10n_ar_afipws_fe/views/product_template_view.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.product.form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <field name="categ_id" position="after">
+                <field name="l10n_ar_ncm_code"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
ticket 27544

As it is in 13.0 official odoo version
* show in product template view.
* when reporting electronic invoice send ncm code or default code instead