### PR TITLE
[FIX] l10n_ar_tax: retenciones con monto cero.

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -313,6 +313,12 @@ class AccountPayment(models.Model):
                 )
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_line_ids = withholdings
+            # Si hay retenciones que no son de ganancias y el importe a retener es 0 las quitamos
+            # Ejemplo: retenciones en pagos de notas de crédito (el monto base es negativo)
+            to_remove = rec.l10n_ar_withholding_line_ids.filtered(
+                lambda wth: wth.amount == 0 and wth.tax_id.l10n_ar_tax_type != "earnings_scale"
+            )
+            rec.l10n_ar_withholding_line_ids -= to_remove
 
     def compute_to_pay_amount_for_check(self):
         checks_payments = self.filtered(


### PR DESCRIPTION
Ticket: 103341
Si hay retenciones que no son de ganancias y el importe a retener es 0 las quitamos. Ejemplo: retenciones en pagos de notas de crédito (el monto base es negativo entonces el cálculo del monto a retener da cero). Antes de este pr solo sacábamos aquellas retenciones cuyo impuesto tienen alícuota de retención del 0%. Pero en este pr lo que hacemos es eliminar aquellas retenciones cuyo monto a retener es 0 sin importar la alícuota del impuesto.