### PR TITLE
[FIX] l10n_ar_account_withholding: astericos al ver clave CIT ARBA

### DIFF
--- a/l10n_ar_account_withholding/__manifest__.py
+++ b/l10n_ar_account_withholding/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Automatic Argentinian Withholdings on Payments',
-    'version': "17.0.1.3.0",
+    'version': "17.0.1.4.0",
     'author': 'ADHOC SA,Odoo Community Association (OCA)',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/l10n_ar_account_withholding/wizard/res_config_settings_views.xml
+++ b/l10n_ar_account_withholding/wizard/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                     <div class="content-group" invisible="country_code != 'AR'">
                         <div class="row mt16">
                             <label for="arba_cit" class="col-lg-3 o_light_label"/>
-                            <field name="arba_cit"/>
+                            <field name="arba_cit" password="True"/>
                         </div>
                         <div class="row mt16">
                             <label for="arba_alicuota_no_sincripto_retencion" class="col-lg-3 o_light_label"/>


### PR DESCRIPTION
Ticket: 87746

Ponemos astericos al ver clave CIT ARBA al ir a "Contabilidad / Configuración / Ajustes".

Sin este pr:
![image](https://github.com/user-attachments/assets/f29fec41-6eb3-45d3-8475-61cd9f29accb)

Con el cambio introducido en este pr:
![image](https://github.com/user-attachments/assets/8ed0e024-48d5-4ccc-84c8-083a1ff307cc)