### PR TITLE
[FIX] l10n_ar_account_withholding, l10n_ar_ux: add report of transfers

### DIFF
--- a/l10n_ar_account_withholding/reports/report_withholding_certificate.xml
+++ b/l10n_ar_account_withholding/reports/report_withholding_certificate.xml
@@ -113,6 +113,7 @@
         name="l10n_ar_account_withholding.report_withholding_certificate"
         file="l10n_ar_account_withholding.report_withholding_certificate"
         print_report_name="'Certificado de Retención Slip - %s' % (object.withholding_number or '')"
+        menu="False"
     />
 
 </odoo>

--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -28,6 +28,7 @@
         'views/afip_activity_view.xml',
         'views/afip_tax_view.xml',
         'views/report_invoice.xml',
+        'reports/report_account_transfer.xml',
         'views/account_payment_view.xml',
         'wizards/res_config_settings_views.xml',
         'reports/account_invoice_report_view.xml',

--- a/l10n_ar_ux/reports/report_account_transfer.xml
+++ b/l10n_ar_ux/reports/report_account_transfer.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_account_transfer_document">
+        <t t-call="web.external_layout">
+            <t t-set="o" t-value="o.with_context(lang=lang)" />
+                <t t-set="custom_header" t-value="'l10n_ar.custom_header'"/>
+                <t t-set="report_date" t-value="o.payment_date"/>
+                <t t-set="report_number" t-value="o.name"/>
+                <t t-set="report_name" t-value="'REPORTE DE TRANSFERENCIA'"/>
+                <t t-set="header_address" t-value="o.company_id.partner_id"/>
+
+                <t t-set="custom_footer">
+                    <div class="row">
+                        <div name="footer_left_column" class="col-8">
+                            Nombre y Apellido Firmante:
+                            <br/>Cargo:
+                        </div>
+                        <div name="footer_right_column" class="col-4">
+                            Firma Responsable
+                        </div>
+                    </div>
+                </t>
+            <div class="page">
+                <hr/>
+                <strong>Creado por:</strong>
+                <span t-field="o.create_uid.name"/>
+                <br/>
+                <strong>Total Transacción:</strong>
+                <span t-field="o.amount"/>
+                <br/>
+                <br/>
+                <strong>Cuenta de Origen:</strong>
+                <span t-field="o.journal_id.name"/>
+                <br/>
+                <strong>Cuenta de Destino:</strong>
+                <span t-field="o.destination_journal_id.name"/>
+                <br/>
+                <strong>Concepto:</strong>
+                <span t-field="o.communication"/>
+                <br/>
+                <br/>
+                <t t-if="o.check_ids">
+                    <strong>Cantidad de Cheques:</strong>
+                    <span t-esc="len(o.check_ids)"/>
+                    <br/>
+                    <strong>Listado de Cheques:</strong>
+                    <br/>
+                    <br/>
+                    <table class="table table-sm o_main_table">
+                        <thead>
+                            <tr>
+                                <td><strong>Nro de Cheque</strong></td>
+                                <td><strong>Fecha de Emisión</strong></td>
+                                <td><strong>Fecha de Pago</strong></td>
+                                <td><strong>Banco</strong></td>
+                                <td><strong>Monto</strong></td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <t t-foreach="o.check_ids.sorted(key=lambda r:r.payment_date or r.issue_date)" t-as="check">
+                                <tr>
+                                    <td><span t-field="check.number"/></td>
+                                    <td><span t-field="check.issue_date"/></td>
+                                    <td><span t-field="check.payment_date"/></td>
+                                    <td><span t-field="check.bank_id.name"/></td>
+                                    <td><span t-field="check.amount"/></td>
+                                </tr>
+                            </t>
+                        </tbody>
+                    </table>
+                </t>
+            </div>
+        </t>
+    </template>
+
+    <template id="report_account_transfer">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-set="lang" t-value="o.partner_id.lang"/>
+                <t t-call="l10n_ar_ux.report_account_transfer_document" t-lang="lang"/>
+            </t>
+        </t>
+    </template>
+
+    <report
+        string="Reporte de Transferencia"
+        id="action_report_account_transfer"
+        model="account.payment"
+        report_type="qweb-pdf"
+        name="l10n_ar_ux.report_account_transfer"
+        file="l10n_ar_ux.report_account_transfer"
+        print_report_name="'Reporte de transferencia'"
+    />
+
+</odoo>


### PR DESCRIPTION
- Remove the report "Certificado de Retención" from the print menu
- Add the report of transfers that we have in v11 and moved to qweb view.
    - Report of transfers in v11 (before): [report.pdf](https://github.com/ingadhoc/odoo-argentina/files/6414602/report.pdf)
    - Report of transfers in v13 (after): [report.pdf](https://github.com/ingadhoc/odoo-argentina/files/6414600/Reporte.de.transferencia.pdf)
  

