### PR TITLE
[FIX] l10n_ar_edi_ux: CN/DN from customer receipts

### DIFF
--- a/l10n_ar_account_withholding/__manifest__.py
+++ b/l10n_ar_account_withholding/__manifest__.py
@@ -26,6 +26,7 @@
         'security/ir.model.access.csv',
         'security/security.xml',
         'wizard/res_config_settings_views.xml',
+        'wizard/account_payment_group_invoice_wizard_view.xml',
         'reports/certificado_de_retencion_report.xml',
         'views/account_payment_group_view.xml',
         'views/afip_tabla_ganancias_escala_view.xml',
@@ -55,5 +56,5 @@
     },
     'installable': True,
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': '12.0.1.2.0',
+    'version': '12.0.1.3.0',
 }

--- a/l10n_ar_account_withholding/wizard/__init__.py
+++ b/l10n_ar_account_withholding/wizard/__init__.py
@@ -4,3 +4,4 @@
 # directory
 ##############################################################################
 from . import res_config_settings
+from . import account_payment_group_invoice_wizard

--- a/l10n_ar_account_withholding/wizard/account_payment_group_invoice_wizard.py
+++ b/l10n_ar_account_withholding/wizard/account_payment_group_invoice_wizard.py
@@ -1,0 +1,32 @@
+from odoo import fields, models
+
+
+class AccountPaymentGroupInvoiceWizard(models.TransientModel):
+    _inherit = "account.payment.group.invoice.wizard"
+
+    afip_asoc_period_start = fields.Date(
+        'Associate Period From',
+    )
+
+    afip_asoc_period_end = fields.Date(
+        'Associate Period To',
+    )
+
+    origin = fields.Many2one(
+        'account.invoice',
+    )
+
+    commercial_partner_id = fields.Many2one(
+        'res.partner',
+        related="payment_group_id.partner_id.commercial_partner_id"
+    )
+
+    def get_invoice_vals(self):
+        self.ensure_one()
+        invoice_vals = super().get_invoice_vals()
+        invoice_vals.update({
+            'afip_asoc_period_start': self.afip_asoc_period_start,
+            'afip_asoc_period_end': self.afip_asoc_period_end,
+            'origin': self.origin
+        })
+        return invoice_vals

--- a/l10n_ar_account_withholding/wizard/account_payment_group_invoice_wizard_view.xml
+++ b/l10n_ar_account_withholding/wizard/account_payment_group_invoice_wizard_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_account_payment_group_invoice_wizard">
+        <field name="name">account.payment.group.invoice.wizard.form</field>
+        <field name="model">account.payment.group.invoice.wizard</field>
+        <field name="inherit_id" ref="account_payment_group.view_account_payment_group_invoice_wizard"/>
+        <field name="arch" type="xml">
+            <field name="date" position="after">
+                <field name="afip_asoc_period_start"/>
+                <field name="afip_asoc_period_end"/>
+                <field name="commercial_partner_id" invisible="1"/>
+                <field name="origin" domain="context.get('refund') and [('type', '=', 'out_invoice'), ('partner_id.commercial_partner_id', '=', commercial_partner_id), ('state', 'not in', ['draft', 'cancel'])] or [('type', 'in', ('out_invoice', 'out_refund')), ('partner_id.commercial_partner_id', '=', commercial_partner_id), ('state', 'not in', ['draft', 'cancel'])]"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ar_afipws_fe/__manifest__.py
+++ b/l10n_ar_afipws_fe/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Factura Electrónica Argentina",
-    'version': '12.0.1.5.0',
+    'version': '12.0.1.6.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA, Moldeo Interactive,Odoo Community Association (OCA)',

--- a/l10n_ar_afipws_fe/models/invoice.py
+++ b/l10n_ar_afipws_fe/models/invoice.py
@@ -275,9 +275,12 @@ class AccountInvoice(models.Model):
             ([52, 53], [51, 52, 53, 54, 88, 991]),
             ([1, 6, 51], [88, 991]),
             ([201, 206, 211], [91, 990, 991, 993, 994, 995]),
-            ([202, 203], [201, 202, 203]),
-            ([207, 208], [206, 207, 208]),
-            ([212, 213], [211, 212, 213])
+            ([202, 203], [201, 202, 203] if self.afip_fce_es_anulacion
+                else [201, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
+            ([207, 208], [206, 207, 208] if self.afip_fce_es_anulacion
+                else [206, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
+            ([212, 213], [211, 212, 213] if self.afip_fce_es_anulacion
+                else [211, 91, 88, 988, 990, 991, 993, 994, 995, 996, 997]),
         ]
         available_codes = list(filter(lambda x: int(self.document_type_id.code) in x[0], code_rules))
         available_codes = available_codes[0][1] if available_codes else []

--- a/l10n_ar_afipws_fe/views/invoice_view.xml
+++ b/l10n_ar_afipws_fe/views/invoice_view.xml
@@ -44,6 +44,10 @@
 
             <xpath expr="//page[@name='other_info']//field[@name='origin']" position="after">
                 <field name="afip_fce_es_anulacion"/>
+                <label for="afip_asoc_period_start" string="Associated Period"/>
+                <div>
+                    <field name="afip_asoc_period_start" class="oe_inline"/> to <field name="afip_asoc_period_end" class="oe_inline"/>
+                </div>
             </xpath>
             <notebook>
                 <page string="AFIP" name="afip" attrs="{'invisible': [('document_type_internal_type', 'not in', ['invoice', 'debit_note', 'credit_note', 'receipt_invoice'])]}">


### PR DESCRIPTION
We add new fields on the "Credit / Debit Note" wizard to support the
RG 4540 when creating a debit/credit note from customer receipts.
When posting debit/credit notes to AFIP we need to report the original
document. If there is not original document related, then the user can
set the PeriodoAsoc information.

New fields:
 * afip_asoc_period_start
 * afip_asoc_period_end
 * origin