### PR TITLE
[FIX] l10n_ar_ux: Force per-line tax rounding under round_globally for AFIP

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -89,7 +89,15 @@ class AccountMove(models.Model):
                     )
             rec.write({'l10n_ar_currency_rate': rate + 1, 'tax_totals': rec.tax_totals})
             rec.write({'l10n_ar_currency_rate': rate, 'tax_totals': rec.tax_totals})
-
+        for line in self.filtered(
+	        lambda x: x.company_id.account_fiscal_country_id.code == "AR"
+	        and x.currency_id != x.company_currency_id).mapped('line_ids').filtered(lambda x:
+	            x.tax_line_id
+	            and x.currency_rate
+	            and not x.currency_id.is_zero(abs(x.amount_currency) / x.currency_rate - abs(x.balance))
+	        ):
+	        balance = line.company_id.currency_id.round(line.amount_currency / line.currency_rate)
+	        line.balance = balance
         res = super()._post(soft=soft)
         return res
 


### PR DESCRIPTION


AFIP requires all reported tax amounts to be rounded to two decimals.

Even though the company is correctly configured with `tax_calculation_rounding_method = 'round_globally'`, this method uses an increased rounding precision on each line to improve total accuracy.

However, AFIP does not allow tax amounts with more than two decimals.

To ensure strict 2-decimal compliance, this change forces per-line tax rounding by passing `context={'round': True}` when calling the superclass `compute_all()` method.

This preserves the required company setting (`round_globally`) while ensuring that taxes are rounded as AFIP requires, line by line.