### PR TITLE
[REM] l10n_ar_ux: remove deprecated fields from invoice report

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "18.0.1.8.0",
+    "version": "18.0.1.9.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/views/report_invoice.xml
+++ b/l10n_ar_ux/views/report_invoice.xml
@@ -55,9 +55,6 @@
         </t>
 
         <div name="comment" position="before">
-            <p t-if="o._fields.get('move_currency_id') and o.move_currency_id and o.move_inverse_currency_rate  &gt; 0.0">
-                El total de este comprobante equivale a un total de <span t-out="o.amount_total / o.move_inverse_currency_rate" t-options="{'widget': 'monetary', 'display_currency': o.move_currency_id}"/> a un tipo de cambio consignado de <span t-field="o.move_inverse_currency_rate"/>
-            </p>
             <p t-if="o.company_id.l10n_ar_invoice_report_ars_amount and o.currency_id != o.company_id.currency_id">
                 El total de este comprobante expresado en moneda de curso legal - Pesos Argentinos - asciende a <span t-out="abs(o.amount_total_signed)" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/>
             </p>


### PR DESCRIPTION
Delete lines containing deprecated fields 'move_currency_id' and 'move_inverse_currency_rate' from the invoice report template.