### PR TITLE
[FIX] account_payment:  prevent KeyError when adjusting withholding amounts without credit/debit keys

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -219,11 +219,11 @@ class AccountPayment(models.Model):
             account_id = self.env["account.account"].browse(line["account_id"])
             # if line['account_id'] in liquidity_accounts:
             if account_id.account_type in valid_account_types:
-                if self.payment_type == "inbound":
+                if self.payment_type == "inbound" and line.get("credit"):
                     line["credit"] += wth_amount
                     if not self._use_counterpart_currency():
                         line["amount_currency"] -= wth_amount / conversion_rate
-                elif self.payment_type == "outbound":
+                elif self.payment_type == "outbound" and line.get("debit"):
                     line["debit"] += wth_amount
                     if not self._use_counterpart_currency():
                         line["amount_currency"] += wth_amount / conversion_rate


### PR DESCRIPTION
Some move lines (e.g., write-off lines) may not include 'credit' or 'debit' keys, causing a KeyError when applying withholding adjustments. This change ensures default values (0.0) are used when the keys are missing, preventing RPC_ERROR and allowing payment creation to complete successfully.