### PR TITLE
[FIX] l10n_ar_ux: 4 digits compatibility

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -70,11 +70,12 @@ class AccountMove(models.Model):
         """ We overwrite original method odoo/odoo/l10n_latam_invoice_document in order to be able to search for
         document numbers that has POS of 4 or 5 digits. In 13.0 we will always have 5 digits, but we need this for
         compatibility of old version migrated clients that have used 4 digits POS numbers """
-        others = self.filtered(lambda x: x.company_id.country_id.code != 'AR')
-        super(AccountMove, others)._check_unique_vendor_number()
-        for rec in (self - others).filtered(lambda x: x.is_purchase_document() and x.l10n_latam_use_documents
-                                            and x.l10n_latam_document_number):
+        ar_purchase_use_document = self.filtered(
+            lambda x: x.is_purchase_document() and x.l10n_latam_use_documents and x.l10n_latam_document_number
+            and x.l10n_latam_document_type_id.code)
 
+        super(AccountMove, self - ar_purchase_use_document)._check_unique_vendor_number()
+        for rec in ar_purchase_use_document:
             # Old 4 digits name
             number = rec._l10n_ar_get_document_number_parts(
                 rec.l10n_latam_document_number, rec.l10n_latam_document_type_id.code)


### PR DESCRIPTION
ticket 37657
---

With this PR we only apply background compatibility to document types that have codes, which means we only apply this functionality in document types that we have a defined number format