### PR TITLE
[FIX] l10n_ar_tax: not neccesary to copy l10n_ar_state_id on taxes.

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -90,7 +90,6 @@ class AccountFiscalPositionL10nArTax(models.Model):
                 'amount': rate,
                 'active': True,
                 'name': name,
-                'l10n_ar_state_id': self.default_tax_id.l10n_ar_state_id,
             })
         return tax
 


### PR DESCRIPTION
Ticket: 87219