### PR TITLE
[FIX] l10n_ar_ux: add multiple checks

### DIFF
--- a/l10n_ar_ux/views/account_payment_group_view.xml
+++ b/l10n_ar_ux/views/account_payment_group_view.xml
@@ -11,10 +11,10 @@
                     name="%(action_account_payment_add_checks)d"
                     class="oe_link"
                     style="margin:12px 0px 12px 0px;"
-                    string="Add multiple checks"
+                    string="Entregar varios cheques"
                     icon="fa-plus-circle"
                     type="action"
-                    attrs="{'invisible':[('state','!=', 'draft')]}"
+                    attrs="{'invisible':[('state','not in', ['draft', 'confirmed'])]}"
                 />
             </field>
         </field>

--- a/l10n_ar_ux/wizards/account_payment_add_checks.py
+++ b/l10n_ar_ux/wizards/account_payment_add_checks.py
@@ -15,6 +15,7 @@ class AccounTpaymentAddChecks(models.TransientModel):
             vals_list = [{
                 'l10n_latam_check_id': check.id,
                 'amount': check.amount,
+                'partner_id': payment_group.partner_id.id,
                 'payment_group_id': payment_group.id,
                 'payment_type': 'outbound',
                 'journal_id': check.l10n_latam_check_current_journal_id.id,


### PR DESCRIPTION
1. renombramos a "entregar varios cheques" para que en recibos de clientes quede mas claro que se usa para enviar cheques y no para cobrar varios a al vez
2. Arreglamos que en pagos con doble confirmación aparezca el botón (state confirmed)
3. arreglamos error de que falta partner en cuenta deudora