### PR TITLE
[FIX] l10n_ar_tax: finish migration (fix test)

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -37,20 +37,20 @@
         "views/account_fiscal_position_view.xml",
         "wizard/account_payment_register_views.xml",
         "wizard/res_config_settings_views.xml",
+    ],
+    "demo": [
         "demo/ir_parameter.xml",
         "demo/account_fiscal_position_demo.xml",
         "demo/account_tax_demo.xml",
         "demo/res_partner_demo.xml",
-    ],
-    "demo": [
-        # "demo/account_move_demo.xml",
+        "demo/account_move_demo.xml",
     ],
     "depends": [
         "l10n_ar",
         "l10n_ar_ux",
         "l10n_ar_withholding",
         "account_payment_pro",
-        # "l10n_latam_check_ux",  # para reporte de pagos/recibos
+        "l10n_latam_check",  # para reporte de pagos/recibos
     ],
     "external_dependencies": {
         "python": ["pyafipws"],

--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -60,9 +60,9 @@ class AccountFiscalPosition(models.Model):
                 )
             )
 
-    def _get_fpos_ranking_functions(self, partner):
+    def _get_fpos_validation_functions(self, partner):
         """
-        Overrides the `_get_fpos_ranking_functions` method to include a custom ranking
+        Overrides the `_get_fpos_validation_functions` method to include a custom ranking
         function for fiscal positions based on Argentine withholding taxes.
         If the context does not include 'l10n_ar_withholding' or the company's country
         is not Argentina (country code "AR"), the method falls back to the parent class
@@ -74,8 +74,19 @@ class AccountFiscalPosition(models.Model):
             partner (res.partner): The partner for whom the fiscal position ranking
                 functions are being determined.
         """
+        functions = super()._get_fpos_validation_functions(partner)
         if not self.env.context.get("l10n_ar_withholding") or self.env.company.country_id.code != "AR":
-            return super()._get_fpos_ranking_functions(partner)
+            return functions
         return [
-            ("l10n_ar_tax_ids", lambda fpos: (any(tax.tax_type == "withholding" for tax in fpos.l10n_ar_tax_ids)))
-        ] + super()._get_fpos_ranking_functions(partner)
+            lambda fpos: any(tax.tax_type == "withholding" for tax in fpos.l10n_ar_tax_ids),
+        ] + functions
+
+    def map_tax(self, taxes):
+        """For argentinean fiscal positions without tax mapping we add domestic taxes because taxes are always required
+        on argentinean invoices so there is no use case for not having them.
+        The other alternative would be to add the new fiscal positions on every VAT tax but that would be a lot of work
+        for the user.
+        """
+        if not self.tax_ids and self.l10n_ar_tax_ids:
+            return self.company_id.domestic_fiscal_position_id.map_tax(taxes)
+        return super().map_tax(taxes)

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -5,6 +5,10 @@ from odoo.exceptions import UserError
 class AccountTax(models.Model):
     _inherit = "account.tax"
 
+    # mejora de usabilidad, duplicar un impuesto mantiene la secuencia
+    l10n_ar_withholding_sequence_id = fields.Many2one(
+        copy=True,
+    )
     l10n_ar_tribute_afip_code = fields.Selection(related="tax_group_id.l10n_ar_tribute_afip_code")
     l10n_ar_state_code = fields.Char(related="l10n_ar_state_id.code")
     api_codigo_articulo_retencion = fields.Selection(

--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -15,11 +15,8 @@ class TestPaymentReceiptbookAndWithholding(TestL10nArWithholdingArRi):
         2. Create IIBB CABA fiscal position for company '(AR) Responsable Inscripto (Unit Tests)' with CABA withholding tax.
         3. Create payment for vendor bill created on step 1.
         4. VALIDATION: draft payment move must not have name.
-        5. VALIDATION: draft payment move must have receiptbook.
-        6. Post payment created on step 3.
-        7. VALIDATION: payment move must have Document Number without document type.
-        8. VALIDATION: Document Type on payment move must be set.
-        9. VALIDATION: validate payment move lines amounts.
+        5. Post payment created on step 3.
+        6. VALIDATION: validate payment move lines amounts.
         """
         # 1. Create vendor bill for CABA partner and post.
         invoice = self.env["account.move"].create(
@@ -74,34 +71,22 @@ class TestPaymentReceiptbookAndWithholding(TestL10nArWithholdingArRi):
         # 4. VALIDATION: draft payment move must not have name.
         self.assertEqual(payment.move_id.name, False)
 
-        # 5. VALIDATION: draft payment move must have receiptbook.
-        # self.assertNotEqual(payment.receiptbook_id.id, False)
-
-        # 6. Post payment created on step 3.
+        # 5. Post payment created on step 3.
         payment.action_post()
 
-        # 7. VALIDATION: payment move must have Document Number without document type.
-        # self.assertEqual(payment.move_id.l10n_latam_document_number, "0001-00000001")
-
-        # 8. VALIDATION: Document Type on payment move must be set.
-        # self.assertEqual(
-        #     self.env.ref("account_payment_pro_receiptbook.dc_orden_pago_x").id,
-        #     payment.move_id.l10n_latam_document_type_id.id,
-        # )
-
-        # 9. VALIDATION: validate payment move lines amounts.
-        # self.assertRecordValues(
-        #     payment.move_id.line_ids.sorted("balance"),
-        #     [
-        #         # Liquidity line:
-        #         {"debit": 0.0, "credit": 605000.0, "amount_currency": -605000.0},
-        #         # base line:
-        #         {"debit": 0.0, "credit": 500000.0, "amount_currency": -500000.0},
-        #         # withholding line:
-        #         {"debit": 0.0, "credit": 50000.0, "amount_currency": -50000.0},
-        #         # base line:
-        #         {"debit": 500000.0, "credit": 0.0, "amount_currency": 500000.0},
-        #         # Receivable line:
-        #         {"debit": 655000.0, "credit": 0.0, "amount_currency": 655000.0},
-        #     ],
-        # )
+        # 6. VALIDATION: validate payment move lines amounts.
+        self.assertRecordValues(
+            payment.move_id.line_ids.sorted("balance"),
+            [
+                # Liquidity line:
+                {"debit": 0.0, "credit": 605000.0, "amount_currency": -605000.0},
+                # base line:
+                {"debit": 0.0, "credit": 500000.0, "amount_currency": -500000.0},
+                # withholding line:
+                {"debit": 0.0, "credit": 50000.0, "amount_currency": -50000.0},
+                # base line:
+                {"debit": 500000.0, "credit": 0.0, "amount_currency": 500000.0},
+                # Receivable line:
+                {"debit": 655000.0, "credit": 0.0, "amount_currency": 655000.0},
+            ],
+        )


### PR DESCRIPTION
Sacamos parte de los tests que no deberían estar en este modulo y deberían estar en account_payment_pro_receiptbook (o en algún test de integración) ya que este módulo no está dependiendo de account_payment_pro_receiptbook