### PR TITLE
[ADD] l10n_ar_ux: add new account tags for IVA SIMPLE

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.8.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/data/account_account_tag_data.xml
+++ b/l10n_ar_ux/data/account_account_tag_data.xml
@@ -112,4 +112,33 @@
         <field name="country_id" ref="base.ar"/>
     </record>
 
+    <record id="tag_venta_bienes_de_uso" model="account.account.tag">
+        <field name="name">IVA Simple: Venta de Bienes de Uso</field>
+        <field name="applicability">accounts</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="tag_compra_bienes_de_uso" model="account.account.tag">
+        <field name="name">IVA Simple: Compra de Bienes de Uso</field>
+        <field name="applicability">accounts</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="tag_compra_bienes" model="account.account.tag">
+        <field name="name">IVA Simple: Compra de Bienes (excepto bienes de uso)</field>
+        <field name="applicability">accounts</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="tag_prestaciones_de_ss" model="account.account.tag">
+        <field name="name">IVA Simple: Compras - Prestaciones de Servicios</field>
+        <field name="applicability">accounts</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="tag_locaciones" model="account.account.tag">
+        <field name="name">IVA Simple: Compra - Locaciones</field>
+        <field name="applicability">accounts</field>
+        <field name="country_id" ref="base.ar"/>
+    </record>
 </odoo>

--- a/l10n_ar_ux/models/res_company.py
+++ b/l10n_ar_ux/models/res_company.py
@@ -26,3 +26,9 @@ class ResCompany(models.Model):
     l10n_ar_afip_activity_id = fields.Many2one(
         "afip.activity", string="Principal Activity", help="Principal registered activity of the company"
     )
+    l10n_ar_iva_simple_default_tag = fields.Many2one(
+        "account.account.tag",
+        string="Default Tag for IVA Simple",
+        domain=[("name", "ilike", "IVA Simple: Compra")],
+        help="This tag will be used by default in taxes with IVA Simple",
+    )

--- a/l10n_ar_ux/models/res_config_settings.py
+++ b/l10n_ar_ux/models/res_config_settings.py
@@ -20,6 +20,10 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.l10n_ar_afip_activity_id",
         readonly=False,
     )
+    l10n_ar_iva_simple_default_tag = fields.Many2one(
+        related="company_id.l10n_ar_iva_simple_default_tag",
+        readonly=False,
+    )
 
     def clean_signature(self):
         self.l10n_ar_report_signature = False

--- a/l10n_ar_ux/views/res_config_settings_views.xml
+++ b/l10n_ar_ux/views/res_config_settings_views.xml
@@ -53,6 +53,12 @@
                         <field name="l10n_ar_afip_activity_id" options="{'no_open': True}"/>
                     </div>
                 </setting>
+                <setting string="IVA Simple" company_dependent="1" help="This tag will be used by default in IVA Simple reports">
+                    <div class="content-group mt16">
+                        <label for="l10n_ar_iva_simple_default_tag" class="o_form_label col-lg-3"/>
+                        <field name="l10n_ar_iva_simple_default_tag" options="{'no_open': True}"/>
+                    </div>
+                </setting>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Creamos nuevas etiquetas para las cuentas contables, para poder identificar los "Tipos de operación" de IVA Simple y generar el reporte CSV