### PR TITLE
[IMP] l10n_ar_ux: add qr-code for invoice payments

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.25.0",
+    'version': "13.0.1.26.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/models/account_journal.py
+++ b/l10n_ar_ux/models/account_journal.py
@@ -10,6 +10,14 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     l10n_ar_document_type_ids = fields.Many2many('l10n_latam.document.type', string='Document Types')
+    qr_code_label = fields.Char(
+        string="QR Code Label",
+        help="String to display before the QR Code on the invoice report."
+    )
+    qr_code = fields.Char(
+        string="QR Code",
+        help="String to generate the QR Code that will be displayed on the invoice report."
+    )
 
     def _get_l10n_ar_afip_pos_types_selection(self):
         """ Add more options to the selection field AFIP POS System, re order options by common use """

--- a/l10n_ar_ux/views/account_journal_views.xml
+++ b/l10n_ar_ux/views/account_journal_views.xml
@@ -15,6 +15,12 @@
             <field name="l10n_ar_afip_pos_partner_id" position="attributes">
                 <attribute name="attrs">{'invisible':['|', ('l10n_latam_country_code', '!=', 'AR'), ('type', '!=', 'sale')], 'required':[('l10n_latam_country_code', '=', 'AR'), ('l10n_latam_use_documents', '=', True), ('type', '=', 'sale')]}</attribute>
             </field>
+            <xpath expr="//page[@name='advanced_settings']/group" position="after">
+                <group string="QR-Code" attrs="{'invisible': [('qr_code', '=', False)]}">
+                    <field name="qr_code_label"/>
+                    <field name="qr_code"/>
+                </group>
+            </xpath>
 
         </field>
     </record>

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -67,6 +67,12 @@
                 El total de este comprobante equivale a un total de <span t-raw="o.amount_total / o.move_inverse_currency_rate" t-options="{'widget': 'monetary', 'display_currency': o.move_currency_id}"/> a un tipo de cambio consignado de <span t-field="o.move_inverse_currency_rate"/>
             </p>
         </p>
+        <div id="qrcode" position="after">
+            <div t-if="o.company_id.country_id.code == 'AR' and o.journal_id.qr_code and o.invoice_payment_state != 'paid'">
+                <field name="qr_code_label"/>
+                <img t-att-src="'/report/barcode/?type=QR&amp;value=%s&amp;width=128&amp;height=128' % o.journal_id.qr_code"/>
+            </div>
+        </div>
     </template>
 
     <template id="report_invoice_document_with_payments" inherit_id="l10n_ar.report_invoice_document_with_payments">
@@ -82,6 +88,13 @@
                 El total de este comprobante equivale a un total de <span t-raw="o.amount_total / o.move_inverse_currency_rate" t-options="{'widget': 'monetary', 'display_currency': o.move_currency_id}"/> a un tipo de cambio consignado de <span t-field="o.move_inverse_currency_rate"/>
             </p>
         </p>
+
+        <div id="qrcode" position="after">
+            <div t-if="o.company_id.country_id.code == 'AR' and o.journal_id.qr_code and o.invoice_payment_state != 'paid'">
+                <strong class="text-center"><span t-field="o.journal_id.qr_code_label"/><br/><br/></strong>
+                <img t-att-src="'/report/barcode/?type=QR&amp;value=%s&amp;width=128&amp;height=128' % o.journal_id.qr_code"/>
+            </div>
+        </div>
     </template>
 
 


### PR DESCRIPTION
Add a new field in the journals to fill with a string that will be used
to generate a QR-code that will be printed in the invoices report.
This field depends on the qr-code configuration from the company.
Also, it adds the possibility of defining a label to be shown before
the qr in the report to give to the final user more information.