### PR TITLE
[IMP] l10n_ar_tax: Hacer cálculo de percepciones de venta teniendo en cuenta el monto mínimo no imponible establecido en el impuesto.

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -65,3 +65,10 @@ class AccountMove(models.Model):
         recs = super().copy(default=default)
         recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs
+
+    def _prepare_product_base_line_for_taxes_computation(self, product_line):
+        """ Si es factura de venta argentina mandamos l10n_ar_perception_invoice por contexto. Dicho contexto se usa en l10n_ar_tax/models/account_tax.py por el método _get_tax_details para el cálculo de percepciones de venta teniendo en cuenta el monto mínimo no imponible establecido en el impuesto. """
+        base_line = super()._prepare_product_base_line_for_taxes_computation(product_line)
+        if self.move_type in ("out_invoice", "out_refund") and self.company_id.country_id.code == "AR":
+            base_line["tax_ids"] = base_line["tax_ids"].with_context(l10n_ar_perception_invoice=True)
+        return base_line

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -100,3 +100,60 @@ class AccountTax(models.Model):
             raise UserError(
                 "Error se esta usando en ws de estas cias %s" % ws.mapped("fiscal_position_id.company_id.name")
             )
+
+
+    def _get_tax_details(
+        self,
+        price_unit,
+        quantity,
+        precision_rounding=0.01,
+        rounding_method="round_per_line",
+        product=None,
+        product_uom=None,
+        special_mode=False,
+        manual_tax_amounts=None,
+        filter_tax_function=None,
+    ):
+        """ Hacer cálculo de percepciones de venta teniendo en cuenta el monto mínimo no imponible establecido en el impuesto."""
+        res = super()._get_tax_details(
+            price_unit,
+            quantity,
+            precision_rounding=precision_rounding,
+            rounding_method=rounding_method,
+            product=product,
+            product_uom=product_uom,
+            special_mode=special_mode,
+            manual_tax_amounts=manual_tax_amounts,
+            filter_tax_function=filter_tax_function,
+        )
+        if not self._context.get("l10n_ar_perception_invoice"):
+            return res
+
+        if not res.get("taxes_data"):
+            return res
+
+        updated = False
+        for tax_data in res["taxes_data"]:
+            tax = tax_data["tax"]
+            if tax.country_code == "AR" and tax.type_tax_use == "sale" and tax.l10n_ar_non_taxable_amount:
+                base_amount = tax_data["base_amount"]
+                net_base = max(0, base_amount - tax.l10n_ar_non_taxable_amount)
+                if not net_base:
+                    if tax_data["tax_amount"] or tax_data["base_amount"]:
+                        tax_data["tax_amount"] = 0.0
+                        tax_data["base_amount"] = 0.0
+                        updated = True
+                else:
+                    if base_amount:
+                        tax_data["tax_amount"] = tax_data["tax_amount"] * (net_base / base_amount)
+                    else:
+                        tax_data["tax_amount"] = 0.0
+                    tax_data["base_amount"] = net_base
+                    updated = True
+
+        if updated:
+            res["total_included"] = res["total_excluded"] + sum(
+                tax_line["tax_amount"] for tax_line in res["taxes_data"]
+            )
+
+        return res

--- a/l10n_ar_tax/views/account_tax_view.xml
+++ b/l10n_ar_tax/views/account_tax_view.xml
@@ -46,6 +46,10 @@
             <field name="l10n_ar_code" position="attributes">
                 <attribute name="invisible">country_code != 'AR'</attribute>
             </field>
+            <!-- Necesitamos que sea visible en percepciones porque Santa Fe requiere el mínimo no imponible -->
+            <field name="l10n_ar_non_taxable_amount" position="attributes">
+                <attribute name="invisible">country_code != 'AR' or l10n_ar_type_tax_use not in ['sale', 'supplier'] or amount_type != 'percent'</attribute>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION
Ejemplo cálculo de percepción de venta argentina con impuesto que tiene alícuota 2.5%:

a) Si el mínimo no imponible es 350000 y la base es 351000 entonces el monto a percibir es 25 --> (351000-350000)*2.5% 
b) S.i el mínimo no imponible es 350000 y la base es inferior a dicho monto entonces el monto a percibir es 0 independientemente de la alícuota aplicada.

Tarea: 64477