### PR TITLE
[IMP] l10n_ar_ux: use document layout fields in invoice report

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "data/res_currency_data.xml",
         "data/account_account_tag_data.xml",
+        "views/base_document_layout_views.xml",
         # 'views/portal_templates.xml',
         "views/res_partner_view.xml",
         "views/afip_concept_view.xml",

--- a/l10n_ar_ux/models/res_company.py
+++ b/l10n_ar_ux/models/res_company.py
@@ -2,6 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from lxml import html
 from odoo import fields, models
 
 
@@ -23,3 +24,13 @@ class ResCompany(models.Model):
     l10n_ar_report_signature = fields.Image("Firma", copy=False, attachment=True)
     l10n_ar_report_signed_by = fields.Text("Aclaracion", copy=False)
     l10n_ar_invoice_report_ars_amount = fields.Boolean("Mostrar importe equivalente en ARS", default=False)
+    extra_company_details = fields.Char(compute="_compute_extra_company_details")
+
+    def _compute_extra_company_details(self):
+        for company in self:
+            html_content = company.company_details or ""
+            doc = html.fromstring(html_content)
+            paragraphs = doc.xpath("//p//text()")
+            cleaned_text = " - ".join([line.strip() for line in paragraphs if line.strip()])
+
+            company.extra_company_details = cleaned_text

--- a/l10n_ar_ux/views/base_document_layout_views.xml
+++ b/l10n_ar_ux/views/base_document_layout_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_base_document_layout_inherit" model="ir.ui.view">
+        <field name="name">Document Layout Inherit</field>
+        <field name="model">base.document.layout</field>
+        <field name="inherit_id" ref="web.view_base_document_layout"/>
+        <field name="arch" type="xml">
+            <field name="company_details" position="attributes">
+                <attribute name="string">Extra Info</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -33,6 +33,24 @@
         <span t-field="o.company_id.l10n_ar_afip_start_date" position="attributes">
             <attribute name="t-field">header_address.start_date</attribute>
         </span>
+        <xpath expr="//div[hasclass('col-6')]//t[@t-if='not pre_printed_report']" position="replace">
+            <span t-field="o.company_id.partner_id.name"/>
+            <br/>
+            <div></div>
+            <t t-out="' - '.join([item for item in [
+                ', '.join([item for item in [header_address.street, header_address.street2] if item]),
+                header_address.city,
+                header_address.state_id and header_address.state_id.name,
+                header_address.zip,
+                header_address.country_id and header_address.country_id.name] if item])"/>
+            <br/>
+            <t t-out="o.company_id.extra_company_details"/>
+        </xpath>
+        <xpath expr="//div[@name='left-upper-side']//img" position="after">
+            <h6 t-att-style="'color: %s;' % o.company_id.primary_color">
+                <span t-out="o.company_id.report_header"/>
+            </h6>
+        </xpath>
 
         <!-- tal vez tambien a este div principal le querramos cambiar la fuente como haciamos antes, aunque en realidad aparentemente ya no ex necesario, era algo asi:
         <div t-att-style="o.company_id.external_report_layout_id.key == 'web.external_layout_standard' and 'font-size: 15px;'">
@@ -73,6 +91,9 @@
                 </div>
             </div>
         </div>
+        <xpath expr="//div[@name='footer_left_column']" position="inside">
+            <p><span t-out="o.company_id.report_footer"/></p>
+        </xpath>
     </template>
 
 


### PR DESCRIPTION
This PR includes modifications to enhancing the ARG invoice report layout and company details handling. Here are the key changes:

1. In res_company.py:
-  Added a new computed field 'cleaned_company_details'
-  Implemented HTML parsing to clean up company details text, removing HTML tags and joining paragraphs with ' - ' separator
-  Added lxml import for HTML parsing
2. In report_invoice.xml:
-  Modified the invoice report template to use the new cleaned company details
-  Added company name and cleaned details display
-  Added support for company tagline with primary color styling
-  Added report footer in the footer left column
-  Updated some field references for header address