### PR TITLE
[FIX] Comment unused dependencies causing conflicts in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httplib2==0.20.4
-git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
-git+https://github.com/ingadhoc/pyafipws@py3k
-git+https://github.com/OCA/openupgradelib/@master
+#httplib2==0.20.4
+#git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
+#git+https://github.com/ingadhoc/pyafipws@py3k
+#git+https://github.com/OCA/openupgradelib/@master


### PR DESCRIPTION
Se comentaron las dependencias que generan conflictos (por ejemplo, pysimplesoap) para evitar problemas de instalación y garantizar compatibilidad con otros módulos. Esto no afecta la funcionalidad principal.