### PR TITLE
[IMP] l10n_ar_account_withholding: allow register manually padron arba if the is an error while connecting to arba

### DIFF
--- a/l10n_ar_account_withholding/models/res_company.py
+++ b/l10n_ar_account_withholding/models/res_company.py
@@ -166,7 +166,9 @@ class ResCompany(models.Model):
                 msg = "%s\n Error %s: %s" % (ws.MensajeError, ws.TipoError, ws.CodigoError)
                 _logger.error('Padron ARBA: %s' % msg)
             else:
-                self._process_message_error(ws)
+                error = True
+                msg = (_('Padron ARBA: %s - %s (%s)') % (ws.CodigoError, message, ws.TipoError))
+                _logger.error('Padron ARBA: %s' % msg)
 
         if error:
             action = self.env.ref('l10n_ar_account_withholding.act_company_jurisdiction_padron')


### PR DESCRIPTION
Task: 31361
Allow to give the user the opportunity to register manually padron arba not only if arba is down or out of service, also if there is other error type.