### PR TITLE
[IMP] l10n_ar_purchase: show only vat tax

### DIFF
--- a/l10n_ar_purchase/__manifest__.py
+++ b/l10n_ar_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Purchase',
-    'version': "16.0.1.2.0",
+    'version': "16.0.1.3.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_purchase/i18n/es.po
+++ b/l10n_ar_purchase/i18n/es.po
@@ -40,6 +40,11 @@ msgstr "<br/><strong>Su referencia de pedido:</strong>"
 
 #. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
+msgid "<strong>% VAT</strong>"
+msgstr "<strong>% IVA</strong>"
+
+#. module: l10n_ar_purchase
+#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchasequotation_document
 msgid "<strong>Purchase Representative:</strong>"
 msgstr "<strong>Comprador:</strong>"

--- a/l10n_ar_purchase/views/purchase_report_templates.xml
+++ b/l10n_ar_purchase/views/purchase_report_templates.xml
@@ -150,6 +150,14 @@
         <h2 position="replace"/>
         <h2 position="replace"/>
 
+        <!-- use column vat instead of taxes and only if vat discriminated -->
+        <xpath expr="//th[@name='th_taxes']/strong" position="replace">
+            <strong>% VAT</strong>
+        </xpath>
+        <t t-set="taxes" position="attributes">
+            <attribute name="t-value">', '.join([(tax.description or tax.name) for tax in line.taxes_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)])</attribute>
+        </t>
+
         <div id="informations" position="replace">
             <div id="l10n_ar_informations" class="row mt8 mb8">
                 <div class="col-6">


### PR DESCRIPTION
Al igual que en facturas y ventas, solo mostramos columna de IVA en reporte argentino