### PR TITLE
[IMP] l10n_ar_tax: only re compute ar percpeptions

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -11,6 +11,8 @@ class AccountFiscalPosition(models.Model):
         # TODO deberiamos unificar mucho de este codigo con _get_tax_domain, _compute_withholdings y _check_tax_group_overlap
         self.ensure_one()
         taxes = self.env["account.tax"]
+        # garantizamos de siempre evaluar segun commercial partner que es donde se guardan y ven los impuestos
+        partner = partner.commercial_partner_id
         for fp_tax in self.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == tax_type):
             domain = self.env["l10n_ar.partner.tax"]._check_company_domain(company)
             domain += [("tax_id.tax_group_id", "=", fp_tax.default_tax_id.tax_group_id.id)]

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -48,7 +48,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
         taxes = self.env["account.tax"]
         for rec in self:
             if rec.webservice:
-                taxes += rec._get_tax_from_ws(partner, date)
+                taxes += rec.sudo()._get_tax_from_ws(partner, date)
             else:
                 taxes += rec.default_tax_id
         return taxes

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -29,22 +29,38 @@ class AccountMove(models.Model):
             tax_factor = 1.0 / 1.21
         return tax_factor
 
-    def _post(self, soft=True):
-        self.filtered(lambda x: x.perceptions_fiscal_positon and not x.invoice_date).mapped(
-            "invoice_line_ids"
-        )._compute_tax_ids()
-        return super()._post(soft=soft)
+    def write(self, vals):
+        res = super().write(vals)
+        if "invoice_date" in vals:
+            self._l10n_ar_recompute_fiscal_position_taxes()
+        return res
 
     @api.onchange("invoice_date")
-    def _l10n_ar_onchange_invoice_date(self):
-        self.filtered(
+    def _l10n_ar_recompute_fiscal_position_taxes(self):
+        """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
+        impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
+        reemplazamos por los nuevos impuestos.
+        """
+        for move in self.filtered(
             lambda x: x.is_sale_document(include_receipts=True) and x.perceptions_fiscal_positon and x.state == "draft"
-        ).mapped("invoice_line_ids")._compute_tax_ids()
+        ):
+            fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
+                lambda x: x.tax_type == "perception"
+            ).mapped("default_tax_id.tax_group_id")
+            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                move.partner_id, move.company_id, move.date, "perception"
+            )
+            for line in move.invoice_line_ids:
+                to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                if to_unlink._origin != new_taxes:
+                    line.tax_ids = [(3, tax.id) for tax in to_unlink] + [
+                        (4, tax.id) for tax in new_taxes if tax not in line.tax_ids
+                    ]
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una factura porque puede ser que la factura venga de otro periodo
         o por alguna razón las percepciones hayan cambiado
         """
         recs = super().copy(default=default)
-        recs._l10n_ar_onchange_invoice_date()
+        recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -47,9 +47,8 @@ class AccountMove(models.Model):
             fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"
             ).mapped("default_tax_id.tax_group_id")
-            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
-                move.partner_id, move.company_id, move.date, "perception"
-            )
+            date = move.date if not move.reversed_entry_id else move.reversed_entry_id.date
+            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(move.partner_id, move.company_id, date, "perception")
             for line in move.invoice_line_ids:
                 to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:

--- a/l10n_ar_tax/models/account_move_line.py
+++ b/l10n_ar_tax/models/account_move_line.py
@@ -20,7 +20,7 @@ class AccountMoveLine(models.Model):
         # heredamos este metodo y no map_tax de fiscal positions porque el metod map_tax recibe solo taxes y no sabe
         # partner ni fecha y estos datos son necesarios para computar correctamente la alicuota
         if self.move_id.is_sale_document(include_receipts=True) and self.move_id.fiscal_position_id.l10n_ar_tax_ids:
-            date = self.move_id.date
+            date = self.move_id.date if not self.move_id.reversed_entry_id else self.move_id.reversed_entry_id.date
             taxes += self.move_id.fiscal_position_id._l10n_ar_add_taxes(
                 self.partner_id, self.company_id, date, "perception"
             )


### PR DESCRIPTION
Antes de este cambio
1. con cualquier cambio se recomputaban todos los impuestos (si el usuario había cambiado iva se le reseteaba)
2. fallaban tests de runbot
3. para líneas down payments no se re-computaban porque el método de odoo que re-computaba impuestos solo lo hacía si había producto

Este pr va junto con https://github.com/ingadhoc/argentina-sale/pull/256/files