### PR TITLE
[FIX] l10n_ar_ux: add partner_type on add_checks

### DIFF
--- a/l10n_ar_ux/wizards/account_payment_add_checks.py
+++ b/l10n_ar_ux/wizards/account_payment_add_checks.py
@@ -19,6 +19,7 @@ class AccounTpaymentAddChecks(models.TransientModel):
                 'partner_id': payment_group.partner_id.id,
                 'payment_group_id': payment_group.id,
                 'payment_type': 'outbound',
+                'partner_type': payment_group.partner_type,
                 'journal_id': check.l10n_latam_check_current_journal_id.id,
                 'payment_method_line_id': check.l10n_latam_check_current_journal_id._get_available_payment_method_lines(
                     'oubound').filtered(lambda x: x.code == 'out_third_party_checks').id,


### PR DESCRIPTION
Now partner_type is send on vals_list to create payment when uses add_checks wizard