### PR TITLE
[FIX] l10n_ar_ux: compute currency rate

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -32,16 +32,19 @@ class AccountMove(models.Model):
         for rec in ar_reversed_other_currency:
             rec.l10n_ar_currency_rate = rec.reversed_entry_id.l10n_ar_currency_rate
 
-    @api.depends('currency_id', 'company_id', 'date')
+    @api.depends('currency_id', 'company_id', 'date', 'invoice_date')
     def _compute_currency_rate(self):
-        for rec in self:
-            if rec.currency_id and rec.company_id and (rec.currency_id != rec.company_id.currency_id):
-                rec.computed_currency_rate = rec.currency_id._convert(
-                    1.0, rec.company_id.currency_id, rec.company_id,
-                    date=rec.date or fields.Date.context_today(rec),
-                    round=False)
-            else:
-                rec.computed_currency_rate = 1.0
+        need_currency_rate = self.filtered(lambda x: x.currency_id and x.company_id and (x.currency_id != x.company_id.currency_id))
+        remaining = self - need_currency_rate
+        for rec in need_currency_rate:
+            rec.computed_currency_rate = rec.currency_id._convert(
+                1.0, rec.company_id.currency_id, rec.company_id,
+                # para previsualizar lo que sería la tasa usamos la fecha contable, sino usamos la fecha al día de hoy
+                # la fecha contable en facturas de venta realmente está seteada cuando el invoice_date está activo o
+                # posterior a la validación de la factura es por eso que comparamos invoice_date
+                date=rec.date if rec.invoice_date else fields.Date.context_today(rec),
+                round=False)
+        remaining.computed_currency_rate = 1.0
 
     @api.model
     def _l10n_ar_get_document_number_parts(self, document_number, document_type_code):

--- a/l10n_ar_ux/wizards/account_move_change_rate.py
+++ b/l10n_ar_ux/wizards/account_move_change_rate.py
@@ -31,7 +31,7 @@ class AccountMoveChangeRate(models.TransientModel):
         self.currency_rate = self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate
 
     def confirm(self):
-        message = _("Currency rate changed from %s to %s") % (self.currency_rate, self.currency_rate)
+        message = _("Currency rate changed from %s to %s") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, self.currency_rate)
         self.move_id.message_post(body=message)
         self.move_id.l10n_ar_currency_rate = self.currency_rate
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
The calculation of the quote depends on the date of the invoice, however this date must be different for the type of invoice:
    * If it is a customer invoice we should take invoice_date
    * If it is a supplier invoice we should take date (accounting date).

This change was necessary because we get the following case: in the case of customer invoices, if we take the date field, what it will do is calculate the quote with the date on which the invoice was created. And this is a problem because if the user creates them before and validates them some time later, they will always take into account an old quote, taking into account that the date field is not shown in customer invoices and therefore they cannot edit.