### PR TITLE
[FIX] l10n_ar_tax: amounts positive in receipts when all payments are of the same type

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.18.0",
+    "version": "18.0.1.19.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -140,18 +140,31 @@
                             </td>
                         </tr>
                     </t>
-                    <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc"  id="payment_bundle_doc">
+                    <t t-set="all_same_type" t-value="len(set(payment_bundle.mapped('payment_type'))) == 1"/>
+
+                    <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc" id="payment_bundle_doc">
                         <t t-set="doc_secondary_currency_rate" t-value="doc.exchange_rate if doc.other_currency else doc.counterpart_exchange_rate"/>
+
+                        <!-- Precompute display amounts -->
+                        <t t-set="display_amount" t-value="abs(doc.amount_signed) if all_same_type else doc.amount_signed"/>
+                        <t t-set="display_amount_secondary" t-value="secondary_currency.round((abs(doc.amount_signed) if all_same_type else doc.amount_signed) / doc_secondary_currency_rate) if doc.other_currency else display_amount"/>
+                        <t t-set="display_amount_company" t-value="doc.company_currency_id.round(display_amount_secondary * doc_secondary_currency_rate) if doc.other_currency else display_amount"/>
                         <tr>
                             <td>
                                 <span t-field="doc.journal_id.name"/>
                                 <span t-field="doc.payment_method_line_id.name"/>
                             </td>
+
                             <td class="text-right" t-if="secondary_currency">
-                                <span class="text-nowrap" t-out="doc.amount_signed if doc.other_currency else secondary_currency.round(doc.amount_signed / doc_secondary_currency_rate)" t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>
+                                <span class="text-nowrap"
+                                    t-out="secondary_currency.round(display_amount_secondary)"
+                                    t-options='{"widget": "monetary", "display_currency": secondary_currency}'/>
                             </td>
+
                             <td class="text-right o_price_total">
-                                <span class="text-nowrap" t-out="doc.company_currency_id.round(doc.amount_signed * doc_secondary_currency_rate) if doc.other_currency else doc.amount_signed" t-options='{"widget": "monetary", "display_currency": doc.company_currency_id}'/>
+                                <span class="text-nowrap"
+                                    t-out="display_amount_company"
+                                    t-options='{"widget": "monetary", "display_currency": doc.company_currency_id}'/>
                             </td>
                         </tr>
                     </t>


### PR DESCRIPTION

- Show absolute values if all payments are of the same type for the bundle (inbound or outbound), otherwise show signed amounts.
- Precompute display amounts to improve readability and maintainability.
- Handle secondary currency conversion and company currency rounding in a clear, consolidated way.