### PR TITLE
[FIX] l10n_ar_tax: print payment reports without secondary currency

### DIFF
--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -84,7 +84,7 @@
                                 <span class="text-nowrap" t-out="check.amount if o.other_currency else secondary_currency.round(check.amount * secondary_currency_rate)" t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>
                             </td>
                             <td class="text-right o_price_total">
-                                <span class="text-nowrap" t-out="check.amount * secondary_currency_rate if o.other_currency else o.company_currency_id.round(o.amount / secondary_currency_rate)"  t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
+                                <span class="text-nowrap" t-if="secondary_currency" t-out="check.amount * secondary_currency_rate if o.other_currency else o.company_currency_id.round(o.amount / secondary_currency_rate)"  t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
                             </td>
                         </tr>
                     </t>


### PR DESCRIPTION
Before this PR, we were receiving the following traceback when trying to print the report of a payment that has no secondary currency set: 
Traceback (most recent call last):
[..]
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/addons/base/models/ir_qweb.py", line 601, in _render
    result = ''.join(rendering)
  File "<1147>", line 84, in template_1147
  File "<1147>", line 66, in template_1147_content
  File "<1147>", line 54, in template_1147_t_call_0
  File "<5377>", line 1690, in template_5377
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
ZeroDivisionError: float division by zero
Template: l10n_ar_tax.report_payment_receipt_document
Path: /t/t/table[1]/tbody/t[1]/tr/td[3]/span
Node: <span class="text-nowrap" t-out="check.amount * secondary_currency_rate if o.other_currency else o.company_currency_id.round(o.amount / secondary_currency_rate)" t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.company_currency_id}"/>