### PR TITLE
Fixed display of "other document types" eligible for credit notes.

### DIFF
--- a/l10n_ar_account/models/account_invoice.py
+++ b/l10n_ar_account/models/account_invoice.py
@@ -448,7 +448,7 @@ class AccountInvoice(models.Model):
                 if not journal_document_type and journal_document_types:
                     journal_document_type = journal_document_types[0]
 
-        if invoice_type == 'in_invoice':
+        if invoice_type in ['in_invoice', 'in_refund']:
             other_document_types = (commercial_partner.other_document_type_ids)
 
             domain = [


### PR DESCRIPTION
Fixed display of "other document types" eligible for credit notes, when business partners have "other accounting documents" added. This was for invoices only.