### PR TITLE
[ADD] l10n_ar_afipws_fe: improves find invoice from sale.order

### DIFF
--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -233,10 +233,12 @@ class AccountInvoice(models.Model):
             if related_invoice:
                 return related_invoice
             else:
-                original_entry = self.mapped('invoice_line_ids.sale_line_ids.invoice_lines').filtered(
-                    lambda x: x.invoice_id.document_type_id.internal_type !=
-                    self.document_type_id.internal_type).mapped('invoice_id')
-                return original_entry
+                if self.sudo().env.ref('base.module_sale').state == 'installed':
+                    original_entry = self.mapped('invoice_line_ids.sale_line_ids.invoice_lines').filtered(
+                        lambda x: x.document_type_id.localization == 'argentina' and
+                        x.invoice_id.document_type_id.internal_type != self.document_type_id.internal_type and
+                        x.invoice_id.afip_result in ['A', 'O'] and x.invoice_id.afip_auth_code).mapped('invoice_id')
+                    return original_entry
         else:
             return self.env['account.invoice']
 


### PR DESCRIPTION
ticket 29058

* only found original invoice from sale lines if sale module is installed.
* only filter the invoices that are Argentinean (generic ones are dismiss)
* ensure that only take into account the original entry only take into account the invoices that has been already sent approved/observed by AFIP