### PR TITLE
[ADD] l10n_ar_account_withholding_fix: new module

### DIFF
--- a/l10n_ar_account_withholding_fix/__init__.py
+++ b/l10n_ar_account_withholding_fix/__init__.py
@@ -1,0 +1,21 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    records = env['ir.model.data'].search([
+        ('module', '=', 'l10n_ar_account_withholding_fix'),
+        ('model', '=', 'account.tax'),
+    ])
+    records.write({
+        'module': 'l10n_ar_account_withholding',
+        'noupdate': True,
+    })
+    _logger.info(records.read([]))

--- a/l10n_ar_account_withholding_fix/__manifest__.py
+++ b/l10n_ar_account_withholding_fix/__manifest__.py
@@ -1,0 +1,35 @@
+##############################################################################
+#
+#    Copyright (C) 2024  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': '(FIX) Create Argentinian Withholdings',
+    'version': "16.0.1.0.0",
+    'author': 'ADHOC SA,Odoo Community Association (OCA)',
+    'website': 'www.adhoc.com.ar',
+    'license': 'AGPL-3',
+    'category': 'Accounting & Finance',
+    'depends': [
+        'l10n_ar_account_withholding',
+    ],
+    'data': [
+        'data/account_tax_withholding.xml',
+    ],
+    'installable': True,
+    'post_init_hook': 'post_init_hook',
+}

