### PR TITLE
[FIX] l10n_ar: t-esc in override is not understood

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "16.0.1.11.0",
+    'version': "16.0.1.12.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -35,7 +35,7 @@
         <span t-field="o.company_id.partner_id.l10n_ar_formatted_vat" position="attributes">
             <attribute name="t-field">header_address.l10n_ar_formatted_vat</attribute>
         </span>
-        <span t-esc="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
+        <span t-out="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
             <attribute name="t-out">header_address.l10n_ar_gross_income_type == 'exempt' and 'Exento' or header_address.l10n_ar_gross_income_number</attribute>
         </span>
         <span t-field="o.company_id.l10n_ar_afip_start_date" position="attributes">


### PR DESCRIPTION
While accessing /my/invoices, and having installed l10n_ar, we have a warning that the t-esc is not understood. The inherited attribute then does not work. Let's replace it for a t-out.
Ticket Adhoc side: 79024