### PR TITLE
[FIX] l10n_ar_ux: avoid error when inheriting portal_my_details_fields if node is missing on install l10n_uy_website_sale

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Accounting UX',
-    'version': "17.0.1.8.0",
+    'version': "17.0.1.9.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_ux/views/portal_templates.xml
+++ b/l10n_ar_ux/views/portal_templates.xml
@@ -66,7 +66,9 @@
 
     <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
         <xpath expr="//label[@for='company_name']/.." position="replace"/>
-        <xpath expr="//label[@for='vat']/.." position="replace"/>
+        <xpath expr="//label[@for='vat']/.." position="attributes">
+            <attribute name="invisible">True</attribute>
+        </xpath>
     </template>
 
     <template id="portal_my_details" name="portal_my_details" inherit_id="portal.portal_my_details">


### PR DESCRIPTION

Prevents an error during module installation of l10n_uy_website_sale does not yet contain the `<label for="vat">` nodes because we where replacing with nothing

Odoo commit:

https://github.com/adhoc-cicd/odoo-odoo/commit/42c43dbb43c6f8b407f298867979cd5c201d544a

Instead of using `position="replace"` (which removes the node and fails if it doesn't exist), we hide the elements via `position="attributes"` and `class="d-none"`, ensuring backward compatibility and avoiding inheritance errors.

This prevents installation failures when using an Odoo version prior to that commit.