### PR TITLE
[ADD] l10n_ar_ux: Readd 'actividades_padron' field to ResPartner model and view

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",
@@ -10,6 +10,7 @@
     "depends": [
         "l10n_ar",
         "account_internal_transfer",
+        "l10n_ar_reports_simple",
     ],
     "data": [
         "data/res_currency_data.xml",

--- a/l10n_ar_ux/models/res_partner.py
+++ b/l10n_ar_ux/models/res_partner.py
@@ -40,6 +40,13 @@ class ResPartner(models.Model):
         "afip.tax", "res_partner_afip_tax_rel", "partner_id", "afip_tax_id", "Impuestos"
     )
     last_update_padron = fields.Date()
+    actividades_padron = fields.Many2many(
+        "l10n_ar.arca.activity",
+        "res_partner_arca_activity_rel",
+        "partner_id",
+        "arca_activity_id",
+        "Actividades",
+    )
 
     @api.constrains("gross_income_jurisdiction_ids", "state_id")
     def check_gross_income_jurisdictions(self):

--- a/l10n_ar_ux/views/res_partner_view.xml
+++ b/l10n_ar_ux/views/res_partner_view.xml
@@ -20,6 +20,7 @@
                         </group>
                         <group name="arca_col_2">
                             <field name="actividad_monotributo_padron"/>
+                            <field name="actividades_padron" widget="many2many_tags"/>
                             <field name="impuestos_padron" widget="many2many_tags"/>
                         </group>
                     </group>


### PR DESCRIPTION
En la migración de este módulo, eliminamos todo lo referente a las actividades de AFIP que teníamos ya que Odoo lo incorporó. Acá estamos reagregando el campo `actividades_padrón`, haciendo referencia a la tabla existente en Odoo, ya que lo necesita el módulo l10n_ar_edi_ux para actualizar los datos de padrón. 
Para poder reagregar el campo tuve que agregar la dependencia a `l10n_ar_reports_simple` que es el módulo donde Odoo agregó las actividades. Esto sólo sucederá en 19, ya que en próximas versiones Odoo lo integraría dentro de `l10n_ar_reports`. Esta decisión la tomamos acá: https://www.adhoc.inc/mail/message/13041559. En el mensaje hablamos de incorporarlo en `l10n_ar_edi_ux`, pero como todo lo referente al padrón está en `l10n_ar_ux`, al revisarlo me pareció más correcto reagregarlo en este módulo. Además, en este módulo vamos a realizar scripts de migración para mover los datos de los campos nuestros a los de Odoo, por lo que también incluiríamos esto.
Por otro lado, en caso de migrarse `l10n_ar_tax_python` se podría migrar derecho ya que también necesita dicho campo y tiene dependencia a `l10n_ar_ux` pero no a `l10n_ar_edi_ux` (por favor comentarme en caso de opinar diferente)


Referencias:
- Código `l10n_ar_edi_ux` donde se necesita el campo `actividades_padron`: https://github.com/ingadhoc/odoo-argentina-ee/blob/c45c049e70e525a3f8bddca37505763b1a4f853a/l10n_ar_edi_ux/models/res_partner.py#L263
- Código `l10n_ar_tax_python` que utiliza dicho campo: https://github.com/ingadhoc/odoo-argentina/blob/fb5fe3052196fb2a7f622c411ab700648242b625/l10n_ar_tax_python/demo/account_fiscal_position_demo.xml#L46