### PR TITLE
[FIX] l10n_ar_ux: forced currency rate on invoice

### DIFF
--- a/l10n_ar_ux/models/account_move_line.py
+++ b/l10n_ar_ux/models/account_move_line.py
@@ -8,5 +8,5 @@ class AccountMoveLine(models.Model):
     def _compute_currency_rate(self):
         forced = self.filtered(lambda x: x.move_id.l10n_ar_currency_rate)
         for rec in forced:
-            rec.currency_rate = rec.move_id.l10n_ar_currency_rate
+            rec.currency_rate = 1 / rec.move_id.l10n_ar_currency_rate if (rec.currency_id != rec.move_id.company_currency_id) else 1
         return super(AccountMoveLine, self - forced)._compute_currency_rate()

--- a/l10n_ar_ux/wizards/account_move_change_rate.py
+++ b/l10n_ar_ux/wizards/account_move_change_rate.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import fields, models, api, _
+from odoo.tools import float_round
 
 
 class AccountMoveChangeRate(models.TransientModel):
@@ -35,10 +36,10 @@ class AccountMoveChangeRate(models.TransientModel):
 
     def confirm(self):
         if self.day_rate:
-            message = _("Currency rate changed from %s to %s") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, self.move_id.computed_currency_rate)
+            message = _("Currency rate changed from %s to %s") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, float_round(self.move_id.computed_currency_rate,2))
             self.move_id.l10n_ar_currency_rate = 0.0
         else:
-            message = _("Currency rate changed from %s to %s . Currency rate forced") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, self.currency_rate)
+            message = _("Currency rate changed from %s to %s . Currency rate forced") % (float_round(self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, 2), float_round(self.currency_rate, 2))
             self.move_id.l10n_ar_currency_rate = self.currency_rate
         self.move_id.message_post(body=message)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
Ticket: 59842
Al forzar la moneda en factura no se toma esa cotización y al volver a la moneda anterior se actualizan incorrectamente los importes de las líneas.