### PR TITLE
[FIX] account_payment: adapt to new Odoo 18 withholding synchronization

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Automatic Argentinian Withholdings on Payments",
-    "version": "18.0.1.23.0",
+    "version": "18.0.1.24.0",
     "author": "ADHOC SA,Odoo Community Association (OCA)",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -133,24 +133,29 @@ class AccountPayment(models.Model):
         # TODO tal vez mejorar y advertir de que se va a computar el importe?
         return res
 
-    def _prepare_witholding_write_off_vals(self):
-        """We don't send currency amounts because withholdings are always in company currency"""
+    def _prepare_move_withholding_lines(self, default_values):
+        res = super()._prepare_move_withholding_lines(default_values)
         self.ensure_one()
-        write_off_line_vals = []
         sign = 1
         if self.payment_type == "outbound":
             sign = -1
+
+        conversion_rate = self.exchange_rate or 1.0
         for line in self.l10n_ar_withholding_line_ids:
             # nuestro approach esta quedando distinto al del wizard. En nuestras lineas tenemos los importes en moneda
             # de la cia, por lo cual el line.amount aca representa eso y tenemos que convertirlo para el amount_currency
 
             __, account_id, tax_repartition_line_id, __ = line._tax_compute_all_helper()
-            write_off_line_vals.append(
+            balance = self.company_id.currency_id.round(sign * line.amount)
+            amount_currency = self.currency_id.round(balance / conversion_rate)
+            res.append(
                 {
                     **self._get_withholding_move_line_default_values(),
                     "name": line.name,
                     "account_id": account_id,
-                    "balance": sign * line.amount,
+                    "balance": balance,
+                    "amount_currency": amount_currency,
+                    "currency_id": self.currency_id.id,
                     "tax_base_amount": sign * line.base_amount,
                     "tax_repartition_line_id": tax_repartition_line_id,
                 }
@@ -160,26 +165,53 @@ class AccountPayment(models.Model):
             withholding_lines = self.l10n_ar_withholding_line_ids.filtered(lambda x: x.base_amount == base_amount)
             nice_base_label = ",".join(withholding_lines.filtered("name").mapped("name"))
             account_id = self.company_id.l10n_ar_tax_base_account_id.id
-            base_amount = sign * base_amount
-            write_off_line_vals.append(
+            balance = self.company_id.currency_id.round(sign * base_amount)
+            # informamos el amount_currency para que Odoo no resetee el balance a 0.0 por inconsistencia de moneda
+            amount_currency = self.currency_id.round(balance / conversion_rate)
+            res.append(
                 {
                     **self._get_withholding_move_line_default_values(),
                     "name": _("Base Ret: ") + nice_base_label,
                     "tax_ids": [Command.set(withholding_lines.mapped("tax_id").ids)],
                     "account_id": account_id,
-                    "balance": base_amount,
+                    "balance": balance,
+                    "amount_currency": amount_currency,
+                    "currency_id": self.currency_id.id,
                 }
             )
-            write_off_line_vals.append(
+            res.append(
                 {
                     **self._get_withholding_move_line_default_values(),  # Counterpart 0 operation
                     "name": _("Base Ret Cont: ") + nice_base_label,
                     "account_id": account_id,
-                    "balance": -base_amount,
+                    "balance": -balance,
+                    "amount_currency": -amount_currency,
+                    "currency_id": self.currency_id.id,
                 }
             )
 
-        return write_off_line_vals
+        return res
+
+    def _prepare_move_liquidity_lines(self, default_values):
+        """Si el importe del pago es el neto (monto de liquidez), debemos deshacer la resta que hace Odoo
+        de las retenciones sobre la línea de liquidez."""
+        wth_lines = self._prepare_move_withholding_lines({})
+        if wth_lines:
+            wth_balance = sum(x["balance"] for x in wth_lines)
+            wth_amount_currency = sum(x["amount_currency"] for x in wth_lines)
+            default_values["balance"] += wth_balance
+            default_values["amount_currency"] += wth_amount_currency
+        return super()._prepare_move_liquidity_lines(default_values)
+
+    def _prepare_move_counterpart_lines(self, default_values):
+        """Si el importe del pago es el neto, la contraparte debe ser el bruto (neto + retenciones)."""
+        wth_lines = self._prepare_move_withholding_lines({})
+        if wth_lines:
+            wth_balance = sum(x["balance"] for x in wth_lines)
+            wth_amount_currency = sum(x["amount_currency"] for x in wth_lines)
+            default_values["balance"] -= wth_balance
+            default_values["amount_currency"] -= wth_amount_currency
+        return super()._prepare_move_counterpart_lines(default_values)
 
     def action_post(self):
         for rec in self:
@@ -229,32 +261,6 @@ class AccountPayment(models.Model):
             debt_in_foreign_currency = dest_currency and dest_currency != rec.company_id.currency_id
             if not rec.company_id.reconcile_on_company_currency or debt_in_foreign_currency:
                 rec.withholding_warning = True
-
-    def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
-        res = super()._prepare_move_line_default_vals(write_off_line_vals, force_balance=force_balance)
-        res += self._prepare_witholding_write_off_vals()
-        wth_amount = sum(self.l10n_ar_withholding_line_ids.mapped("amount"))
-        conversion_rate = self.exchange_rate or 1.0
-        # TODO: EVALUAR
-        # si cambio el valor de la cuenta de liquides quitando las retenciones el campo amount representa el monto que cancelo de la deuda
-        # si cambio la cuenta de contraparte (agregando retenciones) el campo amount representa el monto neto que abono al partner
-        # Ambos caminos funcionan pero no se cual es mejor a nivel usabilidad. depende como realizemos el calculo automatico de la ret
-        # liquidity_accounts = [x.id for x in self._get_valid_liquidity_accounts() if x]
-        valid_account_types = self._get_valid_payment_account_types()
-        for line in res:
-            account_id = self.env["account.account"].browse(line["account_id"])
-            # if line['account_id'] in liquidity_accounts:
-            if account_id.account_type in valid_account_types:
-                if self.payment_type == "inbound" and line.get("balance", 0) < 0:
-                    line["balance"] -= wth_amount
-                    if not self._use_counterpart_currency():
-                        line["amount_currency"] -= wth_amount / conversion_rate
-                elif self.payment_type == "outbound" and line.get("balance", 0) > 0:
-                    line["balance"] += wth_amount
-                    if not self._use_counterpart_currency():
-                        line["amount_currency"] += wth_amount / conversion_rate
-
-        return res
 
     ###################################################
     # desde account_withholding_automatic payment.group

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -192,26 +192,34 @@ class AccountPayment(models.Model):
 
         return res
 
-    def _prepare_move_liquidity_lines(self, default_values):
-        """Si el importe del pago es el neto (monto de liquidez), debemos deshacer la resta que hace Odoo
-        de las retenciones sobre la línea de liquidez."""
-        wth_lines = self._prepare_move_withholding_lines({})
-        if wth_lines:
-            wth_balance = sum(x["balance"] for x in wth_lines)
-            wth_amount_currency = sum(x["amount_currency"] for x in wth_lines)
-            default_values["balance"] += wth_balance
-            default_values["amount_currency"] += wth_amount_currency
-        return super()._prepare_move_liquidity_lines(default_values)
+    def _prepare_move_lines_per_type(self, write_off_line_vals=None, force_balance=None):
+        res = super()._prepare_move_lines_per_type(write_off_line_vals=write_off_line_vals, force_balance=force_balance)
 
-    def _prepare_move_counterpart_lines(self, default_values):
-        """Si el importe del pago es el neto, la contraparte debe ser el bruto (neto + retenciones)."""
-        wth_lines = self._prepare_move_withholding_lines({})
+        # we adjust liquidity and counterpart lines because in ARG payment amount is already net of withholdings
+        # whereas odoo expects it to be gross and subtracts withholdings from it.
+        wth_lines = res.get("withholding_lines", [])
+
         if wth_lines:
-            wth_balance = sum(x["balance"] for x in wth_lines)
-            wth_amount_currency = sum(x["amount_currency"] for x in wth_lines)
-            default_values["balance"] -= wth_balance
-            default_values["amount_currency"] -= wth_amount_currency
-        return super()._prepare_move_counterpart_lines(default_values)
+            wth_balance = sum(line["balance"] for line in wth_lines)
+            wth_amount_currency = sum(line["amount_currency"] for line in wth_lines)
+
+            liquidity_lines = res.get("liquidity_lines", [])
+            if liquidity_lines:
+                liquidity_lines[0]["balance"] += wth_balance
+                liquidity_lines[0]["amount_currency"] += wth_amount_currency
+                # if after adjustment the liquidity line is 0, we remove it
+                # esto podria ir a payment_pro y que cualquier liquidity line en zero no se cree (Es para caso de
+                # puro write off y/o solo retenciones)
+                if self.company_currency_id.is_zero(liquidity_lines[0]["balance"]):
+                    res["liquidity_lines"] = []
+
+            counterpart_lines = res.get("counterpart_lines", [])
+            if counterpart_lines:
+                # the counterpart line (debt) should be the gross amount (net + withholdings)
+                counterpart_lines[0]["balance"] -= wth_balance
+                counterpart_lines[0]["amount_currency"] -= wth_amount_currency
+
+        return res
 
     def action_post(self):
         for rec in self:


### PR DESCRIPTION
Se adapta la lógica de retenciones automáticas a los cambios introducidos recientemente en Odoo 18 sobre la sincronización de asientos de pagos (ver PR Odoo #246675).

A diferencia del estándar de Odoo, donde el campo `amount` representa el monto bruto (el total que se cancela al proveedor), en la localización argentina de ADHOC el campo `amount` representa el importe neto (la liquidez/efectivo que efectivamente sale del banco).

Detalles técnicos:
* Se implementa el nuevo método estándar `_prepare_move_withholding_lines` para generar las líneas de retención y sus correspondientes bases impositivas.
* Se sobreescriben `_prepare_move_liquidity_lines` y `_prepare_move_counterpart_lines` para revertir la resta automática de retenciones que realiza el núcleo de Odoo. Esto asegura que la línea de banco refleje exactamente el `amount` del pago y que la contraparte refleje el monto bruto (Pago neto + Retenciones).
* Se garantiza que todas las líneas informen correctamente su `amount_currency` y `currency_id`, previniendo que el motor de sincronización de Odoo resetee los balances a cero por inconsistencias de moneda.
* Se elimina la lógica obsoleta que ajustaba manualmente los campos `debit`/`credit` en `_prepare_move_line_default_vals`.

Referencia Odoo PR: https://github.com/odoo/odoo/pull/246675