### PR TITLE
[FIX] l10n_ar_ux: delete draft vendor bill 

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -131,3 +131,15 @@ class AccountMove(models.Model):
         """Delete vendor bills without verifying if they are the last ones of the sequence chain."""
         vendor = self.filtered(lambda x: x._is_manual_document_number() and x.l10n_latam_use_documents)
         return super(AccountMove, self - vendor)._unlink_forbid_parts_of_chain()
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_forbid_parts_of_chain(self):
+        """Delete vendor bills without verifying if they are the last ones of the sequence chain."""
+        # Field l10n_latam_use_documents is defined in module l10n_latam_invoice_document but l10n_ax_ux doesn´t has it as depends.
+        l10n_latam_invoice_document_installed = self.env['ir.module.module'].search([
+            ('name', '=', 'l10n_latam_invoice_document'),
+            ('state', '=', 'installed'),
+        ])
+        if l10n_latam_invoice_document_installed:
+            vendor = self.filtered(lambda x: x._is_manual_document_number() and x.l10n_latam_use_documents)
+            return super(AccountMove, self - vendor)._unlink_forbid_parts_of_chain()


### PR DESCRIPTION
Ticket: 55058
This pr replaces odoo/odoo#100728

Description of the issue/feature this PR addresses:

On Runbot Odoo enterprise v15.0 install l10n_ar_edi module (Argentina Electronic Invoicing).

Select and work on "(AR) Responsable Inscripto" Company.

Go to Accounting > Vendor > Bills.

Create a Vendor bill with vendor "ADHOC SA", document number 1-5 (this is an example), and save.

Try to delete de bill, a see the sequence problem. "User Error: You cannot delete this entry, as it has already consumed a sequence number and is not the last one in the chain. You should probably revert it instead."

Current behavior before PR:
Can't delete draft vendor bill situated in a company from l10n_ar localization.

Desired behavior after PR is merged:
Is possible to delete draft vendor bills situated in a company from l10n_ar localization.