### PR TITLE
[IMP] l10n_ar_tax: update perceptions when needed

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -31,6 +31,7 @@
         "views/res_company_jurisdiction_padron_view.xml",
         "views/res_partner_view.xml",
         "views/account_tax_view.xml",
+        "views/account_move_views.xml",
         "views/report_payment_receipt_templates.xml",
         "views/l10n_ar_payment_withholding_views.xml",
         "views/account_fiscal_position_view.xml",

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -1,10 +1,23 @@
-from odoo import models
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
     """Heredamos todos los metodos que de alguna manera llamen a tax.compute_all y les pasamos la fecha"""
 
     _inherit = "account.move"
+
+    perceptions_fiscal_positon = fields.Boolean(
+        compute="_compute_perceptions_fiscal_position",
+    )
+
+    def _compute_perceptions_fiscal_position(self):
+        """
+        Compute if the fiscal position has perceptions.
+        """
+        for move in self:
+            move.perceptions_fiscal_positon = bool(
+                move.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+            )
 
     def _get_tax_factor(self):
         self.ensure_one()
@@ -15,3 +28,16 @@ class AccountMove(models.Model):
         if tax_factor == 1.0 and doc_letter == "B":
             tax_factor = 1.0 / 1.21
         return tax_factor
+
+    def _post(self, soft=True):
+        self.filtered(lambda x: x.perceptions_fiscal_positon and not x.invoice_date).mapped(
+            "invoice_line_ids"
+        )._compute_tax_ids()
+        return super()._post(soft=soft)
+
+    @api.constrains("invoice_date")
+    @api.onchange("invoice_date")
+    def _l10n_ar_onchange_invoice_date(self):
+        self.filtered(
+            lambda x: x.is_sale_document(include_receipts=True) and x.perceptions_fiscal_positon and x.state == "draft"
+        ).mapped("invoice_line_ids")._compute_tax_ids()

--- a/l10n_ar_tax/views/account_move_views.xml
+++ b/l10n_ar_tax/views/account_move_views.xml
@@ -1,0 +1,16 @@
+<odoo>
+
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="name">account.move.form</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <header position="after">
+                <div class="alert alert-warning" role="alert" invisible="invoice_date or not perceptions_fiscal_positon">
+                    Esta utilizando la posición fiscal <strong>"<field name="fiscal_position_id" options="{'no_open': True}" readonly="1"/>"</strong> que tiene impuestos de percepciones. Como las alicuotas podrían variar según la fecha del comprobante, cambiar la fecha o validar la factura re-computará los impuestos.
+                </div>
+            </header>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Mejora varios casos de uso, por ejemplo:
1. si tengo una venta de julio pero que la factura se crea en agosto, las percepciones van a venir calculadas desde julio. Actualizar fecha o validr a factura va a re-computarlas
2. una factura se pudo crear en julio pero no tener fecha, al validarla en agosto se recomputa porque las alícuotas podrían haber cambiado
3. duplicar una factura de julio estando en agosto debe recomputar alícuotas

Casos similares ocurren también con clientes que migran y pueden crear facturas de ventas viejas o duplicar facturas viejas que tienen impuestos archivados (el impuesto legacy de partner aliquot)