### PR TITLE
[FIX] l10n_ar_tax: astericos al ver clave CIT ARBA

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -102,7 +102,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
         self.ensure_one()
         from_date = date + relativedelta(day=1)
         to_date = from_date + relativedelta(days=-1, months=+1)
-        aliquot, ref = getattr(self, "_get_%s_data" % self.webservice)(partner, date, to_date)
+        aliquot, ref = getattr(self, "_get_%s_data" % self.webservice)(partner, from_date, to_date)
         # devolvemos None si es no inscripto
         if aliquot is None:
             tax = self.default_tax_id
@@ -200,7 +200,9 @@ class AccountFiscalPositionL10nArTax(models.Model):
         # figura en el padron, aplicamos alicuota no inscripto
         if ws.NumeroComprobante:
             return (
-                ws.AlicuotaRetencion if self.tax_type == "withholding" else ws.AlicuotaPercepcion,
+                float(ws.AlicuotaRetencion.replace(",", "."))
+                if self.tax_type == "withholding"
+                else float(ws.AlicuotaPercepcion.replace(",", ".")),
                 "%s | %s | %s"
                 % (
                     ws.NumeroComprobante,

--- a/l10n_ar_tax/wizard/res_config_settings_views.xml
+++ b/l10n_ar_tax/wizard/res_config_settings_views.xml
@@ -11,7 +11,7 @@
                     <div class="content-group" invisible="country_code != 'AR'">
                         <div class="row mt16">
                             <label for="arba_cit" class="col-lg-3 o_light_label"/>
-                            <field name="arba_cit"/>
+                            <field name="arba_cit" password="True"/>
                         </div>
                         <div class="row mt16">
                             <button name="l10n_ar_arba_cit_test" type="object" class="oe_link oe_inline" string="⇒ Verificar Clave ARBA"/>


### PR DESCRIPTION
Ticket: 87746

1) Ponemos astericos al ver clave CIT ARBA al ir a "Contabilidad / Configuración / Ajustes".

Sin este pr:
![image](https://github.com/user-attachments/assets/8bef59b6-02b0-42c7-bc17-eea72c70a365)

Con este pr:
![image](https://github.com/user-attachments/assets/3c1718b0-66bc-4e16-a6a3-192b3110ce39)

2) Hacemos que funcione la sincronización al webservice de ARBA.
