### PR TITLE
[FIX] l10n_ar_tax: store tax_base_amount

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -54,3 +54,23 @@ class AccountFiscalPosition(models.Model):
                     % ", ".join(wrong_tax_type_records.default_tax_id.mapped("name"))
                 )
             )
+
+    def _get_fpos_ranking_functions(self, partner):
+        """
+        Overrides the `_get_fpos_ranking_functions` method to include a custom ranking
+        function for fiscal positions based on Argentine withholding taxes.
+        If the context does not include 'l10n_ar_withholding' or the company's country
+        is not Argentina (country code "AR"), the method falls back to the parent class
+        implementation.
+        When the context includes 'l10n_ar_withholding' and the company's country is
+        Argentina, the method adds a ranking function that prioritizes fiscal positions
+        containing taxes of type 'withholding' (`l10n_ar_tax_ids`).
+        Args:
+            partner (res.partner): The partner for whom the fiscal position ranking
+                functions are being determined.
+        """
+        if not self._context.get("l10n_ar_withholding") or self.env.company.country_id.code != "AR":
+            return super()._get_fpos_ranking_functions(partner)
+        return [
+            ("l10n_ar_tax_ids", lambda fpos: (any(tax.tax_type == "withholding" for tax in fpos.l10n_ar_tax_ids)))
+        ] + super()._get_fpos_ranking_functions(partner)

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -138,8 +138,7 @@ class AccountPayment(models.Model):
                     "account_id": account_id,
                     "amount_currency": sign * amount_currency,
                     "balance": sign * line.amount,
-                    # este campo no existe mas
-                    # 'tax_base_amount': sign * line.base_amount,
+                    "tax_base_amount": sign * line.base_amount,
                     "tax_repartition_line_id": tax_repartition_line_id,
                 }
             )

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -53,7 +53,10 @@ class AccountPayment(models.Model):
             else:
                 address = rec.partner_id
             rec.l10n_ar_fiscal_position_id = (
-                self.env["account.fiscal.position"].with_company(rec.company_id)._get_fiscal_position(address)
+                self.env["account.fiscal.position"]
+                .with_company(rec.company_id)
+                .with_context(l10n_ar_withholding=True)
+                ._get_fiscal_position(address)
             )
 
     @api.depends("l10n_ar_withholding_line_ids.amount")


### PR DESCRIPTION
Este campo si existe y debemos almacenarlo para mantener consistencia con lo que hay en odoo nativo https://github.com/odoo/odoo/blob/18.0/addons/l10n_ar_withholding/wizards/account_payment_register.py#L59