### PR TITLE
[IMP] l10n_ar_tax: add associated credit notes to payment receipt tem…

### DIFF
--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -190,6 +190,7 @@
                 </tfoot>
             </table>
             <br/>
+            <t t-set="matched_lines" t-value="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')"/>
             <table class="table table-sm o_main_table" name="matching_table">
                 <thead>
                     <tr>
@@ -200,7 +201,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <t t-foreach="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')" t-as="line">
+                    <t t-foreach="matched_lines" t-as="line">
                         <tr>
                             <td><span t-field='line.move_id.display_name'/></td>
                             <td class="text-center">
@@ -214,7 +215,9 @@
                                 <!-- payment_matched_amount is already expressed in B (destination_currency_id) -->
                                 <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
                             </td>
+
                         </tr>
+                        <span class="reversal_move_lines"/>
                     </t>
                     <tr t-if="sum(payment_bundle.mapped('unmatched_amount'))">
                         <td>On account</td>
@@ -285,6 +288,28 @@
             </table>
         </div>
     </template>
+
+    <template id="report_payment_receipt_reversal_moves" active="False" inherit_id="l10n_ar_tax.report_payment_receipt_document">
+       <xpath expr="//span[hasclass('reversal_move_lines')]" position="replace">
+            <t t-foreach="line.move_id.reversal_move_ids" t-as="reversal_move_id">
+                <t t-set="imputed_amount" t-value="[item['amount'] for item in reversal_move_id.sudo()._get_all_reconciled_invoice_partials() if item['aml_id'] == line.id]"/>
+                <tr>
+                    <td><span style="padding-left: 20px;">└</span> <span t-field='reversal_move_id.display_name'/></td>
+                    <td class="text-center">
+                        <span class="text-nowrap" t-field="reversal_move_id.invoice_date"/>
+                    </td>
+                    <td class="text-right o_price_total" >
+                        <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and 1.0 or -1.0) * sum(imputed_amount)" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
+                    </td>
+                    <td class="text-right o_price_total" >
+                    </td>
+                </tr>
+
+            </t>
+
+        </xpath>
+    </template>
+
   <template id="report_payment_receipt_bundle">
         <t t-call="web.html_container">
             <t t-foreach="docs.with_context(print_in_bundles=True)._get_payment_bundles().values()" t-as="payment_bundle">

--- a/l10n_ar_tax/wizard/res_config_settings.py
+++ b/l10n_ar_tax/wizard/res_config_settings.py
@@ -13,6 +13,21 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.arba_cit",
         readonly=False,
     )
+    show_reversal_moves_in_receipts = fields.Boolean(
+        compute="_compute_show_reversal_moves_in_receipts",
+        inverse="_inverse_show_reversal_moves_in_receipts",
+    )
+
+    def _compute_show_reversal_moves_in_receipts(self):
+        for record in self:
+            report = self.env.ref("l10n_ar_tax.report_payment_receipt_reversal_moves", raise_if_not_found=False)
+            record.show_reversal_moves_in_receipts = report and report.sudo().active
+
+    def _inverse_show_reversal_moves_in_receipts(self):
+        report = self.env.ref("l10n_ar_tax.report_payment_receipt_reversal_moves", raise_if_not_found=False)
+        if not report:
+            return
+        report.sudo().active = self.show_reversal_moves_in_receipts
 
     def l10n_ar_arba_cit_test(self):
         self.ensure_one()

--- a/l10n_ar_tax/wizard/res_config_settings_views.xml
+++ b/l10n_ar_tax/wizard/res_config_settings_views.xml
@@ -20,7 +20,12 @@
                     </div>
                 </setting>
             </xpath>
-
+        <setting id="sepa_payments" position="after">
+                    <setting id="show_reversal_moves_in_receipts" string="Show reversal moves in receipts"
+                        help="Muestra las ND y NC en los recibos de pago, como movimientos a parte.">
+                        <field name="show_reversal_moves_in_receipts"/>
+                    </setting>
+                </setting>
         </field>
     </record>
 


### PR DESCRIPTION
…plate

Modified the Payment Receipt PDF report to include a new section for "Associated Credits/Credit Notes."

Current behavior: When a Credit Note (CN) is reconciled against an Invoice before or during payment, the printed receipt only reflects the final cash/bank amount, omitting the CN's contribution to settling the debt.

New behavior: The report now identifies the Invoices being paid and dynamically fetches all previously or concurrently reconciled credits (CNs). These are displayed in a detailed section to provide a clear breakdown of how the total invoice balance was cleared (e.g., Invoice = CN + Payment).

Technical details:
- Updated the payment receipt QWeb template.
- Implemented logic to traverse reconciled moves related to the paid invoices.
- Added a conditional table for "Other credits applied to invoices."