### PR TITLE
[IMP] l10n_ar_tax: ar Jurisdiction invisible conditions in tax form view.

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.15.0",
+    "version": "18.0.1.16.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/views/account_tax_view.xml
+++ b/l10n_ar_tax/views/account_tax_view.xml
@@ -13,10 +13,6 @@
                 Puede consultar la tabla <a target="_blank" href="https://www.ca.gov.ar/sircar2">aquí</a>, sección "Instructivos y tablas" item "Tabla con la Tipificación de Regímenes..."
             </div>
         </sheet>
-            <xpath expr="//field[@name='amount']/.." position="after">
-                <field name="l10n_ar_state_id" invisible="l10n_ar_tribute_afip_code != '07'" required="l10n_ar_tribute_afip_code == '07'" options="{'no_create': True}"/>
-                <field name="l10n_ar_code" string="Regímen" invisible="l10n_ar_tribute_afip_code not in ['01', '06', '07'] or l10n_ar_type_tax_use not in ['sale', 'supplier']"/>
-            </xpath>
             <!-- limpiamos esta seccion que para retenciones no tiene sentido -->
             <group name="advanced_booleans" position="attributes">
                 <attribute name="invisible">l10n_ar_withholding_payment_type</attribute>
@@ -36,6 +32,20 @@
                     </group>
                 </page>
             </notebook>
+        </field>
+    </record>
+
+    <record id="view_tax_form-l10n_ar" model="ir.ui.view">
+        <field name="name">account.tax.form</field>
+        <field name="model">account.tax</field>
+        <field name="inherit_id" ref="l10n_ar_withholding.view_tax_form-l10n_ar"/>
+        <field name="arch" type="xml">
+            <field name="l10n_ar_state_id" position="attributes">
+                <attribute name="invisible">l10n_ar_tax_type in ['earnings', 'earnings_scale'] or country_code != 'AR'</attribute>
+            </field>
+            <field name="l10n_ar_code" position="attributes">
+                <attribute name="invisible">country_code != 'AR'</attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Arreglos con este PR:
- Como en los setup de impuestos no siempre sabemos si estamos en un IIBB (perc, ret) u otro impuesto, y la jurisdicción la necesitamos para los txt, dejamos la jurisdicción siempre visible salvo para el caso super especifico que estemos en retenciones de ganancias donde ya sabemos que no es necesario. (en 19 probablemente esto cambie porque vamos usar tax groups por tipo de impuesto y tal vez mover la jurisdicción)
- simila anterior, l10n_ar_code lo dejamos siempre visible para compañías argentinas (en este caso tmb para ganancias) para que se pueda configurar para distintos txt

Ticket Adhoc side: 97071