### PR TITLE
17.0 fix ar ux dependency: key error account.change.currency

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -9,6 +9,7 @@
     'summary': '',
     'depends': [
         'l10n_ar',
+        'account_ux',
         # 'l10n_ar_withholding',
     ],
     'data': [


### PR DESCRIPTION
Before the PR:
When trying to install l10n_ar_ux: you get a key error (account.change.currency)

After the PR:
The dependency is fixed in manifest