### PR TITLE
[FIX] l10n_ar_account_withholding: Add title attribute to icon button

### DIFF
--- a/l10n_ar_account_withholding/__manifest__.py
+++ b/l10n_ar_account_withholding/__manifest__.py
@@ -50,5 +50,5 @@
     },
     'installable': True,
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': "16.0.1.3.0",
+    'version': "16.0.1.4.0",
 }

--- a/l10n_ar_account_withholding/views/account_payment_view.xml
+++ b/l10n_ar_account_withholding/views/account_payment_view.xml
@@ -9,7 +9,7 @@
             <tree>
                 <field name="payment_method_code" invisible="1"/>
                 <field name="partner_type" invisible="1"/>
-                <button name="%(action_report_withholding_certificate)d" icon="fa-print " help="Print withholding voucher" type="action" attrs="{'invisible': ['|', ('payment_method_code', '!=', 'withholding'), ('partner_type', '!=', 'supplier')]}"/>
+                <button name="%(action_report_withholding_certificate)d" icon="fa-print" title="Print withholding voucher" help="Print withholding voucher" type="action" attrs="{'invisible': ['|', ('payment_method_code', '!=', 'withholding'), ('partner_type', '!=', 'supplier')]}"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
- Adds a title attribute to a button that has an icon without text.
- Remove trailing space at end of icon attribute.