### PR TITLE
[13.0] [IMP] l10n_ar_ux: Show the partner log instead the company logo, to compatiblity with other modules to use the partner header.

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.4.0",
+    'version': "13.0.1.5.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -27,6 +27,7 @@
         'views/afip_concept_view.xml',
         'views/afip_activity_view.xml',
         'views/afip_tax_view.xml',
+        'views/report_invoice.xml',
         'views/res_config_settings_views.xml',
         'reports/report_payment_group.xml',
         'security/ir.model.access.csv',

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="custom_header" inherit_id="l10n_ar.custom_header">
+        <img t-if="o.company_id.logo" position="replace">
+            <img t-if="header_address.image_1920" t-att-src="image_data_uri(header_address.image_1920)" style="max-height: 45px;" alt="Logo"/>
+        </img>
+    </template>
+
+
+</odoo>


### PR DESCRIPTION
Ticket 33804