### PR TITLE
[FIX] l10n_ar_tax: eliminación de impuesto que existe en fp

### DIFF
--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -73,7 +73,9 @@ class AccountTax(models.Model):
     )
 
     @api.ondelete(at_uninstall=False)
-    def _check_tax_used_on_company_tax_ws(self):
+    def _check_tax_used_on_company_tax_fp(self):
         ws = self.env["account.fiscal.position.l10n_ar_tax"].search([("default_tax_id", "in", self.ids)])
         if ws:
-            raise UserError("error se esta usando en ws de estas cias %s" % ws.mapped("company_id.name"))
+            raise UserError(
+                "Error se esta usando en ws de estas cias %s" % ws.mapped("fiscal_position_id.company_id.name")
+            )


### PR DESCRIPTION
Ticket: 90875
Al eliminar un impuesto que existe en la solapa 'Percepciones y Retenciones' de la vista formulario de una posición fiscal entonces recibimos un error ('piedrazo') porque company_id no es un campo existente en el modelo account.fiscal.position.l10n_ar_tax

piedrazo:
https://new-topneumaticossrl-29-04-2.adhoc.ar/odoo/documents/RVuXD4EnSbePbZg86YGVPQo9e