### PR TITLE
[FIX] l10n_ar_ux: renamed field in report

### DIFF
--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -71,7 +71,7 @@
             </p>
         </div>
         <div id="qrcode" position="after">
-            <div t-if="o.company_id.country_id.code == 'AR' and o.journal_id.qr_code and o.invoice_payment_state != 'paid'">
+            <div t-if="o.company_id.country_id.code == 'AR' and o.journal_id.qr_code and o.payment_state != 'paid'">
                 <div clas="row m-0 justify-content-center align-item-center">
                     <div class="col-auto p-5 text-center">
                         <h5><span t-field="o.journal_id.qr_code_label"/></h5>


### PR DESCRIPTION
`invoice_payment_state` was renamed to `payment_state`