### PR TITLE
[FIX] l10n_ar_tax: parche redondeo en retenciones (un centavo)

### DIFF
--- a/l10n_ar_tax/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax/models/l10n_ar_payment_withholding.py
@@ -98,7 +98,10 @@ class l10nArPaymentWithholding(models.Model):
             partner=False,
             is_refund=False,
         )
-        tax_amount = taxes_res["taxes"][0]["amount"]
+        tax_amount = self.currency_id.round(taxes_res["total_included"] - taxes_res["total_excluded"])
+        # TODO: When Odoo fixes the compute_all method of account_tax, uncomment the line below and
+        # remove the line above. See Adhoc ticket 101778 for more information.
+        # tax_amount = taxes_res["taxes"][0]["amount"]
         tax_account_id = taxes_res["taxes"][0]["account_id"]
         tax_repartition_line_id = taxes_res["taxes"][0]["tax_repartition_line_id"]
 


### PR DESCRIPTION
Tarea Adhoc: 59152
Este pr es un parche que corrige el inconveniente de redondeo en cálculo de retenciones argentinas reportado a odoo (ver ticket de Adhoc 101778 para ver más información). Una vez que odoo arregle el método compute_all del modelo account_tax entonces hacer revert de este pr.