### PR TITLE
[FIX] l10n_ar_account_withholding: Percepciones en facturas de cliente

### DIFF
--- a/l10n_ar_account_withholding/models/account_tax.py
+++ b/l10n_ar_account_withholding/models/account_tax.py
@@ -248,7 +248,7 @@ class AccountTax(models.Model):
     def _compute_amount(
             self, base_amount, price_unit, quantity=1.0, product=None, partner=None, fixed_multiplicator=1):
         if self.amount_type == 'partner_tax':
-            date = self._context.get('invoice_date', fields.Date.context_today(self))
+            date = self._context.get('invoice_date') or fields.Date.context_today(self)
             partner = partner and partner.sudo()
             return base_amount * self.sudo().get_partner_alicuota_percepcion(partner, date)
         else:


### PR DESCRIPTION
En facturas de cliente necesitamos que se calculen las percepciones aplicadas sin necesidad de establecer la fecha en la factura, entonces establecemos la fecha para que se calculen dichas percepciones. Este es el mismo comportamiento que estaba en 16. Ticket: 82729
Este pr reemplaza este fw https://github.com/ingadhoc/odoo-argentina/pull/849 que había sido cerrado.