### PR TITLE
[FIX] l10n_ar_tax: evitar refresco de impuestos al guardar desde UI

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -31,7 +31,11 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        if "invoice_date" in vals:
+        # Si el invoice_date cambia, recomputamos las percepciones.
+        # En Odoo 18+, cuando el guardado viene de un formulario (UI), los 'tax_ids' de las líneas
+        # suelen estar presentes en los 'vals' (dentro de 'invoice_line_ids').
+        # Si el usuario editó las líneas, no queremos re-ejecutar nuestra lógica de refresco automático.
+        if "invoice_date" in vals and "invoice_line_ids" not in vals:
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 


### PR DESCRIPTION
Se corrige un comportamiento donde el método `write` re-ejecutaba el refresco automático de impuestos al guardar una factura desde la interfaz de usuario, sobrescribiendo eliminaciones manuales de impuestos realizadas por el usuario antes de guardar.

Ahora se verifica si `invoice_line_ids` está en `vals` para detectar si el guardado proviene de la UI (donde el onchange ya actuó y el usuario pudo realizar ajustes manuales), en cuyo caso se omite el re-cálculo programático en el `write`.