### PR TITLE
[FIX] l10n_ar_tax: duplicado de facturas, cómputo de impuestos

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.23.0",
+    "version": "18.0.1.24.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -9,6 +9,8 @@ class AccountMove(models.Model):
     perceptions_fiscal_positon = fields.Boolean(
         compute="_compute_perceptions_fiscal_position",
     )
+    # Hacemos almacenado show_update_fpos para que funcione el _onchange_fpos_id_show_update_fpos
+    show_update_fpos = fields.Boolean(store=True)
 
     def _compute_perceptions_fiscal_position(self):
         """
@@ -31,11 +33,11 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "invoice_date" in vals in vals:
+        if "invoice_date" in vals:
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
-    @api.onchange("commercial_partner_id", "fiscal_position_id")
+    @api.onchange("commercial_partner_id")
     def _onchange_fpos_id_show_update_fpos(self):
         """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
         ya que las alícuotas pueden ser diferentes"""
@@ -47,6 +49,11 @@ class AccountMove(models.Model):
             and self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
         ):
             self.show_update_fpos = True
+
+    def action_update_fpos_values(self):
+        """Queremos que desaparezca el botón 'Update Taxes and Accounts' una vez que se haga click en el."""
+        super().action_update_fpos_values()
+        self.show_update_fpos = False
 
     @api.onchange("invoice_date")
     def _l10n_ar_recompute_fiscal_position_taxes(self):

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -31,11 +31,24 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "invoice_date" in vals or "partner_id" in vals:
+        if "invoice_date" in vals in vals:
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
-    @api.onchange("invoice_date", "partner_id")
+    @api.onchange("commercial_partner_id", "fiscal_position_id")
+    def _onchange_fpos_id_show_update_fpos(self):
+        """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
+        ya que las alícuotas pueden ser diferentes"""
+        super()._onchange_fpos_id_show_update_fpos()
+        if (
+            not self.show_update_fpos
+            and self.line_ids
+            and self.commercial_partner_id != self._origin.commercial_partner_id
+            and self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+        ):
+            self.show_update_fpos = True
+
+    @api.onchange("invoice_date")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
         """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
         impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -31,11 +31,11 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "invoice_date" in vals:
+        if "invoice_date" in vals or "partner_id" in vals:
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
-    @api.onchange("invoice_date")
+    @api.onchange("invoice_date", "partner_id")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
         """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
         impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -9,8 +9,6 @@ class AccountMove(models.Model):
     perceptions_fiscal_positon = fields.Boolean(
         compute="_compute_perceptions_fiscal_position",
     )
-    # Hacemos almacenado show_update_fpos para que funcione el _onchange_fpos_id_show_update_fpos
-    show_update_fpos = fields.Boolean(store=True)
 
     def _compute_perceptions_fiscal_position(self):
         """
@@ -37,29 +35,13 @@ class AccountMove(models.Model):
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
-    @api.onchange("commercial_partner_id")
-    def _onchange_fpos_id_show_update_fpos(self):
-        """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
-        ya que las alícuotas pueden ser diferentes"""
-        super()._onchange_fpos_id_show_update_fpos()
-        if (
-            not self.show_update_fpos
-            and self.line_ids
-            and self.commercial_partner_id != self._origin.commercial_partner_id
-            and self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
-        ):
-            self.show_update_fpos = True
-
-    def action_update_fpos_values(self):
-        """Queremos que desaparezca el botón 'Update Taxes and Accounts' una vez que se haga click en el."""
-        super().action_update_fpos_values()
-        self.show_update_fpos = False
-
-    @api.onchange("invoice_date")
+    @api.onchange("invoice_date", "commercial_partner_id")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
-        """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
-        impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
+        """Recalculamos las percepciones si cambiamos la fecha de la orden de venta o el commercial partner.
+        IMPORTANTE: este metodo solo esta pensado para cambiar alicuota de MISMA fiscal position (por cambio en fecha o partner) pero no para cambiar los impuestos.
+        Para ello nos basamos en los impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
         reemplazamos por los nuevos impuestos.
+        NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes
         """
         for move in self.filtered(
             lambda x: x.is_sale_document(include_receipts=True) and x.perceptions_fiscal_positon and x.state == "draft"

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -67,7 +67,7 @@ class AccountMove(models.Model):
             for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
                 to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:
-                    line.tax_ids = [(3, tax.id) for tax in to_unlink] + [(4, tax.id) for tax in new_taxes]
+                    line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una factura porque puede ser que la factura venga de otro periodo

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -47,14 +47,14 @@ class AccountMove(models.Model):
             fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"
             ).mapped("default_tax_id.tax_group_id")
-            date = move.date if not move.reversed_entry_id else move.reversed_entry_id.date
-            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(move.partner_id, move.company_id, date, "perception")
-            for line in move.invoice_line_ids:
+            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                move.partner_id, move.company_id, move.date, "perception"
+            )
+            # Solo queremos que se recomputen los impuestos en facturas de cliente/proveedor
+            for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
                 to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:
-                    line.tax_ids = [(3, tax.id) for tax in to_unlink] + [
-                        (4, tax.id) for tax in new_taxes if tax not in line.tax_ids
-                    ]
+                    line.tax_ids = [(3, tax.id) for tax in to_unlink] + [(4, tax.id) for tax in new_taxes]
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una factura porque puede ser que la factura venga de otro periodo


### PR DESCRIPTION
1) Si tengo una factura de cliente con impuesto de iva y percepción de CABA validada, si luego al contacto le agrego impuesto de ARBA, al duplicar la factura se crea solamente con el impuesto de arba y luego al validar se borra el impuesto de arba y se pone el de caba. VIDEO REPLICA RUNBOT ADHOC --> https://drive.google.com/file/d/1RGyX5SuHCgBjABleQQovwuAfm3uaUlK_/view

2) Este pr va junto a https://github.com/ingadhoc/argentina-sale/pull/279
También necesitamos que se recompute los impuestos al cambiar el contacto --> ver video jgo https://drive.google.com/file/d/1C7oS4EjxmMYzM2N-1MibwbshuShGbSr-/view reportado en ticket 110059 (ver nota jgo 05/02/2026 23:32pm https://www.adhoc.inc/mail/message/15914070 ). Al cambiar un partner, si la FP cambia odoo ofrece un botón para re-calcular. Pero en el caso de que el nuevo partner tenga misma FP, no se recalculan los impuestos. Esto es un problema porque en Argentina, aunque la FP sea la misma, los impuestos pueden variar dependiendo del partner (por ejemplo, por ser monotributista o no). Con este cambio, al cambiar el partner, se recalcularán los impuestos aunque la FP sea la misma.

3) Solo necesitamos que se recomputen los impuestos en las líneas de factura si la factura es de cliente o proveedor. No queremos que se recompute si es nota de cŕedito o nota de débito porque en ese caso queremos que tenga los mismo impuestos que la factura original.
Ticket Adhoc: 110078