### PR TITLE
[FIX] l10n_ar_tax: Fixed multiple inheritance issue in mail.compose.message

### DIFF
--- a/l10n_ar_tax/models/mail_compose_message.py
+++ b/l10n_ar_tax/models/mail_compose_message.py
@@ -7,37 +7,56 @@ from odoo.tools import safe_eval
 class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
-    def _compute_attachment_ids(self):
-        """Extends original method so it is possible to attach and previsualize
-        withholding vouchers when sending payment reports by email."""
-        super()._compute_attachment_ids()
-        for composer in self:
-            res_ids = composer._evaluate_res_ids() or [0]
-            if composer.model == "account.payment" and composer.template_id and len(res_ids) == 1:
-                payment = self.env[composer.model].browse(res_ids)
-                if payment.partner_type != "supplier":
-                    return
+    def _prepare_mail_values(self, res_ids):
+        """Extended to add withholding attachments when sending payments by email."""
+        mail_values_all = super()._prepare_mail_values(res_ids)
 
-                report = self.env.ref("l10n_ar_tax.action_report_withholding_certificate", raise_if_not_found=False)
-                if not report:
-                    return
+        if self.model != "account.payment":
+            return mail_values_all
 
-                attachments = []
-                for withholding in payment.l10n_ar_withholding_line_ids.filtered("amount"):
+        report = self.env.ref(
+            "l10n_ar_tax.action_report_withholding_certificate",
+            raise_if_not_found=False,
+        )
+        if not report:
+            return mail_values_all
+
+        # Check if we're in mass_mail mode (uses commands) or comment mode (uses plain IDs)
+        email_mode = self.composition_mode == "mass_mail"
+
+        payments = self.env["account.payment"].browse(res_ids).filtered(lambda p: p.partner_type == "supplier")
+        for payment in payments:
+            if payment.id not in mail_values_all:
+                continue
+
+            # Get existing attachments
+            attachment_ids = mail_values_all[payment.id].get("attachment_ids", [])
+
+            for withholding in payment.l10n_ar_withholding_line_ids.filtered("amount"):
+                try:
                     report_name = safe_eval.safe_eval(report.print_report_name, {"object": withholding})
-                    result, _ = self.env["ir.actions.report"]._render(report.report_name, withholding.ids)
-                    file = base64.b64encode(result)
+                    report_content, _ = self.env["ir.actions.report"]._render(report.report_name, withholding.ids)
+                    report_content_encoded = base64.b64encode(report_content)
 
                     attachment = self.env["ir.attachment"].create(
                         {
                             "name": report_name,
-                            "datas": file,
-                            "res_model": "mail.compose.message",
+                            "datas": report_content_encoded,
+                            "res_model": "mail.message",
                             "res_id": 0,
                             "type": "binary",
                         }
                     )
-                    attachments.append(attachment.id)
 
-                if attachments:
-                    composer.attachment_ids = [(6, 0, composer.attachment_ids.ids + attachments)]
+                    # In mass_mail mode use commands (4, id), in comment mode use plain IDs
+                    if email_mode:
+                        attachment_ids.append((4, attachment.id))
+                    else:
+                        attachment_ids.append(attachment.id)
+
+                except Exception:
+                    continue
+
+            mail_values_all[payment.id]["attachment_ids"] = attachment_ids
+
+        return mail_values_all


### PR DESCRIPTION
Problema: Los PDFs de retenciones solo se adjuntaban al enviar un pago individual, no al enviar múltiples pagos.

Causa: El código original en [_compute_attachment_ids](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) solo se ejecutaba cuando [len(res_ids) == 1](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Solución: Se movió la lógica a [_prepare_mail_values](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) que funciona tanto para uno como múltiples registros. Ahora crea los ir.attachment directamente y los agrega a [attachment_ids](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).