### PR TITLE
[FIX] l10n_ar_account_withholding: regimen de ganancias en pagos.

### DIFF
--- a/l10n_ar_account_withholding/models/account_payment.py
+++ b/l10n_ar_account_withholding/models/account_payment.py
@@ -79,7 +79,7 @@ class AccountPayment(models.Model):
             else:
                 rec.company_regimenes_ganancias_ids = rec.env['afip.tabla_ganancias.alicuotasymontos']
 
-    @api.onchange('commercial_partner_id')
+    @api.onchange('partner_id', 'commercial_partner_id')
     def change_retencion_ganancias(self):
         # si es exento en ganancias o no tiene clasificacion pero es monotributista, del exterior o consumidor final, sugerimos regimen no_aplica
         if self.partner_id.commercial_partner_id.imp_ganancias_padron in ['EX', 'NC'] or (


### PR DESCRIPTION
Se aplica el cambio porque el campo computado que establece el commercial_partner_id en el pago https://github.com/odoo/odoo/blob/17.0/addons/account/models/account_move.py#L858 se corre cuando se guarda el registro, entonces el onchange del método change_retencion_ganancias no se termina corriendo.
Ticket: 83251