### PR TITLE
[REM] l10n_ar_ux: hook noupdate for doc types

### DIFF
--- a/l10n_ar_ux/hooks.py
+++ b/l10n_ar_ux/hooks.py
@@ -7,16 +7,6 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-def document_types_not_updatable(cr, registry):
-    _logger.info('Update l10n_latam.document.type to noupdate=True')
-    env = api.Environment(cr, SUPERUSER_ID, {})
-    items = env['ir.model.data'].search([
-        ('model', '=', 'l10n_latam.document.type'),
-        ('module', '=', 'l10n_ar'),
-    ])
-    items = items.write({'noupdate': True})
-
-
 def set_tax_included(cr, registry):
     _logger.info('Settig tax included by default')
     env = api.Environment(cr, SUPERUSER_ID, {'active_test': False})
@@ -38,5 +28,4 @@ def set_tax_included(cr, registry):
 def post_init_hook(cr, registry):
     """Loaded after installing the module """
     _logger.info('Post init hook initialized')
-    document_types_not_updatable(cr, registry)
     set_tax_included(cr, registry)


### PR DESCRIPTION
This hook was there for v12- but is incosistent with approach on v13.

Related to ticket 36155