### PR TITLE
[ADD] l10n_ar_ux: inherit account_fiscal_position

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "15.0.1.6.0",
+    'version': "15.0.1.7.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -40,6 +40,7 @@
         'security/ir.model.access.csv',
         'security/l10n_ar_ux_security.xml',
         'data/res_groups_data.xml',
+        'views/account_fiscal_position_view.xml'
     ],
     'demo': [
     ],

--- a/l10n_ar_ux/views/account_fiscal_position_view.xml
+++ b/l10n_ar_ux/views/account_fiscal_position_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_position_form" model="ir.ui.view">
+        <field name="name">account.fiscal.position.form.inherit</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="inherit_id" ref="l10n_ar.view_account_position_form"/>
+        <field name="arch" type="xml">
+            <field name="l10n_ar_afip_responsibility_type_ids" position="attributes">
+                <attribute name="groups"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
ticket 51806

Se heredo la vista de posiciones fiscales para que ahora
muestre el campo l10n_ar_afip_responsibility_type_ids sin
necesidad de estar en debug mode