### PR TITLE
[IMP] l10n_ar_tax: agregado de etiquetas y secuencias a impuestos de ret ganancias.

### DIFF
--- a/l10n_ar_tax/models/account_chart_template.py
+++ b/l10n_ar_tax/models/account_chart_template.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 import logging
+import re
 
 from odoo import Command, api, models
 
@@ -71,9 +72,43 @@ class AccountChartTemplate(models.AbstractModel):
         ]
         for tax_ref, state_ref in tax_state_tupples:
             # Identificamos el impuesto al que se le va a agregar la/s etiqueta/s
-            tax = self.env.ref("account.%s_%s" % (company.id, tax_ref), raise_if_not_found=False)
-            if tax:
-                tax.l10n_ar_state_id = self.env.ref(state_ref).id
+            if tax := self.env.ref("account.%s_%s" % (company.id, tax_ref), raise_if_not_found=False):
+                if not tax.l10n_ar_state_id:
+                    tax.l10n_ar_state_id = self.env.ref(state_ref).id
+
+        # agregado de jurisdiccion a retenciones
+        withholding_tax_state_tupples = [
+            ("tax_retencion_iibb_sf_aplicada", "base.state_ar_s"),
+            ("ri_tax_retencion_iibb_caba_aplicada", "base.state_ar_c"),
+            ("ri_tax_retencion_iibb_ba_aplicada", "base.state_ar_b"),
+            ("ri_tax_retencion_iibb_ca_aplicada", "base.state_ar_k"),
+            ("ri_tax_retencion_iibb_co_aplicada", "base.state_ar_x"),
+            ("ri_tax_retencion_iibb_rr_aplicada", "base.state_ar_w"),
+            ("ri_tax_retencion_iibb_er_aplicada", "base.state_ar_e"),
+            ("ri_tax_retencion_iibb_ju_aplicada", "base.state_ar_y"),
+            ("ri_tax_retencion_iibb_za_aplicada", "base.state_ar_m"),
+            ("ri_tax_retencion_iibb_lr_aplicada", "base.state_ar_f"),
+            ("ri_tax_retencion_iibb_sa_aplicada", "base.state_ar_a"),
+            ("ri_tax_retencion_iibb_nn_aplicada", "base.state_ar_j"),
+            ("ri_tax_retencion_iibb_sl_aplicada", "base.state_ar_d"),
+            ("ri_tax_retencion_iibb_se_aplicada", "base.state_ar_g"),
+            ("ri_tax_retencion_iibb_tn_aplicada", "base.state_ar_t"),
+            ("ri_tax_retencion_iibb_ha_aplicada", "base.state_ar_h"),
+            ("ri_tax_retencion_iibb_ct_aplicada", "base.state_ar_u"),
+            ("ri_tax_retencion_iibb_fo_aplicada", "base.state_ar_p"),
+            ("ri_tax_retencion_iibb_mi_aplicada", "base.state_ar_n"),
+            ("ri_tax_retencion_iibb_ne_aplicada", "base.state_ar_q"),
+            ("ri_tax_retencion_iibb_lp_aplicada", "base.state_ar_l"),
+            ("ri_tax_retencion_iibb_rn_aplicada", "base.state_ar_r"),
+            ("ri_tax_retencion_iibb_az_aplicada", "base.state_ar_z"),
+            ("ri_tax_retencion_iibb_tf_aplicada", "base.state_ar_v"),
+        ]
+
+        for tax_ref, state_ref in withholding_tax_state_tupples:
+            # Identificamos el impuesto al que se le va a agregar la/s etiqueta/s
+            if tax := self.env.ref("l10n_ar_tax.%s_%s" % (company.id, tax_ref), raise_if_not_found=False):
+                if not tax.l10n_ar_state_id:
+                    tax.l10n_ar_state_id = self.env.ref(state_ref).id
 
         # creacion de secuencias y agregado de etiquetas para liquidación de impuestos
         withholdings_domain = [
@@ -85,9 +120,27 @@ class AccountChartTemplate(models.AbstractModel):
         non_profits_domain = withholdings_domain + [("l10n_ar_tax_type", "not in", ["earnings", "earnings_scale"])]
 
         for tax in self.env["account.tax"].with_context(active_test=False).search(non_profits_domain):
+            if not tax.l10n_ar_withholding_sequence_id:
+                sequence_name = re.sub(r"\s+\d+[,.]?\d*\s*%", "", tax.invoice_label or tax.name).strip()
+                sequence = self.env["ir.sequence"].create(
+                    {
+                        "name": sequence_name,
+                        "prefix": "%(year)s-",
+                        "padding": 8,
+                        "number_increment": 1,
+                        "implementation": "standard",
+                        "company_id": company.id,
+                    }
+                )
+                tax.l10n_ar_withholding_sequence_id = sequence.id
+
+        profits_domain = withholdings_domain + [("l10n_ar_tax_type", "in", ["earnings", "earnings_scale"])]
+        profits_taxes = self.env["account.tax"].with_context(active_test=False).search(profits_domain)
+        # Todos los impuestos de retención de ganancias deben compartir la misma secuencia
+        if not all(prof_tax.l10n_ar_withholding_sequence_id for prof_tax in profits_taxes):
             sequence = self.env["ir.sequence"].create(
                 {
-                    "name": tax.invoice_label or tax.name,
+                    "name": "Retención de Ganancias",
                     "prefix": "%(year)s-",
                     "padding": 8,
                     "number_increment": 1,
@@ -95,21 +148,9 @@ class AccountChartTemplate(models.AbstractModel):
                     "company_id": company.id,
                 }
             )
-            tax.l10n_ar_withholding_sequence_id = sequence.id
-
-        profits_domain = withholdings_domain + [("l10n_ar_tax_type", "in", ["earnings", "earnings_scale"])]
-        sequence = self.env["ir.sequence"].create(
-            {
-                "name": "Retención de Ganancias",
-                "prefix": "%(year)s-",
-                "padding": 8,
-                "number_increment": 1,
-                "implementation": "standard",
-                "company_id": company.id,
-            }
-        )
-        profits_taxes = self.env["account.tax"].with_context(active_test=False).search(profits_domain)
-        profits_taxes.l10n_ar_withholding_sequence_id = sequence.id
+            profits_taxes.filtered(
+                lambda tax: not tax.l10n_ar_withholding_sequence_id
+            ).l10n_ar_withholding_sequence_id = sequence.id
 
         # agregado de etiquetas para liquidacion de impuestos sicore
         sicore_taxes = profits_taxes
@@ -121,9 +162,11 @@ class AccountChartTemplate(models.AbstractModel):
                 tax = self.env.ref(xml_id_percep, raise_if_not_found=False)
                 if tax:
                     sicore_taxes += tax
-            self.env["account.tax.repartition.line"].search(
+            sicore_tags = self.env["account.tax.repartition.line"].search(
                 [("tax_id", "in", sicore_taxes.ids), ("repartition_type", "=", "tax")]
-            ).tag_ids = [Command.link(tag.id)]
+            )
+            sicore_tags_to_update = sicore_tags.filtered(lambda line: tag not in line.tag_ids)
+            sicore_tags_to_update.tag_ids = [Command.link(tag.id)]
 
         # agregado de etiquetas para liquidacion de impuestos pago IIBB a cuenta (sifere web)
         # consideramos de IIBB a todo lo que tiene 10n_ar_state_id
@@ -140,7 +183,9 @@ class AccountChartTemplate(models.AbstractModel):
                 ("tax_id.type_tax_use", "=", "none"),
                 ("tax_id.l10n_ar_withholding_payment_type", "=", "customer"),
             ]
