### PR TITLE
[ADD] l10n_ar_ux: Cheque electrónico en reporte (#547)

### DIFF
--- a/l10n_ar_ux/reports/report_payment_group.xml
+++ b/l10n_ar_ux/reports/report_payment_group.xml
@@ -64,7 +64,7 @@
                     <t t-foreach="o.mapped('payment_ids.check_ids').sorted(key=lambda r:r.payment_date or r.issue_date)" t-as="line">
                         <tr>
                             <td>
-                                <span t-raw='"Cheque nro %s - %s" % (line.name, line.bank_id.name or line.journal_id.name)'/><span t-if="line.payment_date"> - Venc. <span t-field="line.payment_date"/></span>
+                                <span t-raw='"Cheque %s nro %s - %s" % ("electrónico " if line.checkbook_id.issue_check_subtype == "electronic" else "", line.name, line.bank_id.name or line.journal_id.name)'/><span t-if="line.payment_date"> - Venc. <span t-field="line.payment_date"/></span>
                            </td>
                             <td  class="text-right" t-if="any(o.mapped('payment_ids.other_currency'))">
                                 <t t-if="line.currency_id">


### PR DESCRIPTION
Ticket 38950. Cuando se imprime el reporte de orden de pago se mostraba la información de los cheques sin diferenciar cuál era electrónico o no. Con este cambio ahora podremos ver la "cheque electrónico nro..." cuando se pague con cheque electrónico propio y "cheque nro..." para los otros casos.

Co-authored-by: Katherine Zaoral <zaoral@users.noreply.github.com>