### PR TITLE
[FIX] l10n_ar_ux: monkey patch

### DIFF
--- a/l10n_ar_ux/__init__.py
+++ b/l10n_ar_ux/__init__.py
@@ -9,6 +9,7 @@ from . import reports
 from . import wizards
 from .hooks import post_init_hook
 from odoo.addons.l10n_latam_invoice_document.models.account_move import AccountMove
+from odoo.addons.l10n_ar.models.account_move import AccountMove as AccountMoveAr
 from odoo.addons.l10n_ar.models.account_fiscal_position import AccountFiscalPosition
 from odoo.exceptions import UserError
 
@@ -18,8 +19,7 @@ def monkey_patches():
     orginal_method = AccountMove._inverse_l10n_latam_document_number
 
     def _inverse_l10n_latam_document_number(self):
-        """ Parche feo para poder usar liquidaciones hasta que se mezcle https://github.com/odoo/odoo/pull/78632 en
-        master"""
+        """ Parche feo para poder usar liquidaciones. Eliminar al migrar a version 17 """
         orginal_method(self)
         to_review = self.filtered(lambda x: (
             x.journal_id.l10n_ar_is_pos
@@ -41,7 +41,7 @@ def monkey_patches():
                     raise UserError(_('The document number can not be changed for this journal, you can only modify'
                                       ' the POS number if there is not posted (or posted before) invoices'))
 
-    AccountMove._inverse_l10n_latam_document_number = _inverse_l10n_latam_document_number
+    AccountMoveAr._inverse_l10n_latam_document_number = _inverse_l10n_latam_document_number
 
     # monkey patch
     @api.model


### PR DESCRIPTION
Make it work for liquido producto. The patch should call the original method in latam module, and it does, but for some reason later it call the one in AR loc and give us this problem.

This does not happen on version 13. Not sure why

Ticket 71348