### PR TITLE
[FIX] l10n_ar_ux: save draf vendor bill with document number

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -104,6 +104,7 @@ class AccountMove(models.Model):
 
             domain = [
                 ('type', '=', rec.type),
+                ('name', '!=', '/'),
                 # by validating name we validate l10n_latam_document_number and l10n_latam_document_type_id
                 '|', ('name', '=', old_name_compat), ('name', '=', rec.name),
                 ('company_id', '=', rec.company_id.id),


### PR DESCRIPTION
Ticket: 55545

El problema que se soluciona es que al duplicar una factura de proveedor en borrador que no tiene seteado número de documento y a la factura duplicada se le cambia el número de documento y se guarda entonces se contempla que ese número ya existe cuando no necesariamente es así.