### PR TITLE
[FIX] l10n_ar_ux: persist modified taxes on multicurrency situations

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -107,14 +107,16 @@ class AccountMove(models.Model):
         today = fields.Date.context_today(self)
         old_date = '1970-01-01'
         for inv in other_currency_ar_invoices:
+            # en todos los casos pasamos el tax_totals para que account_invoice_tax pueda persistir los impuestos modificados
+            # lo podemos hacer "tranquilos" porque sabemos que no estamos cambiando importes
             invoice_date = inv.invoice_date
-            inv.invoice_date = old_date
-            inv.invoice_date = invoice_date or today
- 
+            inv.write({'invoice_date': old_date, 'tax_totals': inv.tax_totals})
+            inv.write({'invoice_date': invoice_date or today, 'tax_totals': inv.tax_totals})
+
             if inv.move_type in ['in_invoice', 'in_refund']:
                 accounting_date = inv.date
-                inv.date = old_date
-                inv.date = accounting_date or today
+                inv.write({'date': old_date, 'tax_totals': inv.tax_totals})
+                inv.write({'date': accounting_date or today, 'tax_totals': inv.tax_totals})
 
         res = super()._post(soft=soft)
 

--- a/l10n_ar_ux/wizards/account_move_change_rate.py
+++ b/l10n_ar_ux/wizards/account_move_change_rate.py
@@ -35,18 +35,14 @@ class AccountMoveChangeRate(models.TransientModel):
         self.currency_rate = self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate
 
     def confirm(self):
-        # Agrego este contexto para obtenerlo desde el modulo account_invoice_tax y evitar que se recompute el monto (amount_currency ) de los impuestos fijos
-        # al cambiar la cotizacion de la moneda
-        # Si bien no seria necesario si no esta instalado este modulo, nos evita un modulo puente
-        context = {
-                'tax_list_origin': self.move_id.mapped('invoice_line_ids.tax_ids'),
-                'tax_total_origin': self.move_id.tax_totals
-        }
         if self.day_rate:
-            message = _("Currency rate changed from %s to %s") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, float_round(self.move_id.computed_currency_rate,2))
-            self.move_id.with_context(context).l10n_ar_currency_rate = 0.0
+            message = _("Currency rate changed from %s to %s") % (self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, float_round(self.move_id.computed_currency_rate, 2))
+            rate = 0.0
         else:
             message = _("Currency rate changed from %s to %s . Currency rate forced") % (float_round(self.move_id.l10n_ar_currency_rate or self.move_id.computed_currency_rate, 2), float_round(self.currency_rate, 2))
-            self.move_id.with_context(context).l10n_ar_currency_rate = self.currency_rate
+            rate = self.currency_rate
+        # pasamos el tax_totals porque es lo que termina usando  account_invoice_tax para poder mantener impuestos forzados
+        # lo podemos hacer aca de anera segura porque sabemos que solo cambia rate y no cambia ningun importe
+        self.move_id.write({'l10n_ar_currency_rate': rate, 'tax_totals': self.move_id.tax_totals})
         self.move_id.message_post(body=message)
         return {'type': 'ir.actions.act_window_close'}


### PR DESCRIPTION
En este commit arreglamos dos cosas:
1. una que era NTH, es que cambiar cotizacion en una factura no resetee impuestos modificados a mano
2. que al postear una factura en otra divisa, tampoco se reseteen impuestos modificados a mano.

Ambas cosas las logramos agregando en el vals tax_totals que de alguna manera luego es interpretado por "account_invoice_tax" quien es el responsable de mantener impuestos fijos que se modificaron