### PR TITLE
[IMP] l10n_ar_ux: nro de ingresos brutos y fecha de inicio de actividades en pdf facturas

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.8.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -28,10 +28,10 @@
             <attribute name="t-field">header_address.l10n_ar_formatted_vat</attribute>
         </span>
         <span t-out="o.company_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or o.company_id.l10n_ar_gross_income_number" position="attributes">
-            <attribute name="t-out">header_address.l10n_ar_gross_income_type == 'exempt' and 'Exento' or header_address.l10n_ar_gross_income_number</attribute>
+            <attribute name="t-out">header_address.commercial_partner_id.l10n_ar_gross_income_type == 'exempt' and 'Exento' or header_address.commercial_partner_id.l10n_ar_gross_income_number</attribute>
         </span>
         <span t-field="o.company_id.l10n_ar_afip_start_date" position="attributes">
-            <attribute name="t-field">header_address.start_date</attribute>
+            <attribute name="t-field">header_address.commercial_partner_id.start_date</attribute>
         </span>
 
         <!-- tal vez tambien a este div principal le querramos cambiar la fuente como haciamos antes, aunque en realidad aparentemente ya no ex necesario, era algo asi:


### PR DESCRIPTION
Tarea: 62287 (vinculada a ticket 106612)
Queremos en los pdf de facturas electrónicas argentinas se muestre el número de ingresos brutos y fecha de incio de actividad del commercial_partner (campo "Dirección PdV AFIP" (l10n_ar_afip_pos_partner_id) en los diarios electrónicos)

Respecto al campo "Dirección PdV AFIP" (l10n_ar_afip_pos_partner_id) en los diarios electrónicos:
a) Si es Contacto, siempre va a tomar los datos del Padre. Es el cambio mas simple, si queremos sincronizar entre padres e hijos es medio overkill a nivel técnico.
b) Si es Empresa, debe definir sus propios campos de IIBB y Start Activity. La fecha de inicio de actividades es requerida para distintos puntos de venta, cada punto de venta puede tener una fecha de inicio distinta. La sugerencia va a ser usar branches (en este caso directamente son partners distintos). Y si se quiere partner hijo se puede marcar que sea "commercial partner" y listo.