### PR TITLE
[FIX] l10n_latam_invoice_document: sequence draft vendor bill

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -159,3 +159,9 @@ class AccountMove(models.Model):
                 document_types = rec.l10n_latam_available_document_type_ids._origin
                 document_types = document_types.filtered(lambda x: x.internal_type == 'debit_note')
                 rec.l10n_latam_document_type_id = document_types and document_types[0].id
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_forbid_parts_of_chain(self):
+        """Delete vendor bills without verifying if they are the last ones of the sequence chain."""
+        vendor = self.filtered(lambda x: x._is_manual_document_number() and x.l10n_latam_use_documents)
+        return super(AccountMove, self - vendor)._unlink_forbid_parts_of_chain()


### PR DESCRIPTION
Ticket: 55058
Task: 899 en latam y 28337 en adhoc

Description of the issue/feature this PR addresses:

1) On Runbot Odoo enterprise v15.0 install l10n_ar_edi module (Argentina Electronic Invoicing).

2) Select and work on "(AR) Responsable Inscripto" Company.

3) Go to Accounting > Vendor > Bills.

4) Create a Vendor bill with vendor "ADHOC SA", document number 1-5 (this is an example), and save.

5) Try to delete de bill, a see the sequence problem. "User Error: You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. You should probably revert it instead."

Current behavior before PR:
Can't delete draft vendor bill situated in a company from l10n_ar localization.

Desired behavior after PR is merged:
Is possible to delete draft vendor bills situated in a company from l10n_ar localization.