### PR TITLE
[IMP] l10n_ar_ux: POS Address

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "13.0.1.35.0",
+    'version': "13.0.1.36.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/models/account_journal.py
+++ b/l10n_ar_ux/models/account_journal.py
@@ -19,6 +19,7 @@ class AccountJournal(models.Model):
         help="String to generate the QR Code that will be displayed on the invoice report."
     )
     l10n_ar_is_pos = fields.Boolean(compute="_compute_l10n_ar_is_pos", store=True, readonly=False, string="Is AFIP POS?")
+    l10n_ar_afip_pos_partner_id = fields.Many2one(string='Dirección Punto de venta')
 
     @api.onchange('l10n_ar_is_pos')
     def _onchange_l10n_ar_is_pos(self):

--- a/l10n_ar_ux/views/account_journal_views.xml
+++ b/l10n_ar_ux/views/account_journal_views.xml
@@ -26,7 +26,7 @@
                 <attribute name="attrs">{'invisible':[('l10n_ar_is_pos', '=', False)], 'required':[('l10n_ar_is_pos', '=', True)]}</attribute>
             </field>
             <field name="l10n_ar_afip_pos_partner_id" position="attributes">
-                <attribute name="attrs">{'invisible':['|', ('l10n_latam_country_code', '!=', 'AR'), ('type', 'not in', ['sale', 'purchase'])], 'required':[('l10n_ar_is_pos', '=', True)]}</attribute>
+                <attribute name="attrs">{'invisible':['|', ('l10n_latam_country_code', '!=', 'AR'), ('type', 'not in', ['sale', 'purchase'])], 'required':['|',('l10n_ar_is_pos', '=', True), '&amp;', '&amp;',('l10n_latam_use_documents', '=', False), ('l10n_latam_country_code', '=', 'AR'), ('type', '=', 'sale')]}</attribute>
             </field>
             <xpath expr="//page[@name='advanced_settings']/group" position="after">
                 <group string="QR-Code" attrs="{'invisible': ['|', '|', ('l10n_latam_country_code', '!=', 'AR'), ('type', '!=', 'sale'), ('l10n_latam_use_documents', '=', False)]}">


### PR DESCRIPTION
Rename AFIP POS Address field to POS Address in order to reuse this
 field to set the address of the custom header in the invoice report

ticket 50336