### PR TITLE
[FIX] change to httplib2==0.20.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httplib2>=0.7
+httplib2==0.20.4
 git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
 git+https://github.com/ingadhoc/pyafipws@py3k
 git+https://github.com/OCA/openupgradelib/@master


### PR DESCRIPTION
Related to new releasse 21 where we get Cannot set verify_mode to CERT_NONE when check_hostname is enabled