### PR TITLE
[IMP] l10n_ar_ux: partner always configurable on journal

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.32.0",
+    'version': "13.0.1.33.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/views/account_journal_views.xml
+++ b/l10n_ar_ux/views/account_journal_views.xml
@@ -26,7 +26,7 @@
                 <attribute name="attrs">{'invisible':[('l10n_ar_is_pos', '=', False)], 'required':[('l10n_ar_is_pos', '=', True)]}</attribute>
             </field>
             <field name="l10n_ar_afip_pos_partner_id" position="attributes">
-                <attribute name="attrs">{'invisible':[('l10n_ar_is_pos', '=', False)], 'required':[('l10n_ar_is_pos', '=', True)]}</attribute>
+                <attribute name="attrs">{'invisible':['|', ('l10n_latam_country_code', '!=', 'AR'), ('type', 'not in', ['sale', 'purchase'])], 'required':[('l10n_ar_is_pos', '=', True)]}</attribute>
             </field>
             <xpath expr="//page[@name='advanced_settings']/group" position="after">
                 <group string="QR-Code" attrs="{'invisible': ['|', '|', ('l10n_latam_country_code', '!=', 'AR'), ('type', '!=', 'sale'), ('l10n_latam_use_documents', '=', False)]}">


### PR DESCRIPTION
Como estamos usando reporte argentino en todos los diarios (compra y venta) de cias argentinas, dejamos que sea seleccionable el partner.