--- a/l10n_ar_account_withholding_fix/data/account_tax_withholding.xml
+++ b/l10n_ar_account_withholding_fix/data/account_tax_withholding.xml
@@ -1,0 +1,1940 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <data>
+
+<!-- EXENTO -->
+    <!-- Retenciones suss -->
+        <record id="1_ri_tax_retencion_suss_sufrida" model="account.tax">
+            <field name="name">Retención SUSS Sufrida</field>
+            <field name="description">Ret SUSS S</field>
+            <field name="sequence">10</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_suss_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_suss')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_suss_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_suss')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="account.tax_group_taxes"/>
+        </record>
+
+    <!-- Retenciones ganancias -->
+        <record id="1_ri_tax_retencion_ganancias_sufrida" model="account.tax">
+            <field name="name">Retención Ganancias Sufrida</field>
+            <field name="description">Ret Ganancias S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_ganancias_sufrida'),
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_ganancias_sufrida'),
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_ganancias"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_ganancias_aplicada" model="account.tax">
+            <field name="name">Retención Ganancias Aplicada</field>
+            <field name="description">Ret Ganancias A</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_ganancias_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_sicore_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_ganancias_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_sicore_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_ganancias"/>
+        </record>
+
+    <!-- Retenciones IIBB -->
+        <record id="1_ri_tax_retencion_iibb_caba_sufrida" model="account.tax">
+            <field name="name">Retención IIBB CABA Sufrida</field>
+            <field name="description">Ret IIBB CABA S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_caba_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_901')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_caba_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_901')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_caba"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ba_sufrida" model="account.tax">
+            <field name="name">Retención IIBB ARBA Sufrida</field>
+            <field name="description">Ret IIBB ARBA S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ba_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_902')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ba_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_902')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ba"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ca_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Catamarca Sufrida</field>
+            <field name="description">Ret IIBB Catamarca S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ca_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_903')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ca_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_903')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ca"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_co_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Córdoba Sufrida</field>
+            <field name="description">Ret IIBB Córdoba S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_co_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_904')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_co_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_904')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_co"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_rr_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Corrientes Sufrida</field>
+            <field name="description">Ret IIBB Corrientes S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_rr_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_905')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_rr_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_905')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_rr"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_er_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Entre Ríos Sufrida</field>
+            <field name="description">Ret IIBB Entre Ríos S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_er_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_908')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_er_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_908')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_er"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ju_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Jujuy Sufrida</field>
+            <field name="description">Ret IIBB Jujuy S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ju_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_910')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ju_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_910')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ju"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_za_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Mendoza Sufrida</field>
+            <field name="description">Ret IIBB Mendoza S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_za_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_913')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_za_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_913')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_za"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_lr_sufrida" model="account.tax">
+            <field name="name">Retención IIBB La Rioja Sufrida</field>
+            <field name="description">Ret IIBB La Rioja S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_lr_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_912')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_lr_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_912')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_lr"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sa_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Salta Sufrida</field>
+            <field name="description">Ret IIBB Salta S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sa_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_917')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sa_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_917')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sa"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_nn_sufrida" model="account.tax">
+            <field name="name">Retención IIBB San Juan Sufrida</field>
+            <field name="description">Ret IIBB San Juan S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_nn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_918')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_nn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_918')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_nn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sl_sufrida" model="account.tax">
+            <field name="name">Retención IIBB San Luis Sufrida</field>
+            <field name="description">Ret IIBB San Luis S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sl_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_919')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sl_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_919')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sl"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sf_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Santa Fe Sufrida</field>
+            <field name="description">Ret IIBB Santa Fe S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sf_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_921')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_sf_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_921')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sf"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_se_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Santiago del Estero Sufrida</field>
+            <field name="description">Ret IIBB Santiago del Estero S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_se_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_922')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_se_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_922')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_se"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_tn_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Tucumán Sufrida</field>
+            <field name="description">Ret IIBB Tucumán S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_tn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_924')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_tn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_924')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_tn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ha_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Chaco Sufrida</field>
+            <field name="description">Ret IIBB Chaco S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ha_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_906')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ha_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_906')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ha"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ct_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Chubut Sufrida</field>
+            <field name="description">Ret IIBB Chubut S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ct_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_907')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ct_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_907')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ct"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_fo_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Formosa Sufrida</field>
+            <field name="description">Ret IIBB Formosa S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_fo_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_909')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_fo_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_909')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_fo"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_mi_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Misiones Sufrida</field>
+            <field name="description">Ret IIBB Misiones S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_mi_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_914')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_mi_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_914')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_mi"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ne_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Neuquén Sufrida</field>
+            <field name="description">Ret IIBB Neuquén S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ne_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_915')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_ne_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_915')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ne"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_lp_sufrida" model="account.tax">
+            <field name="name">Retención IIBB La Pampa Sufrida</field>
+            <field name="description">Ret IIBB La Pampa S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_lp_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_911')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_lp_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_911')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_lp"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_rn_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Río Negro Sufrida</field>
+            <field name="description">Ret IIBB Río Negro S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_rn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_916')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_rn_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_916')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_rn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_az_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Santa Cruz Sufrida</field>
+            <field name="description">Ret IIBB Santa Cruz S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_az_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_920')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_az_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_920')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_az"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_tf_sufrida" model="account.tax">
+            <field name="name">Retención IIBB Tierra del Fuego Sufrida</field>
+            <field name="description">Ret IIBB Tierra del Fuego S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_tf_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_923')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_base_retencion_iibb_tf_sufrida'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tax_tag_a_cuenta_iibb'), ref('l10n_ar_ux.tag_tax_jurisdiccion_923')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_tf"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_caba_aplicada" model="account.tax">
+            <field name="name">Retención IIBB CABA Aplicada</field>
+            <field name="description">Ret IIBB CABA A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_caba_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_caba_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_caba"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ba_aplicada" model="account.tax">
+            <field name="name">Retención IIBB ARBA Aplicada</field>
+            <field name="description">Ret IIBB ARBA A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ba_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ba_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ba"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ca_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Catamarca Aplicada</field>
+            <field name="description">Ret IIBB Catamarca A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ca_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ca_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ca"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_co_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Córdoba Aplicada</field>
+            <field name="description">Ret IIBB Córdoba A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_co_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_co_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_co"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_rr_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Corrientes Aplicada</field>
+            <field name="description">Ret IIBB Corrientes A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_rr_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_rr_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_rr"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_er_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Entre Ríos Aplicada</field>
+            <field name="description">Ret IIBB Entre Ríos A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_er_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_er_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_er"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ju_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Jujuy Aplicada</field>
+            <field name="description">Ret IIBB Jujuy A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ju_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ju_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ju"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_za_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Mendoza Aplicada</field>
+            <field name="description">Ret IIBB Mendoza A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_za_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_za_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_za"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_lr_aplicada" model="account.tax">
+            <field name="name">Retención IIBB La Rioja Aplicada</field>
+            <field name="description">Ret IIBB La Rioja A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_lr_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_lr_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_lr"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sa_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Salta Aplicada</field>
+            <field name="description">Ret IIBB Salta A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sa_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sa_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sa"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_nn_aplicada" model="account.tax">
+            <field name="name">Retención IIBB San Juan Aplicada</field>
+            <field name="description">Ret IIBB San Juan A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_nn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_nn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_nn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sl_aplicada" model="account.tax">
+            <field name="name">Retención IIBB San Luis Aplicada</field>
+            <field name="description">Ret IIBB San Luis A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sl_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sl_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sl"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_sf_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Santa Fe Aplicada</field>
+            <field name="description">Ret IIBB Santa Fe A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sf_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_sf_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_sf"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_se_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Santiago del Estero Aplicada</field>
+            <field name="description">Ret IIBB Santiago del Estero A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_se_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_se_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_se"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_tn_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Tucumán Aplicada</field>
+            <field name="description">Ret IIBB Tucumán A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_tn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_tn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_tn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ha_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Chaco Aplicada</field>
+            <field name="description">Ret IIBB Chaco A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ha_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ha_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ha"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ct_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Chubut Aplicada</field>
+            <field name="description">Ret IIBB Chubut A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ct_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ct_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ct"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_fo_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Formosa Aplicada</field>
+            <field name="description">Ret IIBB Formosa A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_fo_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_fo_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_fo"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_mi_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Misiones Aplicada</field>
+            <field name="description">Ret IIBB Misiones A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_mi_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_mi_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_mi"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_ne_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Neuquén Aplicada</field>
+            <field name="description">Ret IIBB Neuquén A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ne_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_ne_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_ne"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_lp_aplicada" model="account.tax">
+            <field name="name">Retención IIBB La Pampa Aplicada</field>
+            <field name="description">Ret IIBB La Pampa A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_lp_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_lp_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_lp"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_rn_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Río Negro Aplicada</field>
+            <field name="description">Ret IIBB Río Negro A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_rn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_rn_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_rn"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_az_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Santa Cruz Aplicada</field>
+            <field name="description">Ret IIBB Santa Cruz A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_az_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_az_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_az"/>
+        </record>
+
+        <record id="1_ri_tax_retencion_iibb_tf_aplicada" model="account.tax">
+            <field name="name">Retención IIBB Tierra del Fuego Aplicada</field>
+            <field name="description">Ret IIBB Tierra del Fuego A</field>
+            <field name="sequence">4</field>
+            <field name="active" eval="False"/>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_tf_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iibb_tf_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_iibb_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iibb_tf"/>
+        </record>
+
+    <!-- Retenciones iva -->
+        <record id="1_ri_tax_retencion_iva_aplicada" model="account.tax">
+            <field name="name">Retención IVA Aplicada</field>
+            <field name="description">Ret IVA A</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iva_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_sicore_aplicada')])],
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iva_aplicada'),
+                    'tag_ids': [(6, 0, [ref('l10n_ar_ux.tag_ret_perc_sicore_aplicada')])],
+                }),
+            ]"/>
+            <field name="type_tax_use">supplier</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iva"/>
+        </record>
+
+<!-- SOLO RI -->
+    <!-- Retenciones iva -->
+        <record id="1_ri_tax_retencion_iva_sufrida" model="account.tax">
+            <field name="name">Retención IVA Sufrida</field>
+            <field name="description">Ret IVA S</field>
+            <field name="sequence">4</field>
+            <field name="amount_type">fixed</field>
+            <field eval="0.0" name="amount"/>
+            <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iva_sufrida'),
+                }),
+            ]"/>
+            <field name="refund_repartition_line_ids" eval="[(5, 0, 0),
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'base',
+                }),
+
+                (0,0, {
+                    'factor_percent': 100,
+                    'repartition_type': 'tax',
+                    'account_id': ref('l10n_ar.1_ri_retencion_iva_sufrida'),
+                }),
+            ]"/>
+            <field name="type_tax_use">customer</field>
+            <field name="tax_group_id" ref="l10n_ar_ux.tax_group_retencion_iva"/>
+        </record>
+
+  </data>
+</odoo>


### PR DESCRIPTION
Autoamtically create the missing account.tax for a AR database that was initallizated with account taxes.

We need to check that all the accounts and tags exist in the database Also this will only work if company id = 1