### PR TITLE
[FIX] l10n_ar_withholding_ux: calculation of withholdable advanced amount

### DIFF
--- a/l10n_ar_withholding_ux/models/account_payment.py
+++ b/l10n_ar_withholding_ux/models/account_payment.py
@@ -1,6 +1,6 @@
 from ast import literal_eval
 
-from odoo import models, fields, api, Command, _
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
 
@@ -419,23 +419,8 @@ class AccountPayment(models.Model):
             withholdable_invoiced_amount -= (
                 sign * self.unreconciled_amount * invoice_factor)
         elif withholding_advances:
-            # si el pago esta publicado obtenemos los valores de los importes
-            # conciliados (porque el pago pudo prepararse como adelanto
-            # pero luego haberse conciliado y en ese caso lo estariamos sumando
-            # dos veces si lo usamos como base de otros pagos). Si estan los
-            # campos withholdable_advanced_amount y unreconciled_amount le
-            # sacamos el proporcional correspondiente
-            if self.state == 'posted':
-                if self.unreconciled_amount and \
-                   self.withholdable_advanced_amount:
-                    withholdable_advanced_amount = self.amount_residual * (
-                        self.withholdable_advanced_amount /
-                        self.unreconciled_amount)
-                else:
-                    withholdable_advanced_amount = self.amount_residual
-            else:
-                withholdable_advanced_amount = \
-                    self.withholdable_advanced_amount
+            withholdable_advanced_amount = \
+                self.withholdable_advanced_amount
         return (withholdable_advanced_amount, withholdable_invoiced_amount)
 
     def _get_name_receipt_report(self, report_xml_id):


### PR DESCRIPTION
Made this change to fix errors on the accumulated amount in case of multiple payments for a same invoice, when some payments are advanced. 
With the code we removed, the advanced amount was not taken into account when calculating the accumulated amount for advanced payments, because amount_residual is always 0.0 in that case. So the result of the calculation is always 0.0.:

 withholdable_advanced_amount = self.amount_residual * (self.withholdable_advanced_amount / self.unreconciled_amount) ---> withholdable_advanced_amount = 0.0

In the internal description of the [ticket](https://www.adhoc.inc/odoo/knowledge/110/helpdesk.ticket/92875) I put a use case to make the explanation clearer.
 
