### PR TITLE
[FIX] l10n_ar_ux: 4 digits backward compatibility only for Argentina

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -71,8 +71,8 @@ class AccountMove(models.Model):
         document numbers that has POS of 4 or 5 digits. In 13.0 we will always have 5 digits, but we need this for
         compatibility of old version migrated clients that have used 4 digits POS numbers """
         ar_purchase_use_document = self.filtered(
-            lambda x: x.is_purchase_document() and x.l10n_latam_use_documents and x.l10n_latam_document_number
-            and x.l10n_latam_document_type_id.code)
+            lambda x: x.company_id.country_id.code == 'AR' and x.is_purchase_document() and x.l10n_latam_use_documents
+            and x.l10n_latam_document_number and x.l10n_latam_document_type_id.code)
 
         super(AccountMove, self - ar_purchase_use_document)._check_unique_vendor_number()
         for rec in ar_purchase_use_document:


### PR DESCRIPTION
ticket 37764
----

The last changes to this file introduce an error removing is country Argentina condition, we add it again because we only need to make this check for Argentinean documents.