### PR TITLE
[FIX] l10n_ar_account_withholding: certificados de retencion en envio de mails

### DIFF
--- a/l10n_ar_account_withholding/models/mail_compose_message.py
+++ b/l10n_ar_account_withholding/models/mail_compose_message.py
@@ -6,34 +6,29 @@ import base64
 class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
-    # TODO falta adaptar
-    def _onchange_template_id(self, template_id, composition_mode, model, res_id):
-        values = super()._onchange_template_id(
-            template_id, composition_mode, model, res_id)
-        if template_id and model == 'account.payment':
-            payment = self.env[model].browse(res_id)
-            if payment.partner_type != 'supplier':
-                return values
-            report = self.env.ref('l10n_ar_account_withholding.action_report_withholding_certificate',
-                                  raise_if_not_found=False)
-            if not report:
-                return values
-            attachment_ids = []
-            for payment in payment.payment_ids.filtered(lambda p: p.payment_method_code == 'withholding'):
-                report_name = safe_eval.safe_eval(report.print_report_name, {'object': payment})
-                result, format = self.env['ir.actions.report']._render(report.report_name, payment.ids)
-                file = base64.b64encode(result)
-                data_attach = {
-                    'name': report_name,
-                    'datas': file,
-                    'res_model': 'mail.compose.message',
-                    'res_id': 0,
-                    'type': 'binary',
-                }
-                attachment_ids.append(self.env['ir.attachment'].create(data_attach).id)
-            if values.get('value', False) and values['value'].get('attachment_ids', []) or attachment_ids:
-                values_attachment_ids = values['value'].get('attachment_ids', False) and \
-                    values['value']['attachment_ids'][0][2] or []
-                values['value']['attachment_ids'] = [(6, 0, values_attachment_ids + attachment_ids)]
+    def _compute_attachment_ids(self):
+        """ Extendemos el método original para que se pueda previsualizar en el envío de mails de pagos el/los archivos de retenciones. """
+        super()._compute_attachment_ids()
+        for composer in self:
+            res_ids = composer._evaluate_res_ids() or [0]
+            if composer.model == 'account.payment' and composer.template_id and len(res_ids) == 1:
+                payment = self.env[composer.model].browse(res_ids)
+                if payment.partner_type != 'supplier':
+                    return
 
-        return values
+                report = self.env.ref('l10n_ar_withholding_ux.action_report_withholding_certificate', 
+                                      raise_if_not_found=False)
+                if not report:
+                    return
+                for withholding in payment.l10n_ar_withholding_line_ids:
+                    report_name = safe_eval.safe_eval(report.print_report_name, {'object': withholding})
+                    result, _ = self.env['ir.actions.report']._render(report.report_name, withholding.ids)
+                    file = base64.b64encode(result)
+                    data_attach = {
+                        'name': report_name,
+                        'datas': file,
+                        'res_model': 'mail.compose.message',
+                        'res_id': 0,
+                        'type': 'binary',
+                    }
+                    composer.attachment_ids += self.env['ir.attachment'].create(data_attach)


### PR DESCRIPTION
Extendimos el método original de _compute_attachment_ids para poder agregar como adjuntos los certificados de retenciones en los mails de pagos.
Esto es posible hacerlo desde el botón de acción  "send receipts by email" desde el pago individual, o seleccionando un pago desde la vista lista y luego clickeando el mismo botón de acción.


Según los docstrings del método original, en el template del mail sólo hay que mostrar los adjuntos cuando se trata de un sólo pago, y en caso de seleccionar más de un pago el template se muestra sin adjuntos y luego al momento de enviar el mail se deberían adjuntar los archivos correspondientes. Quedaría pendiente agregar esta posibilidad en caso de que se quiera implementar. 
En v16 hay un bug ya que al seleccionar más de un pago dentro del template figuran los comprobantes de retención de un sólo pago y esos comprobantes son adjuntos a todos los mails de los pagos seleccionados. Es por eso que sólo dejé la funcionalidad para cuando se selecciona un solo pago.