### PR TITLE
[FIX] l10n_ar_ux: cambio en vista l10n_ar.custom_header

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "16.0.1.12.0",
+    'version': "16.0.1.13.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/migrations/16.0.1.13.0/pre-migration.py
+++ b/l10n_ar_ux/migrations/16.0.1.13.0/pre-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade
+import logging
+logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+
+    logger.info('Forzamos la actualización de la vista de report_invoice en módulo l10n_ar para que pueda aplicarse correctamente este cambio https://github.com/odoo/odoo/pull/177283')
+    openupgrade.load_data(env.cr, 'l10n_ar', 'views/report_invoice.xml')

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -35,7 +35,7 @@
         <span t-field="o.company_id.partner_id.l10n_ar_formatted_vat" position="attributes">
             <attribute name="t-field">header_address.l10n_ar_formatted_vat</attribute>
         </span>
-        <span t-esc="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
+        <span t-out="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
             <attribute name="t-out">header_address.l10n_ar_gross_income_type == 'exempt' and 'Exento' or header_address.l10n_ar_gross_income_number</attribute>
         </span>
         <span t-field="o.company_id.l10n_ar_afip_start_date" position="attributes">


### PR DESCRIPTION
While accessing /my/invoices, and having installed l10n_ar, we have a warning that the t-esc is not understood. The inherited attribute then does not work. Let's replace it for a t-out. Ticket Adhoc side: 79024