### PR TITLE
[IMP] l10n_ar_tax, l10n_ar_tax_python: adaptaciones para migrar l10n_ar_account_tax_settlement_mendoza

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -7,7 +7,7 @@ class AccountFiscalPosition(models.Model):
 
     l10n_ar_tax_ids = fields.One2many("account.fiscal.position.l10n_ar_tax", "fiscal_position_id")
 
-    def _l10n_ar_add_taxes(self, partner, company, date, tax_type):
+    def _l10n_ar_add_taxes(self, partner, company, date, tax_type, payment=None):
         # TODO deberiamos unificar mucho de este codigo con _get_tax_domain, _compute_withholdings y _check_tax_group_overlap
         self.ensure_one()
         taxes = self.env["account.tax"]
@@ -36,7 +36,7 @@ class AccountFiscalPosition(models.Model):
                 partner_tax = partner.l10n_ar_partner_tax_ids.filtered_domain(domain).mapped("tax_id")
             # agregamos taxes para grupos de impuestos que no estaban seteados en el partner
             if not partner_tax:
-                partner_tax = fp_tax._get_missing_taxes(partner, date)
+                partner_tax = fp_tax._get_missing_taxes(partner, date, payment)
             if len(partner_tax) > 1:
                 raise RedirectWarning(
                     message=_(

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -44,7 +44,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
             if conflicting_records:
                 raise ValidationError("No puede haber dos impuestos del mismo grupo para la misma posicion fiscal.")
 
-    def _get_missing_taxes(self, partner, date):
+    def _get_missing_taxes(self, partner, date, payment=None):
         taxes = self.env["account.tax"]
         for rec in self:
             if rec.webservice:

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -321,7 +321,7 @@ class AccountPayment(models.Model):
             withholdings = [Command.clear()]
             if rec.l10n_ar_fiscal_position_id.l10n_ar_tax_ids:
                 taxes = rec.l10n_ar_fiscal_position_id._l10n_ar_add_taxes(
-                    rec.partner_id, rec.company_id, date, "withholding"
+                    rec.partner_id, rec.company_id, date, "withholding", rec
                 )
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_line_ids = withholdings

--- a/l10n_ar_tax_python/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax_python/models/account_fiscal_position_l10n_ar_tax.py
@@ -32,9 +32,9 @@ class AccountFiscalPositionL10nArTax(models.Model):
                     )
                 )
 
-    def _get_missing_taxes(self, partner, date):
+    def _get_missing_taxes(self, partner, date, payment=None):
         python_formula = self.filtered(lambda x: x.webservice == "python_formula")
-        taxes = super(AccountFiscalPositionL10nArTax, self - python_formula)._get_missing_taxes(partner, date)
+        taxes = super(AccountFiscalPositionL10nArTax, self - python_formula)._get_missing_taxes(partner, date, payment)
         from_date = date + relativedelta(day=1)
         to_date = from_date + relativedelta(days=-1, months=+1)
         for rec in python_formula:
@@ -43,9 +43,10 @@ class AccountFiscalPositionL10nArTax(models.Model):
                 "to_date": to_date,
                 "from_date": from_date,
                 "default_tax": rec.default_tax_id,
+                "payment": payment,
             }
             safe_eval(
-                self.python_formula,
+                rec.python_formula,
                 local_dict,
                 mode="exec",
                 nocopy=True,


### PR DESCRIPTION
Tarea: 47856
Para migrar l10n_ar_account_tax_settlement_mendoza necesitamos hacer algunas adaptaciones en l10n_ar_tax y l10n_ar_tax_python para que en el código python de los impuestos que están en las posiciones fiscales se pueda recibir el registro de pago en el cual se aplica la retención.