### PR TITLE
[IMP] l10n_ar_ux: hide fields "Ganancias", "Iva", "Monotributo" from res.partner form views

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "18.0.1.6.0",
+    "version": "18.0.1.7.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/views/res_partner_view.xml
+++ b/l10n_ar_ux/views/res_partner_view.xml
@@ -15,10 +15,7 @@
                             <field name="start_date"/>
                             <field name="last_update_padron"/>
                             <field name="estado_padron"/>
-                            <field name="imp_ganancias_padron"/>
-                            <field name="imp_iva_padron"/>
                             <field name="integrante_soc_padron"/>
-                            <field name="monotributo_padron"/>
                             <field name="empleador_padron"/>
                         </group>
                         <group name="afip_col_2">


### PR DESCRIPTION
Ticket: 87686
Hide fields "Ganancias" (imp_ganancias_padron), "Iva" (imp_iva_padron), "Monotributo" (monotributo_padron) from res.partner form views (page "Fiscal Data").