### PR TITLE
[FIX] fix fe using specific commit of pysimplesoap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pyOpenSSL
 M2Crypto
 httplib2>=0.7
-git+https://github.com/pysimplesoap/pysimplesoap@stable_py3k
+git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
 # fpdf>=1.7.2
 # dbf>=0.88.019
 # Pillow>=2.0.0


### PR DESCRIPTION
with the changes on 24 and 25 of june on pysimplesoap (https://github.com/pysimplesoap/pysimplesoap/commits/stable_py3k), our FE was broken and we're receiving the error "TypeError data must be bytes or None, not str"
We use last commit that was working ok for us