### PR TITLE
[FIX] l10n_ar_ux: Improve document number handling with error handling for unexpected formats

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -47,10 +47,17 @@ class AccountMove(models.Model):
 
     @api.model
     def _l10n_ar_get_document_number_parts(self, document_number, document_type_code):
-        # eliminamos todo lo que viene después '(' que es un sufijo que odoo agrega y que nosotros agregamos para
-        # forzar unicidad con cambios de approach al ir migrando de versiones
-        document_number = document_number.split("(")[0]
-        return super()._l10n_ar_get_document_number_parts(document_number, document_type_code)
+        """Eliminamos todo lo que viene después '(' que es un sufijo que odoo agrega y que nosotros agregamos para
+        forzar unicidad con cambios de approach al ir migrando de versiones.
+        Captamos con un try/except para no romper en caso de que el formato no sea el esperado. En Odoo no podemos
+        replicarlo, por eso lo dejamos acá."""
+        try:
+            document_number = document_number.split("(")[0]
+            return super()._l10n_ar_get_document_number_parts(document_number, document_type_code)
+        except ValueError:
+            raise UserError(
+                _("The associated document number does not appear to be in the Argentine format: %s", document_number)
+            )
 
     def button_cancel(self):
         """


### PR DESCRIPTION
Intentamos hacer este [PR](https://github.com/odoo/odoo/pull/227753) a Odoo pero no pudimos replicarlo en runbot nativo ya que nosotros estamos forzando que aparezca el botón "Reversal of". 

Description of the issue/feature this PR addresses:
This pull request improves error handling in the `_l10n_ar_get_document_number_parts` method in `account_move.py`. The main change is to provide a user-friendly error message when the document number does not match the expected Argentine format.

Error handling improvement:

* Added a `try/except` block to catch `ValueError` when splitting the `document_number`, raising a `UserError` with a localized message if the format is incorrect.

Current behavior before PR:
If the user tries to reverse a document that does not match the argentinean format, a traceback an error such as the following is generated:
`File "/home/odoo/src/enterprise/l10n_ar_edi/models/account_move.py", line 588, in _get_related_invoice_datawskey[afip_ws]['number']: self._l10n_ar_get_document_number_parts(File "/home/odoo/src/repositories/ingadhoc-odoo-argentina/l10n_ar_ux/models/account_move.py", line 101, in _l10n_ar_get_document_number_partsreturn super()._l10n_ar_get_document_number_parts(document_number, document_type_code)File "/home/odoo/src/odoo/addons/l10n_ar/models/account_move.py", line 21, in _l10n_ar_get_document_number_partspos, invoice_number = document_number.split('-')ValueError: not enough values to unpack (expected 2, got 1)​as`

Desired behavior after PR is merged:
An `UserError` is raised. 
<img width="1553" height="419" alt="image" src="https://github.com/user-attachments/assets/b47dc205-6997-4117-a768-d6241d33b158" />




