### PR TITLE
[FIX]  l10n_ar_tax: correct payment receipt for bundle

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.16.0",
+    "version": "18.0.1.17.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -148,10 +148,10 @@
                                 <span t-field="doc.payment_method_line_id.name"/>
                             </td>
                             <td class="text-right" t-if="secondary_currency">
-                                <span class="text-nowrap" t-out="doc.amount_signed if doc.other_currency else secondary_currency.round(doc.amount / doc_secondary_currency_rate)" t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>
+                                <span class="text-nowrap" t-out="doc.amount_signed if doc.other_currency else secondary_currency.round(doc.amount_signed / doc_secondary_currency_rate)" t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>
                             </td>
                             <td class="text-right o_price_total">
-                                <span class="text-nowrap" t-out="doc.company_currency_id.round(doc.amount * doc_secondary_currency_rate) if doc.other_currency else doc.amount" t-options='{"widget": "monetary", "display_currency": doc.company_currency_id}'/>
+                                <span class="text-nowrap" t-out="doc.company_currency_id.round(doc.amount_signed * doc_secondary_currency_rate) if doc.other_currency else doc.amount_signed" t-options='{"widget": "monetary", "display_currency": doc.company_currency_id}'/>
                             </td>
                         </tr>
                     </t>


### PR DESCRIPTION
- Fix the sign of payment receipt amounts in the report.
- Update the report to use the new method for fetching open move lines to be inheritable.