### PR TITLE
[FIX] l10n_ar_ux: checks order on report

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "16.0.1.15.0",
+    'version': "16.0.1.16.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/reports/report_payment_group.xml
+++ b/l10n_ar_ux/reports/report_payment_group.xml
@@ -62,7 +62,7 @@
                 </thead>
                 <tbody>
                     <!-- TODO podriamos unir todos los pagos en un foreach y cambiar la descripción segun el tipo de pago, deberiamos hacer un sort acorde al inicio -->
-                    <t t-foreach="o.payment_ids.filtered(lambda x: x.payment_method_code in ['check_printing', 'new_third_party_checks', 'in_third_party_checks', 'out_third_party_checks']).sorted(key=lambda r:r.l10n_latam_check_payment_date or r.date)" t-as="line">
+                    <t t-foreach="o.payment_ids.filtered(lambda x: x.payment_method_code in ['check_printing', 'new_third_party_checks', 'in_third_party_checks', 'out_third_party_checks']).sorted(key=lambda r:r.l10n_latam_check_payment_date or r.l10n_latam_check_id.l10n_latam_check_payment_date or r.date)" t-as="line">
                         <t t-set="check" t-value="line.l10n_latam_check_id or line"/>
                         <tr>
                             <td>


### PR DESCRIPTION
Solo estabamos ordenando new checks y own checks. Faltaba ordenar los cheques entregados