### PR TITLE
[IMP] l10n_ar_ux: hide/show l10n fields

### DIFF
--- a/l10n_ar_ux/views/account_journal_views.xml
+++ b/l10n_ar_ux/views/account_journal_views.xml
@@ -13,7 +13,7 @@
             </field>
 
             <field name="l10n_ar_afip_pos_partner_id" position="after">
-                <field name="l10n_ar_document_type_ids" widget="many2many_tags" attrs="{'invisible': ['|', '|', ('l10n_latam_use_documents', '=', False), '&amp;', ('type', '=', 'sale'), ('l10n_ar_is_pos', '=', True), '&amp;', ('type', '=', 'purchase'), ('l10n_ar_is_pos', '=', False)]}" domain="[('country_id.code', '=', country_code), ('code', 'in', [
+                <field name="l10n_ar_document_type_ids" widget="many2many_tags" attrs="{'invisible': ['|',  ('country_code', '!=', 'AR'), '|', '|', ('l10n_latam_use_documents', '=', False), '&amp;', ('type', '=', 'sale'), ('l10n_ar_is_pos', '=', True), '&amp;', ('type', '=', 'purchase'), ('l10n_ar_is_pos', '=', False)]}" domain="[('country_id.code', '=', country_code), ('code', 'in', [
                     '23', '24', '25', '26', '27', '28', '33', '43', '45', '46', '48', '58', '60', '61', '150', '151', '157',
                     '158', '161', '162', '164', '166', '167', '171', '172', '180', '182', '186', '188', '332'])]"/>
             </field>


### PR DESCRIPTION
Only show localization fields if the current record belongs to a company that use the l10n_ar localization