### PR TITLE
[FIX] l10n_ar_tax: Recompute amount on partner change

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -99,6 +99,12 @@ class AccountPayment(models.Model):
             rec.amount = amount if amount > 0 else 0
             # rec.unreconciled_amount = rec.to_pay_amount - rec.selected_debt
 
+    @api.onchange("partner_id")
+    def _onchange_partner_id(self):
+        for rec in self:
+            if rec.partner_id != rec._origin.partner_id:
+                rec._onchange_withholdings()
+
     # # ver mensaje en commit
     # @api.onchange('to_pay_amount', 'withholdable_advanced_amount', 'partner_id')
     # def _onchange_to_pay_amount(self):


### PR DESCRIPTION
Before this commit, only recomputed amount when withholdings_amount changed. This could lead to incorrect total amount if the partner was changed to one with different withholding rules. Now, the amount is recomputed when either withholdings_amount or partner_id changes.