### PR TITLE
[FIX] l10n_ar_tax: retención de ganancias con importe cero.

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -326,7 +326,7 @@ class AccountPayment(models.Model):
             # Si hay retenciones que no son de ganancias y el importe a retener es 0 las quitamos
             # Ejemplo: retenciones en pagos de notas de crédito (el monto base es negativo)
             to_remove = rec.l10n_ar_withholding_line_ids.filtered(
-                lambda wth: wth.amount == 0 and wth.tax_id.l10n_ar_tax_type != "earnings_scale"
+                lambda wth: wth.amount == 0 and wth.tax_id.l10n_ar_tax_type not in ["earnings", "earnings_scale"]
             )
             rec.l10n_ar_withholding_line_ids -= to_remove
 


### PR DESCRIPTION
Al realizar un pago de proveedor con impuesto de ganancias (que no va por escala) cuyo importe calculado da cero por no llegar al mínimo imponible, el sistema no estaba creando la retención correspondiente en el pago. Este pr lo corrige para que se cree la retención aun cuando el importe sea cero (solo en retenciones de ganancias sea con escala o sin escala).
Ticket: 107485