### PR TITLE
[IMP] l10n_ar_account_withholding: get_partner_alicuot method (account.tax)

### DIFF
--- a/l10n_ar_account_withholding/models/account_tax.py
+++ b/l10n_ar_account_withholding/models/account_tax.py
@@ -148,7 +148,7 @@ class AccountTax(models.Model):
             return arba.alicuota_percepcion / 100.0
         return 0.0
 
-    def get_partner_alicuot(self, partner, date):
+    def get_partner_alicuot(self, partner, date, line=None):
         self.ensure_one()
         commercial_partner = partner.commercial_partner_id
         company = self.company_id


### PR DESCRIPTION
Task: 38394
In new module l10n_ar_account_tax_settlement_mendoza is extended the method get_partner_alicuot (account.tax) and it is needed to add line=None argument to that method