### PR TITLE
[ADD] l10n_ar_tax: demo data and tests for editing payments with with…

### DIFF
--- a/l10n_ar_tax/__init__.py
+++ b/l10n_ar_tax/__init__.py
@@ -4,6 +4,7 @@
 ##############################################################################
 from . import models
 from . import wizard
+from . import demo
 from odoo.addons.l10n_ar_withholding.models.account_payment import AccountPayment
 import logging
 

--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -44,6 +44,7 @@
         "demo/account_tax_demo.xml",
         "demo/res_partner_demo.xml",
         "demo/account_move_demo.xml",
+        "demo/l10n_ar_tax_demo.xml",
     ],
     "depends": [
         "l10n_ar",

--- a/l10n_ar_tax/demo/__init__.py
+++ b/l10n_ar_tax/demo/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_ar_tax_demo

--- a/l10n_ar_tax/demo/l10n_ar_tax_demo.py
+++ b/l10n_ar_tax/demo/l10n_ar_tax_demo.py
@@ -1,0 +1,126 @@
+import logging
+
+from odoo import Command, api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+# pylint: disable=R8180
+class AccountChartTemplate(models.AbstractModel):
+    _inherit = "account.chart.template"
+
+    @api.model
+    def _install_l10n_ar_tax_demo(self, company):
+        """Crea demo data mínima para testing de edición de pagos con retenciones.
+
+        Casos cubiertos:
+        - Pago sin amount (solo retenciones)
+        - Pago con amount, retenciones y write-off
+        """
+        company.ensure_one()
+        self = self.with_company(company)
+
+        _logger.info("Creating l10n_ar_tax payment demo data for company: %s", company.name)
+
+        today = fields.Date.today()
+
+        demo_data = {
+            "account.move": {
+                # Factura de proveedor CABA para test de pago sin amount
+                "demo_vendor_bill_caba_1": {
+                    "partner_id": "l10n_ar_tax.res_partner_adhoc_caba",
+                    "move_type": "in_invoice",
+                    "company_id": company.id,
+                    "invoice_date": today,
+                    "l10n_latam_document_number": "0001-00000100",
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": "product.product_product_16",
+                                "quantity": 1,
+                                "price_unit": 100000,
+                            }
+                        )
+                    ],
+                },
+                # Factura de proveedor CABA para test de edición de pago
+                "demo_vendor_bill_caba_2": {
+                    "partner_id": "l10n_ar_tax.res_partner_adhoc_caba",
+                    "move_type": "in_invoice",
+                    "company_id": company.id,
+                    "invoice_date": today,
+                    "l10n_latam_document_number": "0001-00000101",
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": "product.product_product_16",
+                                "quantity": 1,
+                                "price_unit": 200000,
+                            }
+                        )
+                    ],
+                },
+            },
+        }
+
+        self.sudo().with_context(skip_pdf_attachment_generation=True)._load_data(demo_data)
+
+        # Post invoices
+        for xml_id in ["demo_vendor_bill_caba_1", "demo_vendor_bill_caba_2"]:
+            invoice = self.ref(xml_id)
+            if invoice.state == "draft":
+                invoice.action_post()
+                _logger.info("Posted invoice %s", xml_id)
+
+        # Create payments (draft state para que los tests puedan modificarlos)
+        bank_journal = self.env["account.journal"].search(
+            [("company_id", "=", company.id), ("type", "=", "bank")], limit=1
+        )
+
+        # Payment 1: sin amount (solo retenciones)
+        invoice_1 = self.ref("demo_vendor_bill_caba_1")
+        action_context_1 = invoice_1.action_register_payment()["context"]
+        payment_1 = (
+            self.env["account.payment"]
+            .with_context(**action_context_1)
+            .create(
+                {
+                    "journal_id": bank_journal.id,
+                    "amount": 0.0,
+                    "date": today,
+                }
+            )
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": "demo_payment_only_withholdings",
+                "module": "l10n_ar_tax",
+                "model": "account.payment",
+                "res_id": payment_1.id,
+            }
+        )
+        _logger.info("Created payment demo_payment_only_withholdings")
+
+        # Payment 2: con amount para editar
+        invoice_2 = self.ref("demo_vendor_bill_caba_2")
+        action_context_2 = invoice_2.action_register_payment()["context"]
+        payment_2 = (
+            self.env["account.payment"]
+            .with_context(**action_context_2)
+            .create(
+                {
+                    "journal_id": bank_journal.id,
+                    "amount": 150000,
+                    "date": today,
+                }
+            )
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": "demo_payment_to_edit",
+                "module": "l10n_ar_tax",
+                "model": "account.payment",
+                "res_id": payment_2.id,
+            }
+        )
+        _logger.info("Created payment demo_payment_to_edit")

