### PR TITLE
[12.0][FIX] M2Crypto version py3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyOpenSSL
-M2Crypto
+M2Crypto; python_version != '3.6'
+M2Crypto<=0.36.0; python_version == '3.6'
 httplib2>=0.7
 git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
 # fpdf>=1.7.2


### PR DESCRIPTION
Fixed M2Crypto version in python3.6 due to a problem of incompatibility of dependencies.

pylint-odoo 0.0.1.dev532 requires docutils==0.16, but you have docutils 0.12 which is incompatible.
pylint-odoo 0.0.1.dev532 requires lxml>=4.2.3, but you have lxml 3.7.1 which is incompatible.