### PR TITLE
[FIX]l10n_ar_ux:parent company in receipts

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.24.0",
+    'version': "13.0.1.25.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/reports/report_payment_group.xml
+++ b/l10n_ar_ux/reports/report_payment_group.xml
@@ -30,7 +30,7 @@
                 <!-- IDENTIFICACION (ADQUIRIENTE-LOCATARIO-PRESTARIO) -->
 
                 <!-- (14) Apellido uy Nombre: Denominicacion o Razon Soclial -->
-                <strong><span t-raw="o.partner_type == 'supplier' and 'Proveedor: ' or 'Cliente: '"/></strong><span t-field="o.partner_id.name"/>
+                <strong><span t-raw="o.partner_type == 'supplier' and 'Proveedor: ' or 'Cliente: '"/></strong><span t-field="o.partner_id.commercial_partner_id.name"/>
 
                 <!-- (15) Domicilio Comercial -->
                 <br/>


### PR DESCRIPTION
When a receipt is for a costumer which has a parent company
with this fix is shown as costumer the parent company insted of
the child contact