### PR TITLE
[IMP] l10n_ar_ux: report header partner data

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.13.0",
+    'version': "13.0.1.14.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/migrations/13.0.1.14.0/pre-migration.py
+++ b/l10n_ar_ux/migrations/13.0.1.14.0/pre-migration.py
@@ -1,0 +1,11 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute("""
+        UPDATE res_partner SET start_date = rc.l10n_ar_afip_start_date
+        FROM res_company as rc
+        WHERE res_partner.id = rc.partner_id
+            AND res_partner.start_date is null
+            AND rc.l10n_ar_afip_start_date is not null""")

--- a/l10n_ar_ux/models/res_company.py
+++ b/l10n_ar_ux/models/res_company.py
@@ -13,9 +13,12 @@ class ResCompany(models.Model):
         related='partner_id.gross_income_jurisdiction_ids',
         readonly=False,
     )
-
     # TODO this field could be defined directly on l10n_ar_account_withholding
     arba_cit = fields.Char(
         'CIT ARBA',
         help='Clave de Identificación Tributaria de ARBA',
     )
+    # la fecha de comienzo de actividades puede ser por cada punto de venta distinta, lo convertimos a related del
+    # partner
+    l10n_ar_afip_start_date = fields.Date(
+        related='partner_id.start_date', string='Activities Start', readonly=False)

--- a/l10n_ar_ux/models/res_partner.py
+++ b/l10n_ar_ux/models/res_partner.py
@@ -14,7 +14,7 @@ class ResPartner(models.Model):
     )
 
     # AFIP Padron
-    start_date = fields.Date('Start-up Date')
+    start_date = fields.Date('Activities Start')
     estado_padron = fields.Char('Estado AFIP')
     imp_ganancias_padron = fields.Selection([
         ('NI', 'No Inscripto'),

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -2,9 +2,26 @@
 <odoo>
 
     <template id="custom_header" inherit_id="l10n_ar.custom_header">
+        <!-- usar datos de header_adress en vez de company -->
         <img t-if="o.company_id.logo" position="replace">
             <img t-if="header_address.image_1920" t-att-src="image_data_uri(header_address.image_1920)" style="max-height: 45px;" alt="Logo"/>
         </img>
+        <span t-field="o.company_id.partner_id.name" position="attributes">
+            <attribute name="t-field">header_address.name</attribute>
+        </span>
+        <span t-field="o.company_id.l10n_ar_afip_responsibility_type_id" position="attributes">
+            <attribute name="t-field">header_address.l10n_ar_afip_responsibility_type_id</attribute>
+        </span>
+        <span t-field="o.company_id.partner_id.l10n_ar_formatted_vat" position="attributes">
+            <attribute name="t-field">header_address.l10n_ar_formatted_vat</attribute>
+        </span>
+        <span t-esc="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
+            <attribute name="t-esc">header_address.l10n_ar_gross_income_type == 'exempt' and 'Exento' or header_address.l10n_ar_gross_income_number</attribute>
+        </span>
+        <span t-field="o.company_id.l10n_ar_afip_start_date" position="attributes">
+            <attribute name="t-field">header_address.start_date</attribute>
+        </span>
+
         <!-- tal vez tambien a este div principal le querramos cambiar la fuente como haciamos antes, aunque en realidad aparentemente ya no ex necesario, era algo asi:
         <div t-att-style="o.company_id.external_report_layout_id.key == 'web.external_layout_standard' and 'font-size: 15px;'">
          -->


### PR DESCRIPTION
Con este commit hacemos que el header de los reportes use toda la información del partner como era en v12-. De esta manera se garantiza mayor consistencia y se resuelve, por ejemplo, que la fecha de comienzo de actividades es por punto de venta.