### PR TITLE
[FIX] l10n_ar_tax: Prevent duplicate tax withholdings when splitting payments

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -39,6 +39,7 @@ class AccountPayment(models.Model):
                 or rec.partner_type != "supplier"
                 or rec.country_code != "AR"
                 or not rec.use_payment_pro
+                or self.env.context.get("create_and_new")
             ):
                 rec.l10n_ar_fiscal_position_id = False
                 continue


### PR DESCRIPTION

Ensure that tax withholdings are not recalculated when a payment is split, particularly when changing the journal in the second payment. To achieve this, added a context flag to detect when the payment is being created using the "Create and New" button. This prevents the system from incorrectly applying withholdings again in the new payment.