### PR TITLE
[IMP] New module l10n_ar_tax_backward_compatibility

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/views/report_withholding_certificate_templates.xml
+++ b/l10n_ar_tax/views/report_withholding_certificate_templates.xml
@@ -52,6 +52,7 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <t t-set="tax" t-value="o._get_withholding_tax()"/>
                         <tr>
                             <td style="width: 50%;" class="text-right">
                                 Impuesto:
@@ -61,8 +62,8 @@
                                     Si es ganancias, como los stax names son "feos" e invoice_label por ahora no lo populamos, mostramos campo invoice_label si está definido y si no sacamos un label por defecto 'Retención Ganancias'
                                     Tal vez para IIBB y otros podamos hacer similar. En realidad lo ideal es modificar chart para que tenga invoice_label en todos los casos.
                                 -->
-                                <span t-if="o.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="o.tax_id.invoice_label or 'Retención Ganancias'"/>
-                                <span t-else="" t-out="o.tax_id.invoice_label or o.tax_id.name"/>
+                                <span t-if="tax.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="tax.invoice_label or 'Retención Ganancias'"/>
+                                <span t-else="" t-out="tax.invoice_label or tax.name"/>
                             </td>
                         </tr>
                         <tr>
@@ -70,7 +71,7 @@
                                 Régimen:
                             </td>
                             <td class="text-left">
-                                <span t-field="o.tax_id.l10n_ar_code"/>
+                                <span t-field="tax.l10n_ar_code"/>
                             </td>
 
                         </tr>

--- a/l10n_ar_tax_backward_compatibility/README.rst
+++ b/l10n_ar_tax_backward_compatibility/README.rst
@@ -1,0 +1,103 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================================
+Argentinian Withholdings backward compatibility
+===============================================
+How Odoo calculates income withholdings has varied substantially between versions 16, 17, and 18. This module is a technical module. Its objective is to allow continued calculation of accumulated withholdings in installations that migrate mid-period, or to perform the calculation of accumulated amounts in the months prior to migration when a payment is added in that period.
+
+In addition to installing the module, it is necessary to migrate certain data available in previous versions.
+
+If coming from an Odoo 16 installation:
+
+* You must move the regime code from the ``payment.group`` model to the ``account.payment`` model, mark those payments as ``is_backward_withholding_payment``
+* You must also move all withholding data from the payment model (``account.payment``) to the ``l10n_ar.payment.withholding`` model  and recalculate the ``regime_tax_id`` field..
+
+    The fields are:
+
+    ``automatic``,
+    ``withholdable_invoiced_amount``,
+    ``withholdable_advanced_amount``,
+    ``accumulated_amount``,
+    ``total_amount``,
+    ``withholding_non_taxable_minimum``,
+    ``withholding_non_taxable_amount``,
+    ``withholdable_base_amount``,
+    ``period_withholding_amount``,
+    ``previous_withholding_amount``,
+    ``computed_withholding_amount``.
+
+If the source installation is Odoo 17:
+
+* You only need to update the ``account.payment`` data by mapping the ``codigo_regimen`` to the new ``regime_code`` field, mark those payments as ``is_backward_withholding_payment``, and recalculate the ``regime_tax_id`` field.
+
+-------------------------------------
+
+La manera en que Odoo calcula las retenciones de ganancias ha variado sustancialmente entre las versiones 16, 17 y 18. Este módulo es un módulo técnico. Su objetivo es permitir seguir calculando retenciones acumuladas en instalaciones que migran en medio de un período, o realizar el cálculo de acumulados en los meses anteriores a la migración cuando se agrega un pago en ese período.
+
+Además de instalar el módulo, es necesario migrar ciertos datos disponibles en versiones anteriores.
+
+Si viene de una instalación de Odoo 16:
+
+*   Debe mover el código de régimen desde el modelo ``payment.group`` al modelo ``account.payment``, marcar esos pagos como ``is_backward_withholding_payment`` .
+*   También debe mover todos los datos sobre retención del modelo de pago (``account.payment``) al modelo ``l10n_ar.payment.withholding`` y recalcular el campo ``regime_tax_id``.
+
+    Los campos son:
+
+    ``automatic``,
+    ``withholdable_invoiced_amount``,
+    ``withholdable_advanced_amount``,
+    ``accumulated_amount``,
+    ``total_amount``,
+    ``withholding_non_taxable_minimum``,
+    ``withholding_non_taxable_amount``,
+    ``withholdable_base_amount``,
+    ``period_withholding_amount``,
+    ``previous_withholding_amount``,
+    ``computed_withholding_amount``.
+
+Si la instalación de origen es de Odoo 17:
+
+*   Solo debe actualizar los datos de ``account.payment`` mapeando el ``codigo_regimen`` al nuevo campo ``regime_code``, marcar esos pagos como ``is_backward_withholding_payment`` y recalcular el campo ``regime_tax_id``.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/odoo-argentina/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_tax_backward_compatibility/__init__.py
+++ b/l10n_ar_tax_backward_compatibility/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_tax_backward_compatibility/__manifest__.py
+++ b/l10n_ar_tax_backward_compatibility/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "Automatic Argentinian Withholdings backward compatibility",
+    "version": "18.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Accounting & Finance",
+    "depends": [
+        "l10n_ar_tax",
+    ],
+    "installable": True,
+    "auto_install": False,
+}

