### PR TITLE
[IMP] l10n_ar_tax: profits withholdings with amount 0.0 .

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.14.0",
+    "version": "18.0.1.15.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -181,7 +181,14 @@ class AccountPayment(models.Model):
                 if not line.name or line.name == "/":
                     if line.tax_id.l10n_ar_withholding_sequence_id:
                         commands.append(
-                            Command.update(line.id, {"name": line.tax_id.l10n_ar_withholding_sequence_id.next_by_id()})
+                            Command.update(
+                                line.id,
+                                {
+                                    "name": line.tax_id.l10n_ar_withholding_sequence_id.next_by_id()
+                                    if line.amount
+                                    else "/"
+                                },
+                            )
                         )
                     else:
                         raise UserError(

--- a/l10n_ar_tax/models/mail_compose_message.py
+++ b/l10n_ar_tax/models/mail_compose_message.py
@@ -23,7 +23,7 @@ class MailComposeMessage(models.TransientModel):
                     return
 
                 attachments = []
-                for withholding in payment.l10n_ar_withholding_line_ids:
+                for withholding in payment.l10n_ar_withholding_line_ids.filtered("amount"):
                     report_name = safe_eval.safe_eval(report.print_report_name, {"object": withholding})
                     result, _ = self.env["ir.actions.report"]._render(report.report_name, withholding.ids)
                     file = base64.b64encode(result)

--- a/l10n_ar_tax/views/account_payment_view.xml
+++ b/l10n_ar_tax/views/account_payment_view.xml
@@ -54,7 +54,7 @@
                             <field name="base_amount"/>
                             <field name="amount"/>
                             <field name="ref" optional="hide" readonly="l10n_ar_tax_type in ['earnings', 'earnings_scale']" force_save="1"/>
-                            <button name="%(action_report_withholding_certificate)d" icon="fa-print " title="Print withholding voucher" type="action" invisible="parent.partner_type != 'supplier' or parent.state == 'draft'"/>
+                            <button name="%(action_report_withholding_certificate)d" icon="fa-print " title="Print withholding voucher" type="action" invisible="parent.partner_type != 'supplier' or parent.state == 'draft' or amount == 0"/>
                             <button name="action_l10n_ar_payment_withholding_tree" icon="fa-bars" title="Watch previous withholdings" type="object" invisible="parent.partner_type != 'supplier' or l10n_ar_tax_type not in ['earnings', 'earnings_scale']"/>
                         </list>
                     </field>

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -97,7 +97,7 @@
                             </tr>
                         </t>
                     </t>
-                    <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids" t-as="line">
+                    <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids.filtered('amount')" t-as="line">
                         <tr>
                             <td>
                                 <span t-if="line.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="line.tax_id.invoice_label or 'Retención Ganancias'"/>


### PR DESCRIPTION
Remove consuming number for withholdings at $0, from now on, they are enumerated with a "/". Removed Withholding Certificates for Profits at $0. Removed automatic sending of the $0 Withholding PDF to the Supplier. Removed printing of $0 Withholding line in the Payment Receipt. 
Task Adhoc side: 53304.