### PR TITLE
[FIX] l10n_ar_tax: error al verificar clave ARBA.

### DIFF
--- a/l10n_ar_tax/wizard/res_config_settings.py
+++ b/l10n_ar_tax/wizard/res_config_settings.py
@@ -19,7 +19,7 @@ class ResConfigSettings(models.TransientModel):
         cuit = self.company_id.partner_id.ensure_vat()
         _logger.info("Getting ARBA data for cuit %s" % (cuit))
         try:
-            self.fiscal_position_id.company_id.arba_consultar_contribuyente(
+            self.company_id.arba_consultar_contribuyente(
                 cuit,
                 fields.Date.start_of(fields.Date.today(), "month"),
                 fields.Date.end_of(fields.Date.today(), "month"),


### PR DESCRIPTION
Al verificar clave ARBA aparece el mensaje "No se pudo conectar a ARBA: 'res.config.settings' object has no attribute 'fiscal_position_id'". Este commit lo arregla.
Ticket: 111993