### PR TITLE
[FIX] l10n_ar_ux: Ensure all the records have values for computed field.

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -28,6 +28,7 @@ class AccountMove(models.Model):
             x.company_id.country_id == self.env.ref('base.ar') and
             x.currency_id != x.company_id.currency_id and
             x.reversed_entry_id.currency_id == x.currency_id)
+        self.filtered(lambda x: x.type == 'entry').l10n_ar_currency_rate = False
         for rec in ar_reversed_other_currency:
             rec.l10n_ar_currency_rate = rec.reversed_entry_id.l10n_ar_currency_rate
 


### PR DESCRIPTION
For this case, the bug is an Record rule of account move for users without accounts rights.


The problems occurs with the sale type automaticon module with auto payment for an user without accounting rights.


For more details see the ticket 46537