### PR TITLE
[FIX] l10n_ar_ux: sanitize document_number

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -95,3 +95,10 @@ class AccountMove(models.Model):
         ar_invoices.filtered(lambda x: not x.l10n_latam_use_documents)._set_afip_rate()
 
         return res
+
+    @api.model    
+    def _l10n_ar_get_document_number_parts(self, document_number, document_type_code):
+        # eliminamos todo lo que viene después '(' que es un sufijo que odoo agrega y que nosotros agregamos para
+        # forzar unicidad con cambios de approach al ir migrando de versiones
+        document_number = document_number.split('(')[0]
+        return super()._l10n_ar_get_document_number_parts(document_number, document_type_code)


### PR DESCRIPTION
FW of https://github.com/ingadhoc/odoo-argentina/pull/862 

Removes added characters (e.g. (1)) for repeated document numbers before sending them to l10n_ar method that returns document number parts