-            self.env["account.tax.repartition.line"].search(domain).tag_ids = [Command.link(tag.id)]
+            repartition_lines = self.env["account.tax.repartition.line"].search(domain)
+            if repartition_lines_without_tag := repartition_lines.filtered(lambda line: tag not in line.tag_ids):
+                repartition_lines_without_tag.tag_ids = [Command.link(tag.id)]
 
     def _load(self, template_code, company, install_demo, force_create=True):
         """Luego de que creen los impuestos del archivo account.tax-ar_ri.csv de l10n_ar al instalar el plan de cuentas en la nueva compañìa argentina agregamos en este método las etiquetas que correspondan en los repartition lines."""


### PR DESCRIPTION
El hook _l10n_ar_update_taxes NO se termina corriendo para bases que migran a 18 (por más que sea un módulo nuevo no se termina corriendo porque el un módulo renombrado), por lo que creamos el ul "[RET18] Etiquetas y secuencias en impuestos" (id: 2241) para que se termine corriendo. Pero el hook termina asignando secuencia y etiquetas a los impuestos de retención de ganancias y no queremos que eso suceda cuando se trata de una migración porque el upgrade line "✏️[RET18] Migración retenciones de  Ganancias" (id: 1415) crea los impuestos de retención de ganancias con sus respectivas secuencias y etiquetas entonces por eso tenemos que hacer el ajuste de este commit para que no se vuelva a pisar la secuencia de retención de ganancias y las etiquetas.
Ticket: 111529