### PR TITLE
[FIX] l10n_ar_tax: l10n_ar_code on tax form view and l10n_ar_state_id field on model res.country.state

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': "18.0.1.0.0",
+    'version': "18.0.1.1.0",
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_tax/views/account_tax_view.xml
+++ b/l10n_ar_tax/views/account_tax_view.xml
@@ -15,7 +15,7 @@
         </sheet>
             <xpath expr="//field[@name='amount']/.." position="after">
                 <field name="l10n_ar_state_id" invisible="l10n_ar_tribute_afip_code != '07'" required="l10n_ar_tribute_afip_code == '07'" options="{'no_create': True}"/>
-                <field name="l10n_ar_code" string="Regímen" invisible="(l10n_ar_tribute_afip_code != '07' and l10n_ar_tax_type not in ['iibb_untaxed', 'iibb_total']) or l10n_ar_type_tax_use not in ['sale', 'supplier']" options="{'no_create': True}"/>
+                <field name="l10n_ar_code" string="Regímen" invisible="l10n_ar_tribute_afip_code not in ['01', '06', '07'] or l10n_ar_type_tax_use not in ['sale', 'supplier']" options="{'no_create': True}"/>
             </xpath>
             <!-- limpiamos esta seccion que para retenciones no tiene sentido -->
             <group name="advanced_booleans" position="attributes">

--- a/l10n_ar_ux/models/res_country_state.py
+++ b/l10n_ar_ux/models/res_country_state.py
@@ -13,7 +13,7 @@ class ResCountryState(models.Model):
     @api.depends()
     def _compute_jurisdiction_code(self):
         for rec in self:
-            if rec.l10n_ar_state_id.country_id == 'AR':
+            if rec.country_id == 'AR':
                 rec.jurisdiction_code = {
                     'B': '902',
                     'K': '903',


### PR DESCRIPTION
Task: 43373
1) Make l10n_ar_code field visible on tax form view because is needed for vat withholding and perceptions applied when sicore_aplicado txt is generated.
2) l10n_ar_state_id field does not exist on model res.country.state. The bug was introduced here https://github.com/ingadhoc/odoo-argentina/commit/a7deb299006f334491fd2c21f3971124cfaff89a#diff-99c97e49d76ce120e4e6b9a7ec8d9d742870b6d2644d18804a7ec1e2c333b38aR16
