### PR TITLE
[FIX] l10n_ar_ux: Fix bad inherit reference

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -12,6 +12,7 @@
         'l10n_latam_check',
         'account_withholding',
         'account_payment_group',
+        'account_ux'
     ],
     'data': [
         'data/res_currency_data.xml',

--- a/l10n_ar_ux/views/account_move_view.xml
+++ b/l10n_ar_ux/views/account_move_view.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
     <record id="view_move_form" model="ir.ui.view">
-        <field name="name">account.move.form</field>
         <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="priority">30</field>
+        <field name="name">l10n_ar_ux.account.move.form</field>
+        <field name="inherit_id" ref="account_ux.view_move_form"/>
         <field name="arch" type="xml">
-
             <button name="%(account_ux.action_account_change_currency)d" position="after">
                 <!-- distinto margen segun este validado o no (y se vea el boton fa-pencil) -->
                 <span class="oe_inline o_form_label ml-2 mr-2" groups="base.group_multi_currency" attrs="{'invisible': ['|', ('state','=','draft'), ('other_currency', '=', False)]}">-</span>
@@ -17,14 +14,23 @@
                 <button name="%(action_account_move_change_rate)d" type="action" icon="fa-pencil" style="color:red" class="btn-link" attrs="{'invisible':['|', '|', '|' , '|', ('state','!=','draft'), ('other_currency', '=', False), ('country_code', '!=', 'AR'), ('l10n_ar_currency_rate', '=', 0.0), ('l10n_ar_currency_rate', '=', False)]}" help="Currency rate forced"/>
                 <button name="%(action_account_move_change_rate)d" type="action" icon="fa-pencil" class="btn-link" attrs="{'invisible':['|', '|', '|' , ('state','!=','draft'), ('other_currency', '=', False), ('country_code', '!=', 'AR'), ('l10n_ar_currency_rate', '!=', 0.0)]}"/>
             </button>
+            <button name="%(account_ux.action_account_change_currency)d" position="attributes">
+                <attribute name="string">(change currency)</attribute>
+            </button>
+        </field>
+    </record>
+
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="priority">30</field>
+        <field name="arch" type="xml">
             <field name="currency_id" position="after">
                 <field name="l10n_ar_currency_rate" attrs="{'invisible': ['|', ('country_code', '!=', 'AR'), '|', '|', ('l10n_ar_currency_rate', '=', False), ('l10n_ar_currency_rate', '=', 0.0), ('l10n_ar_currency_rate', '=', 1.0)]}"/>
                 <field name="computed_currency_rate" string="Currency Rate (preview)" attrs="{'invisible': ['|', ('country_code', '!=', 'AR'), '|', ('l10n_ar_currency_rate', '!=', 0.0), ('computed_currency_rate', '=', 1.0)]}"/>
                 <button name="%(action_account_move_change_rate)d" type="action" string="(change rate)" attrs="{'invisible':['|', ('country_code', '!=', 'AR'), '|', ('state','!=','draft'), ('computed_currency_rate', '=', 1.0)]}" class="oe_link"/>
             </field>
-            <button name="%(account_ux.action_account_change_currency)d" position="attributes">
-                <attribute name="string">(change currency)</attribute>
-            </button>
         </field>
     </record>
 


### PR DESCRIPTION
Some views inheritance have bad reference.

- Add account_ux intho Manifest
- Add new inheritance to solve bad reference code. Cant use account_move. to inherit component that exist into account_ux. Its better add extra inheritance