### PR TITLE
[FIX] l10n_ar_ux, l10n_ar_account_withholding: show VAT on invoices report

### DIFF
--- a/l10n_ar_account_withholding/__manifest__.py
+++ b/l10n_ar_account_withholding/__manifest__.py
@@ -49,5 +49,5 @@
     },
     'installable': True,
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': "13.0.1.1.0",
+    'version': "13.0.1.2.0",
 }

--- a/l10n_ar_account_withholding/reports/report_withholding_certificate.xml
+++ b/l10n_ar_account_withholding/reports/report_withholding_certificate.xml
@@ -38,7 +38,7 @@
 
                         <!-- (17) CUIT -->
                         <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
-                            <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat if o.partner_id.l10n_latam_identification_type_id.is_vat else o.partner_id.vat"/>
+                            <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
                         </t>
 
                     </div>

--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.23.0",
+    'version': "13.0.1.24.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/reports/report_payment_group.xml
+++ b/l10n_ar_ux/reports/report_payment_group.xml
@@ -41,7 +41,7 @@
 
                 <!-- (17) CUIT -->
                 <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
-                    <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat if o.partner_id.l10n_latam_identification_type_id.is_vat else o.partner_id.vat"/>
+                    <br/><strong><t t-esc="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
                 </t>
 
             </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Show on the invoices report the identification number of foreign customers when the identification type is "VAT"

Steps to replicate the error:
1. Create a partner with:
    - Responsibility type: "Cliente / Proveedor del Exterior"
    - Identification number: "VAT" with a random number.
2. Create and print an invoice for this partner.

**Current behavior before PR:**
Before this commit, the vat number was empty.

**Desired behavior after PR is merged:**
Show de number
