### PR TITLE
[REF] l10n_ar_partner: uniquness on main_id_number

### DIFF
--- a/l10n_ar_partner/models/res_partner_id_number.py
+++ b/l10n_ar_partner/models/res_partner_id_number.py
@@ -23,14 +23,19 @@ class ResPartnerIdNumber(models.Model):
             related_partners = rec.partner_id.search([
                 '|', ('id', 'parent_of', rec.partner_id.id),
                 ('id', 'child_of', rec.partner_id.id)])
-            same_id_numbers = rec.search([
-                ('name', '=', rec.name),
-                ('category_id', '=', rec.category_id.id),
-                # por ahora no queremos la condicion de igual cia
-                # ('company_id', '=', rec.company_id.id),
-                ('partner_id', 'not in', related_partners.ids),
-                # ('id', '!=', rec.id),
-            ]) - rec
+            same_id_numbers = rec.partner_id.search([
+                ('main_id_category_id', '=', rec.category_id.id),
+                ('main_id_number', '=', rec.name),
+                ('id', 'not in', related_partners.ids),
+            ]) - rec.partner_id
+            # same_id_numbers = rec.search([
+            #     ('name', '=', rec.name),
+            #     ('category_id', '=', rec.category_id.id),
+            #     # por ahora no queremos la condicion de igual cia
+            #     # ('company_id', '=', rec.company_id.id),
+            #     ('partner_id', 'not in', related_partners.ids),
+            #     # ('id', '!=', rec.id),
+            # ]) - rec
             if same_id_numbers:
                 raise ValidationError(_(
                     'Id Number must be unique per id category!\nSame number '


### PR DESCRIPTION
Most of customers don't use many docs numbers per partner and this uniquness could lead
to confusion because the could have change the document on a partner, the previous document is stored on the res.partner.id_number list but as they don't see the list they don't know why it's not unique.

This functionality is deprecated on v13, till then, we make this quick fix

ticket #29265