### PR TITLE
[FIX] l10n_ar_tax: remove counterpart currency check from withholding validation

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -218,8 +218,7 @@ class AccountPayment(models.Model):
         """Para todos los pagos con retenciones verificamos que la deuda se esté conciliando en moneda local
         ya que todavía no tenemos implementado cálculos de retenciones ajustados por diferencia de cambio"""
         for rec in self.filtered(
-            lambda x: x.l10n_ar_withholding_line_ids
-            and (x.currency_id != x.company_id.currency_id or x._use_counterpart_currency())
+            lambda x: x.l10n_ar_withholding_line_ids and (x.currency_id != x.company_id.currency_id)
         ):
             # Verificar si la deuda está gestionada en moneda extranjera
             dest_currency = rec.destination_account_id.currency_id


### PR DESCRIPTION
Remove the _use_counterpart_currency() check from the withholding
currency validation. The constraint now only validates payments when
the payment currency differs from the company currency, without
considering the journal's counterpart currency setting.