### PR TITLE
[IMP] l10n_ar_tax: campo l10n_ar_withholding_sequence_id con copy=True

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.21.0",
+    "version": "18.0.1.22.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -88,6 +88,10 @@ class AccountTax(models.Model):
         api_articulo_inciso_calculo_selection,
         string="Artículo/Inciso para el cálculo retención",
     )
+    # mejora de usabilidad, duplicar un impuesto mantiene la secuencia
+    l10n_ar_withholding_sequence_id = fields.Many2one(
+        copy=True,
+    )
 
     @api.ondelete(at_uninstall=False)
     def _check_tax_used_on_company_tax_fp(self):


### PR DESCRIPTION
Ticket: 104507
Necesitamos este cambio para que el upgrade line "[RET18] Retenciones: agregar a FP "Retenciones" líneas de otros taxes + migra partner aliquot" (id: 1538) cuando hace el copy de impuestos (ejemplo: línea 321 al día de hoy) también copie la secuencia asociada al impuesto, de lo contrario por ejemplo cuando el usuario haga una retención aplicada de iibb entonces va a tener que colocar la secuencia manualmente al impuesto y queremos con este pull request evitar eso.