### PR TITLE
[FIX] l10n_ar_tax: added tag to PaymentReceiptbookAndWithholding tests

### DIFF
--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -1,10 +1,10 @@
 from odoo import Command, fields
-from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestL10nArWithholdingArRi
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
-class TestPaymentReceiptbookAndWithholding(TestL10nArWithholdingArRi):
+class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
     def setUp(self):
         super().setUp()
         self.today = fields.Date.today()

--- a/l10n_ar_tax/tests/test_payment_withholding_validation.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_validation.py
@@ -1,10 +1,10 @@
 from odoo import Command, fields
-from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestL10nArWithholdingArRi
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
 from odoo.tests import tagged
 
 
 @tagged("-at_install", "post_install")
-class TestPaymentWithholdingValidation(TestL10nArWithholdingArRi):
+class TestPaymentWithholdingValidation(TestArWithholdingArRi):
     def setUp(self):
         super().setUp()
         self.today = fields.Date.today()


### PR DESCRIPTION
Cambió el nombre de la clase TestL10nArWithholdingArRi que estabamos heredando en este commit https://github.com/odoo/odoo/commit/0499dbd8944b4002883afab5d3ed76d8e55dab9c#diff-2c28500c58eec52feb578a0677445522094cd5ae72a50562a6c05814c7850fe4, ahora se llama TestArWithholdingArRi