### PR TITLE
[IMP] l10n_ar_withholding_ux: Add payment method and check due date to payment info in report

### DIFF
--- a/l10n_ar_withholding_ux/__manifest__.py
+++ b/l10n_ar_withholding_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian withholding UX',
-    'version': "17.0.1.13.0",
+    'version': "17.0.1.14.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_withholding_ux/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_withholding_ux/views/report_payment_receipt_templates.xml
@@ -107,8 +107,12 @@
                     <tr>
                         <td>
                             <span t-field="o.journal_id.name"/>
+                            <span t-field="o.payment_method_line_id.name"/>
                             <span class="text-nowrap" t-out="' - ' + o.l10n_latam_check_number if o.l10n_latam_check_number else False"></span>
                             <span class="text-nowrap" t-out="' - ' + o.l10n_latam_check_id.l10n_latam_check_number if o.l10n_latam_check_id.l10n_latam_check_number else False"></span>
+                            <span t-if="o.l10n_latam_check_payment_date">
+                                Venc. <span t-field="o.l10n_latam_check_payment_date"/>
+                            </span>
                         </td>
                         <td class="text-right" t-if="secondary_currency">   
                             <span class="text-nowrap" t-out="secondary_currency.round(o.amount / secondary_currency_rate) if (has_pro_currency and o.counterpart_currency_id) else secondary_currency.round(o.amount)" t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>


### PR DESCRIPTION

Extended the payment information in the report table by including the payment method name 
(payment_method_line_id.name).
Also added the check due date (l10n_latam_check_payment_date) display when applicable.

This enhances clarity when identifying the payment method and relevant details for checks, such as their expiration date.