### PR TITLE
[FIX] l10n_ar_ux: renamed parameter in report controller

### DIFF
--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -76,7 +76,7 @@
                     <div class="col-auto p-5 text-center">
                         <h5><span t-field="o.journal_id.qr_code_label"/></h5>
                         <br/>
-                        <img t-att-src="'/report/barcode/?type=QR&amp;value=%s&amp;width=128&amp;height=128' % o.journal_id.qr_code" style="height:100px"/>
+                        <img t-att-src="'/report/barcode/?barcode_type=QR&amp;value=%s&amp;width=128&amp;height=128' % o.journal_id.qr_code" style="height:100px"/>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
`type` is now `barcode_type`

See https://github.com/odoo/odoo/commit/ee324e8374536cebca4d7302210b07e8f33d3852