### PR TITLE
[FW][FIX] l10n_ar_edi, l10n_ar_afipws_fe: forward port from v11.0

### DIFF
--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Factura Electrónica Argentina",
-    'version': '12.0.1.5.0',
+    'version': '12.0.1.6.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',

--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -275,9 +275,12 @@ class AccountInvoice(models.Model):
             ([52, 53], [51, 52, 53, 54, 88, 991]),
             ([1, 6, 51], [88, 991]),
             ([201, 206, 211], [91, 990, 991, 993, 994, 995]),
-            ([202, 203], [201, 202, 203]),
-            ([207, 208], [206, 207, 208]),
-            ([212, 213], [211, 212, 213])
+            ([202, 203], [201, 202, 203] if self.afip_fce_es_anulacion
+                else [201, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
+            ([207, 208], [206, 207, 208] if self.afip_fce_es_anulacion
+                else [206, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
+            ([212, 213], [211, 212, 213] if self.afip_fce_es_anulacion
+                else [211, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
         ]
         available_codes = list(filter(lambda x: int(self.document_type_id.code) in x[0], code_rules))
         available_codes = available_codes[0][1] if available_codes else []

--- a/l10n_ar_afipws_fe/views/invoice_view.xml
+++ b/l10n_ar_afipws_fe/views/invoice_view.xml
@@ -44,6 +44,10 @@
 
             <xpath expr="//page[@name='other_info']//field[@name='origin']" position="after">
                 <field name="afip_fce_es_anulacion"/>
+                <label for="afip_asoc_period_start" string="Associated Period"/>
+                <div>
+                    <field name="afip_asoc_period_start" class="oe_inline"/> to <field name="afip_asoc_period_end" class="oe_inline"/>
+                </div>
             </xpath>
             <notebook>
                 <page string="AFIP" name="afip" attrs="{'invisible': [('document_type_internal_type', 'not in', ['invoice', 'debit_note', 'credit_note', 'receipt_invoice'])]}">


### PR DESCRIPTION
**[ADD] l10n_ar_edi: support for RG 4540**
* When posting debit/credit notes to AFIP we need to report the original document.
If not found original document (reversed_entry_id or debit_origin_id) then try to found the original document from the sale.order.lines
If there is not original document related, then the user can set the PeriodoAsoc information.
add two new fields to the account.move model to let the user set this information

**[FIX] l10n_ar_afipws_fe: get related invoice proper filter**
* When credit/debit note of type FCE (Mipyme) the rules of the related
invoices change depending on if the invoice has been set or not as as
afip_fce_es_anulacion.