--- a/l10n_ar_tax/demo/l10n_ar_tax_demo.xml
+++ b/l10n_ar_tax/demo/l10n_ar_tax_demo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Trigger demo data creation for l10n_ar_tax payment tests -->
+    <function model="account.chart.template" name="_install_l10n_ar_tax_demo">
+        <value eval="[ref('base.company_ri')]"/>
+    </function>
+
+</odoo>

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_arba
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_validation
+from . import test_payment_write

--- a/l10n_ar_tax/tests/test_payment_write.py
+++ b/l10n_ar_tax/tests/test_payment_write.py
@@ -1,0 +1,161 @@
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentWrite(TestArWithholdingArRi):
+    """Tests para validar que al modificar un pago se actualicen correctamente los apuntes contables."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Instalar demo data dinámica
+        chart_template = cls.env["account.chart.template"]
+        chart_template._install_l10n_ar_tax_demo(cls.company_ri)
+
+        # Referenciar demo data creada dinámicamente
+        cls.invoice_1 = chart_template.ref("demo_vendor_bill_caba_1")
+        cls.invoice_2 = chart_template.ref("demo_vendor_bill_caba_2")
+        cls.payment_1 = chart_template.ref("demo_payment_only_withholdings")
+        cls.payment_2 = chart_template.ref("demo_payment_to_edit")
+
+    def test_01_payment_with_only_withholdings_no_liquidity(self):
+        """Test pago sin amount (solo retenciones).
+
+        1. Usar payment de demo data (amount = 0)
+        2. Post payment
+        3. VALIDATION: No debe existir línea de liquidez
+        4. VALIDATION: Deben existir líneas de retención
+        5. VALIDATION: Debe existir línea de deuda (counterpart)
+        """
+        payment = self.payment_1
+
+        # Post payment
+        payment.action_post()
+
+        # VALIDATION: No debe existir línea de liquidez (amount es 0)
+        liquidity_lines = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id == payment.journal_id.default_account_id
+        )
+        self.assertFalse(liquidity_lines, "Liquidity line should not exist when payment amount is zero")
+
+        # VALIDATION: Deben existir líneas de retención
+        withholding_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+        self.assertTrue(withholding_lines, "Withholding lines should be created even with zero payment amount")
+
+        # VALIDATION: Debe existir línea de deuda (counterpart)
+        receivable_lines = payment.move_id.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
+        self.assertTrue(receivable_lines, "Counterpart debt line should exist")
+        self.assertGreater(sum(receivable_lines.mapped("debit")), 0, "Counterpart line should have positive debit")
+
+        # VALIDATION: El asiento debe estar balanceado
+        total_balance = sum(payment.move_id.line_ids.mapped("balance"))
+        self.assertAlmostEqual(total_balance, 0.0, places=2, msg="Move should be balanced")
+
+    def test_02_payment_edit_updates_accounting_entries(self):
+        """Test edición de pago actualiza apuntes contables.
+
+        1. Usar payment de demo data con amount
+        2. Post payment y guardar valores originales
+        3. Editar payment (cambiar amount)
+        4. VALIDATION: Las líneas del move deben actualizarse
+        5. VALIDATION: Los nuevos balances deben reflejar el nuevo amount
+        6. VALIDATION: El asiento debe seguir balanceado
+        """
+        payment = self.payment_2
+
+        # Post payment
+        payment.action_post()
+
+        # Guardar valores originales
+        original_liquidity_balance = sum(
+            payment.move_id.line_ids.filtered(lambda l: l.account_id == payment.journal_id.default_account_id).mapped(
+                "balance"
+            )
+        )
+        original_withholding_balance = sum(
+            payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id).mapped("balance")
+        )
+
+        # Editar payment: cambiar amount
+        payment.write({"amount": 100000})
+
+        # VALIDATION: Las líneas del move deben actualizarse
+        new_liquidity_balance = sum(
+            payment.move_id.line_ids.filtered(lambda l: l.account_id == payment.journal_id.default_account_id).mapped(
+                "balance"
+            )
+        )
+        new_withholding_balance = sum(
+            payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id).mapped("balance")
+        )
+
+        self.assertNotEqual(
+            original_liquidity_balance,
+            new_liquidity_balance,
+            "Liquidity line should be updated after payment amount change",
+        )
+        self.assertNotEqual(
+            original_withholding_balance,
+            new_withholding_balance,
+            "Withholding lines should be updated after payment amount change",
+        )
+
+        # VALIDATION: Los nuevos balances deben reflejar el nuevo amount
+        # Withholding es 10% del base amount
+        expected_withholding_amount = -10000  # 10% of 100000
+        self.assertAlmostEqual(
+            new_withholding_balance,
+            expected_withholding_amount,
+            places=2,
+            msg="Withholding amount should be 10% of new payment amount",
+        )
+
+        # VALIDATION: El asiento debe seguir balanceado
+        total_balance = sum(payment.move_id.line_ids.mapped("balance"))
+        self.assertAlmostEqual(total_balance, 0.0, places=2, msg="Move should remain balanced after edit")
+
+    def test_03_payment_edit_with_amount_withholding_and_writeoff(self):
+        """Test edición de pago con amount, retenciones y write-off.
+
+        1. Copiar payment de demo y modificar amount
+        2. Post payment
+        3. Editar amount a un valor aún menor
+        4. VALIDATION: Todas las líneas deben actualizarse (liquidity, withholding, write-off, counterpart)
+        5. VALIDATION: El asiento debe seguir balanceado
+        """
+        # Copiar payment para no afectar otros tests
+        payment = self.payment_2.copy({"amount": 180000})
+
+        # Post payment
+        payment.action_post()
+
+        # Contar líneas originales
+        original_line_count = len(payment.move_id.line_ids)
+
+        # Editar payment: reducir más el amount
+        payment.write({"amount": 120000})
+
+        # VALIDATION: El número de líneas debería ser similar (pueden variar ligeramente)
+        new_line_count = len(payment.move_id.line_ids)
+        self.assertTrue(
+            abs(original_line_count - new_line_count) <= 2,
+            f"Line count should remain similar. Original: {original_line_count}, New: {new_line_count}",
+        )
+
+        # VALIDATION: El asiento debe seguir balanceado
+        total_balance = sum(payment.move_id.line_ids.mapped("balance"))
+        self.assertAlmostEqual(
+            total_balance, 0.0, places=2, msg="Move should remain balanced after edit with write-off"
+        )
+
+        # VALIDATION: Debe existir línea de liquidez
+        liquidity_lines = payment.move_id.line_ids.filtered(
+            lambda l: l.account_id == payment.journal_id.default_account_id
+        )
+        self.assertTrue(liquidity_lines, "Liquidity line should exist")
+
+        # VALIDATION: El balance de liquidez debe ser negativo (pago saliente)
+        liquidity_balance = sum(liquidity_lines.mapped("balance"))
+        self.assertLess(liquidity_balance, 0, "Liquidity balance should be negative for outbound payment")


### PR DESCRIPTION
…holdings

Adds minimalist dynamic demo data:
- 2 vendor bills (CABA) using _load_data()
- _install_l10n_ar_tax_demo(company) method in account.chart.template

Adds tests to validate update of journal entries when editing payments:
- test_01: Payment without amount (only withholdings)
- test_02: Editing payment updates journal entries (amount, withholdings)
- test_03: Editing with amount, withholdings, and write-off

Tests use dynamic demo data with chart_template.ref() (no manual record creation)