### PR TITLE
[FIX] l10n_ar_ux: Use the correct field to check if the move is invoice

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -73,7 +73,7 @@ class AccountMove(models.Model):
         ar_invoices = self.filtered(
             lambda x: x.company_id.account_fiscal_country_id.code == "AR"
             and x.currency_id != x.company_currency_id
-            and x.document_type_internal_type == "invoice"
+            and x.l10n_latam_document_type_id.internal_type == "invoice"
         )
         ar_invoice_line_ids = ar_invoices.mapped("invoice_line_ids").ids
 


### PR DESCRIPTION
This commit changes the field used to determine if an account move is an invoice from this commit https://github.com/ingadhoc/odoo-argentina/commit/a2d9cd3b07fc38ade3c046a436fc3bd675e54eb5 to use a native odoo field instead of a custom one.