### PR TITLE
[FIX] l10n_ar_account_withholding - API no se puede ver en contactos

### DIFF
--- a/l10n_ar_account_withholding/__manifest__.py
+++ b/l10n_ar_account_withholding/__manifest__.py
@@ -50,5 +50,5 @@
     },
     'installable': True,
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': "16.0.1.0.0",
+    'version': "16.0.1.1.0",
 }

--- a/l10n_ar_account_withholding/views/res_partner_arba_alicuot_views.xml
+++ b/l10n_ar_account_withholding/views/res_partner_arba_alicuot_views.xml
@@ -67,7 +67,7 @@
             </field>
             <!-- TODO mejorar esto, por ahora solo lo hacemos visible con este grupo ya que este grupo solo lo estamos usando en realidad para API, deberiamos ver de hacerlo de otra manera -->
             <notebook>
-                <page string="API" groups="l10n_ar_account_withholding.l10n_apartner_tax_withholding_amount_type">
+                <page string="API" groups="l10n_ar_account_withholding.partner_tax_withholding_amount_type">
                     <group>
                         <field name="api_codigo_articulo_retencion"/>
                         <field name="api_articulo_inciso_calculo_retencion"/>


### PR DESCRIPTION
Task: 33633
No se puede ver en contactos la solapa "API": 

Explicacioń: https://drive.google.com/file/d/1RsB5rWqWc_KbOeIvrwIodvyFdl1cTMR-/view 

Este grupo no existe en 16:

https://github.com/ingadhoc/odoo-argentina/blob/16.0/l10n_ar_account_withholding/views/res_partner_arba_alicuot_views.xml#L70 