--- a/l10n_ar_tax_backward_compatibility/models/__init__.py
+++ b/l10n_ar_tax_backward_compatibility/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_payment
+from . import l10n_ar_payment_withholding

--- a/l10n_ar_tax_backward_compatibility/models/account_payment.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_payment.py
@@ -1,0 +1,14 @@
+from odoo import fields, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    is_backward_withholding_payment = fields.Boolean()
+
+    # TODO: Este metodo modifica el pago para que utilize el impuesto definido en el regime_tax_id
+    # y cree el asiento al estilo 18
+    # Por ahora lo dejo pero si da problemas recalculamos ya que es un NTH
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
+        self.filtered("is_backward_withholding_payment").is_backward_withholding_payment = False
+        return super()._prepare_move_line_default_vals(write_off_line_vals, force_balance=force_balance)

--- a/l10n_ar_tax_backward_compatibility/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax_backward_compatibility/models/l10n_ar_payment_withholding.py
@@ -1,0 +1,138 @@
+from odoo import api, fields, models
+
+
+class l10nArPaymentWithholding(models.Model):
+    _inherit = "l10n_ar.payment.withholding"
+
+    # The regime code in version 16.0 is available in the payment.group model,
+    # and in version 17, it's located in account.payment.
+    regime_code = fields.Char(
+        readonly=True,
+    )
+    regime_tax_id = fields.Many2one("account.tax", compute="_compute_regime_tax_id", store=True)
+
+    @api.depends("company_id", "regime_code", "payment_id.is_backward_withholding_payment")
+    def _compute_regime_tax_id(self):
+        """Computamos el valor de regime_code y seteamos regime_tax_id con el impuesto
+        Activo que tiene ese regimen en el campo l10n_ar_code
+        TODO: Deberiamos buscar con active_test False ¿puede haber mas de un
+        impuesto con el mismo l10n_ar_code que este activo y desactivado?
+        """
+        for company in self.mapped("company_id"):
+            backward_lines_ids = self.filtered(
+                lambda x: x.payment_id.is_backward_withholding_payment and x.company_id == company
+            )
+            if backward_lines_ids:
+                regime_codes = backward_lines_ids.filtered("regime_code").mapped("regime_code")
+                if regime_codes:
+                    tax_by_codes = {
+                        x.l10n_ar_code: x
+                        for x in self.env["account.tax"].search(
+                            [("company_id", "=", company.id), ("l10n_ar_code", "in", regime_codes)]
+                        )
+                    }
+                    for line in backward_lines_ids:
+                        line.regime_tax_id = tax_by_codes.get(line.regime_code, False)
+                        self -= line
+        self.regime_tax_id = False
+
+    # These fields are used in previous versions that
+    # We use this to calculating accumulated amounts
+    # in addition as backup and reference
+
+    automatic = fields.Boolean()
+    withholdable_invoiced_amount = fields.Monetary(
+        "Importe imputado sujeto a retencion",
+        readonly=True,
+    )
+    withholdable_advanced_amount = fields.Monetary(
+        "Importe a cuenta sujeto a retencion",
+    )
+    accumulated_amount = fields.Monetary(
+        readonly=True,
+    )
+    total_amount = fields.Monetary(
+        readonly=True,
+    )
+    withholding_non_taxable_minimum = fields.Monetary(
+        "Non-taxable Minimum",
+        readonly=True,
+    )
+    withholding_non_taxable_amount = fields.Monetary(
+        "Non-taxable Amount",
+        readonly=True,
+    )
+    withholdable_base_amount = fields.Monetary(
+        readonly=True,
+    )
+    period_withholding_amount = fields.Monetary(
+        readonly=True,
+    )
+    previous_withholding_amount = fields.Monetary(
+        readonly=True,
+    )
+    computed_withholding_amount = fields.Monetary(
+        readonly=True,
+    )
+
+    ########################
+    # EARNING COMPUTE HELPERS
+    ########################
+
+    def _get_withholding_tax(self):
+        """If payment is a backward withholding payment the applied tax is regime_tax_id"""
+        self.ensure_one()
+        if self.payment_id.is_backward_withholding_payment and self.regime_tax_id:
+            return self.regime_tax_id
+        return super()._get_withholding_tax()
+
+    def _get_same_period_withholdings_domain(self):
+        """Avoid compute backward payments two times"""
+        return super()._get_same_period_withholdings_domain() + [
+            ("payment_id.is_backward_withholding_payment", "=", False)
+        ]
+
+    def _get_same_period_base_domain(self):
+        """Avoid compute bases backward payments two times"""
+        return super()._get_same_period_base_domain() + [("payment_id.is_backward_withholding_payment", "=", False)]
+
+    def _get_same_period_withholdings_amount(self):
+        amount = super()._get_same_period_withholdings_amount()
+        to_date, from_date = self._get_same_period_dates()
+        tax_id = self._get_withholding_tax()
+
+        domain_same_period_withholdings = [
+            *self._check_company_domain(tax_id.company_id),
+            ("payment_id.state", "in", ["paid", "posted"]),
+            ("payment_id.is_backward_withholding_payment", "=", True),
+            ("regime_tax_id.l10n_ar_code", "=", tax_id.l10n_ar_code),
+            ("regime_tax_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
+            ("payment_id.partner_id.commercial_partner_id", "=", self.payment_id.partner_id.commercial_partner_id.id),
+            ("payment_id.date", "<=", to_date),
+            ("payment_id.date", ">=", from_date),
+        ]
+
+        if same_period_partner_withholdings := self._read_group(
+            domain_same_period_withholdings, ["company_id"], ["amount:sum"]
+        ):
+            amount += abs(same_period_partner_withholdings[0][1])
+        return amount
+
+    def _get_same_period_base_amount(self):
+        self.ensure_one()
+        amount = super()._get_same_period_base_amount()
+        to_date, from_date = self._get_same_period_dates()
+        tax_id = self._get_withholding_tax()
+        domain_same_period_base = [
+            *self._check_company_domain(tax_id.company_id),
+            ("payment_id.state", "in", ["paid", "posted"]),
+            ("payment_id.is_backward_withholding_payment", "=", True),
+            ("regime_tax_id.l10n_ar_code", "=", tax_id.l10n_ar_code),
+            ("regime_tax_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
+            ("payment_id.partner_id.commercial_partner_id", "=", self.payment_id.partner_id.commercial_partner_id.id),
+            ("payment_id.date", "<=", to_date),
+            ("payment_id.date", ">=", from_date),
+        ]
+        if same_period_partner_base := self._read_group(domain_same_period_base, ["company_id"], ["base_amount:sum"]):
+            amount += abs(same_period_partner_base[0][1])
+        return amount


### PR DESCRIPTION
This commit introduces a new module, `l10n_ar_tax_backward_compatibility`. Due to significant changes in withholding calculations across different Odoo versions, records prior to Odoo 18.0 are not included in calculations and withholding certificates cannot be reprinted.

This module extends the withholding lines to enable recalculation, providing backward compatibility.

Note: While the module enables this functionality, it requires a data migration from previous versions to work correctly.