### PR TITLE
[FIX] l10n_ar: fix datetime.today call

### DIFF
--- a/l10n_ar_tax/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax/models/l10n_ar_payment_withholding.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from dateutil.relativedelta import relativedelta
 from odoo import _, api, fields, models
 from odoo.exceptions import RedirectWarning, UserError
@@ -172,7 +170,7 @@ class l10nArPaymentWithholding(models.Model):
 
     def _get_same_period_dates(self):
         self.ensure_one()
-        to_date = self.payment_id.date or datetime.date.today()
+        to_date = self.payment_id.date or fields.Date.context_today(self)
         from_date = to_date + relativedelta(day=1)
         return to_date, from_date
 


### PR DESCRIPTION
Hacemos fix y nos movemos a usar fields.Date.context_today(self) que es el standard en odoo Usamos context_today para que, por ejemplo, si se hace pago a las 22 horas se siga usando el día en gmt -3