### PR TITLE
[FIX] l10n_ar_tax: interacion with pay pro and foreign currency

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -144,13 +144,24 @@ class AccountPayment(models.Model):
             sign = -1
 
         conversion_rate = self.exchange_rate or 1.0
+        # Cuando el pago es en moneda extranjera, las retenciones se calculan en moneda de la compañía (ARS).
+        # Usamos moneda de la compañía en las move lines de retención para evitar que _inverse_amount_currency
+        # recalcule el balance a partir de un amount_currency redondeado en moneda extranjera, lo que produce
+        # diferencias de redondeo (ej: 84,894.75 ARS -> 60 USD -> 84,900 ARS en el roundtrip).
+        use_company_currency = self.currency_id != self.company_id.currency_id
+
         for line in self.l10n_ar_withholding_line_ids:
             # nuestro approach esta quedando distinto al del wizard. En nuestras lineas tenemos los importes en moneda
             # de la cia, por lo cual el line.amount aca representa eso y tenemos que convertirlo para el amount_currency
 
             __, account_id, tax_repartition_line_id, __ = line._tax_compute_all_helper()
             balance = self.company_id.currency_id.round(sign * line.amount)
-            amount_currency = self.currency_id.round(balance / conversion_rate)
+            if use_company_currency:
+                amount_currency = balance
+                currency_id = self.company_id.currency_id.id
+            else:
+                amount_currency = self.currency_id.round(balance / conversion_rate)
+                currency_id = self.currency_id.id
             res.append(
                 {
                     **self._get_withholding_move_line_default_values(),
@@ -158,7 +169,7 @@ class AccountPayment(models.Model):
                     "account_id": account_id,
                     "balance": balance,
                     "amount_currency": amount_currency,
-                    "currency_id": self.currency_id.id,
+                    "currency_id": currency_id,
                     "tax_base_amount": sign * line.base_amount,
                     "tax_repartition_line_id": tax_repartition_line_id,
                 }
@@ -169,8 +180,13 @@ class AccountPayment(models.Model):
             nice_base_label = ",".join(withholding_lines.filtered("name").mapped("name"))
             account_id = self.company_id.l10n_ar_tax_base_account_id.id
             balance = self.company_id.currency_id.round(sign * base_amount)
-            # informamos el amount_currency para que Odoo no resetee el balance a 0.0 por inconsistencia de moneda
-            amount_currency = self.currency_id.round(balance / conversion_rate)
+            if use_company_currency:
+                amount_currency = balance
+                currency_id = self.company_id.currency_id.id
+            else:
+                # informamos el amount_currency para que Odoo no resetee el balance a 0.0 por inconsistencia de moneda
+                amount_currency = self.currency_id.round(balance / conversion_rate)
+                currency_id = self.currency_id.id
             res.append(
                 {
                     **self._get_withholding_move_line_default_values(),
@@ -179,7 +195,7 @@ class AccountPayment(models.Model):
                     "account_id": account_id,
                     "balance": balance,
                     "amount_currency": amount_currency,
-                    "currency_id": self.currency_id.id,
+                    "currency_id": currency_id,
                 }
             )
             res.append(
@@ -189,7 +205,7 @@ class AccountPayment(models.Model):
                     "account_id": account_id,
                     "balance": -balance,
                     "amount_currency": -amount_currency,
-                    "currency_id": self.currency_id.id,
+                    "currency_id": currency_id,
                 }
             )
 
@@ -204,12 +220,33 @@ class AccountPayment(models.Model):
 
         if wth_lines:
             wth_balance = sum(line["balance"] for line in wth_lines)
-            wth_amount_currency = sum(line["amount_currency"] for line in wth_lines)
+            # Suma directa de amount_currency de las líneas de retención. Cuando el pago es en moneda
+            # extranjera, las withholding lines usan moneda de compañía (ARS) y por lo tanto este valor
+            # está en ARS. Lo usamos para revertir el ajuste que hizo base Odoo sobre la liquidez.
+            raw_wth_amount_currency = sum(line["amount_currency"] for line in wth_lines)
+
+            # Para ajustar la contrapartida necesitamos el equivalente en moneda del pago.
+            # Cuando el pago es en moneda extranjera, lo convertimos; si no, es el mismo valor.
+            if self.currency_id != self.company_id.currency_id:
+                conversion_rate = self.exchange_rate or 1.0
+                wth_amount_currency_pay = self.currency_id.round(wth_balance / conversion_rate)
+            else:
+                wth_amount_currency_pay = raw_wth_amount_currency
+
+            # Cuando force_amount_company_currency está activo, account_payment_pro ya estableció el balance
+            # correcto en la línea de liquidez (monto neto de retenciones) y ajustó la contrapartida para que
+            # el asiento cuadre. Si aquí volvemos a sumar/restar wth_balance sobre los balances, se produce un
+            # doble ajuste que rompe los importes en moneda de compañía. Por eso, solo ajustamos los balances
+            # cuando NO hay monto forzado.
+            has_forced_amount = bool(self.force_amount_company_currency)
 
             liquidity_lines = res.get("liquidity_lines", [])
             if liquidity_lines:
-                liquidity_lines[0]["balance"] += wth_balance
-                liquidity_lines[0]["amount_currency"] += wth_amount_currency
+                if not has_forced_amount:
+                    liquidity_lines[0]["balance"] += wth_balance
+                # Revertimos el ajuste de amount_currency que hizo base Odoo (usó raw_wth_amount_currency
+                # para restarlo de la liquidez).
+                liquidity_lines[0]["amount_currency"] += raw_wth_amount_currency
                 # if after adjustment the liquidity line is 0, we remove it
                 # esto podria ir a payment_pro y que cualquier liquidity line en zero no se cree (Es para caso de
                 # puro write off y/o solo retenciones)
@@ -219,12 +256,15 @@ class AccountPayment(models.Model):
             counterpart_lines = res.get("counterpart_lines", [])
             if counterpart_lines:
                 # the counterpart line (debt) should be the gross amount (net + withholdings)
-                counterpart_lines[0]["balance"] -= wth_balance
+                if not has_forced_amount:
+                    counterpart_lines[0]["balance"] -= wth_balance
                 # Solo sumo el valor de la retencion si no uso moneda de contrpartida
                 # porque sino ya esta incluido el total en el campo amount_currency
                 # Porque lo cambio Payment pro
                 if not self._use_counterpart_currency():
-                    counterpart_lines[0]["amount_currency"] -= wth_amount_currency
+                    # Usamos el equivalente en moneda del pago (no la suma raw) para que el
+                    # amount_currency de la contrapartida quede correctamente en la moneda del pago.
+                    counterpart_lines[0]["amount_currency"] -= wth_amount_currency_pay
 
         return res
 

--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -10,6 +10,272 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
             [("company_id", "=", self.company_ri.id), ("type", "=", "bank")], limit=1
         )
 
+    def test_force_amount_company_currency_with_withholdings(self):
+        """Test that when paying a foreign currency vendor bill with withholdings and a forced
+        company currency amount, the journal entry lines are correctly computed.
+
+        Bug scenario: when force_amount_company_currency is set, the withholding adjustment in
+        l10n_ar_tax was double-adjusting the balance of liquidity and counterpart lines, because
+        account_payment_pro had already set the correct forced balance.
+
+        Expected behavior:
+        - Liquidity line balance must equal the forced amount (not payment_total).
+        - Counterpart line balance must equal the payment_total (to cancel the original debt).
+        - Withholding lines keep their own balance untouched.
+        """
+        # 1. Set up USD currency with a known rate (1 USD = 100 ARS)
+        usd = self.other_currency  # already set up in TestArWithholdingArRi with rates
+
+        # Create a bank journal in USD for the payment
+        usd_bank_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank USD Test",
+                "type": "bank",
+                "code": "BUSD",
+                "company_id": self.company_ri.id,
+                "currency_id": usd.id,
+            }
+        )
+
+        # 2. Create a vendor bill in USD
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.env.ref("l10n_ar_tax.res_partner_adhoc_caba").id,
+                "move_type": "in_invoice",
+                "company_id": self.company_ri.id,
+                "currency_id": usd.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 1000,
+                        }
+                    ),
+                ],
+                "invoice_date": self.today,
+                "l10n_latam_document_number": "1-100",
+            }
+        )
+        invoice.action_post()
+
+        # 3. Create fiscal position with IIBB CABA withholding for this partner
+        fiscal_pos = self.env["account.fiscal.position"].create(
+            {
+                "name": "IIBB CABA FC",
+                "l10n_ar_afip_responsibility_type_ids": [(6, 0, [self.env.ref("l10n_ar.res_IVARI").id])],
+                "sequence": 10,
+                "auto_apply": True,
+                "country_id": self.env.ref("base.ar").id,
+                "company_id": self.company_ri.id,
+                "state_ids": [(6, 0, [self.env.ref("base.state_ar_c").id])],
+            }
+        )
+        self.env["account.fiscal.position.l10n_ar_tax"].create(
+            {
+                "fiscal_position_id": fiscal_pos.id,
+                "default_tax_id": self.tax_wth_test_1.id,
+                "tax_type": "withholding",
+            }
+        )
+
+        # 4. Create payment from the invoice
+        action_context = invoice.action_register_payment()["context"]
+        payment = (
+            self.env["account.payment"]
+            .with_context(**action_context)
+            .create(
+                {
+                    "journal_id": usd_bank_journal.id,
+                    "amount": invoice.amount_total,
+                    "date": self.today,
+                }
+            )
+        )
+
+        # Verify withholdings were computed
+        self.assertTrue(payment.l10n_ar_withholding_line_ids, "Withholdings should have been computed")
+        withholding_amount = payment.withholdings_amount
+        self.assertGreater(withholding_amount, 0, "Withholding amount should be positive")
+
+        # 5. Set force_amount_company_currency to simulate the user forcing a rounded amount
+        # The forced amount is slightly different from the computed conversion to simulate rounding adjustment
+        normal_amount_company_currency = payment.amount_company_currency
+        forced_amount = normal_amount_company_currency - 1  # simulate a small rounding difference
+        payment.force_amount_company_currency = forced_amount
+
+        # 6. Generate journal entry and post to materialize the move lines
+        payment.action_post()
+
+        self.assertTrue(payment.move_id, "Payment should have a journal entry after posting")
+
+        liquidity_line = payment.move_id.line_ids.filtered(lambda l: l.account_id == payment.outstanding_account_id)
+        counterpart_line = payment.move_id.line_ids.filtered(lambda l: l.account_type == "liability_payable")
+        withholding_tax_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+
+        # 7. CRITICAL ASSERTIONS:
+        # The liquidity line balance must reflect the forced amount, NOT the payment_total
+        self.assertAlmostEqual(
+            abs(liquidity_line.balance),
+            forced_amount,
+            places=2,
+            msg="Liquidity line balance should equal the forced company currency amount, "
+            "not the payment total. This was the main bug: the withholding adjustment "
+            "was overwriting the forced amount.",
+        )
+
+        # The liquidity line balance must NOT equal payment_total (which includes withholdings)
+        self.assertNotAlmostEqual(
+            abs(liquidity_line.balance),
+            payment.payment_total,
+            places=2,
+            msg="Liquidity line balance should NOT equal payment_total when force amount is set",
+        )
+
+        # The counterpart (payable) line must equal liquidity + withholdings (journal entry balances to 0)
+        expected_counterpart = forced_amount + withholding_amount
+        self.assertAlmostEqual(
+            abs(counterpart_line.balance),
+            expected_counterpart,
+            places=2,
+            msg="Counterpart line balance should equal liquidity + withholdings "
+            "(the journal entry must balance to zero).",
+        )
+
+        # Withholding lines should have the correct amount
+        total_withholding_balance = abs(sum(withholding_tax_lines.mapped("balance")))
+        self.assertAlmostEqual(
+            total_withholding_balance,
+            withholding_amount,
+            places=2,
+            msg="Withholding lines balance should match the computed withholdings amount",
+        )
+
+    def test_foreign_currency_withholding_balance_precision(self):
+        """Test that withholding lines in a foreign currency payment preserve the exact ARS balance
+        without rounding errors caused by the USD → ARS roundtrip.
+
+        Bug scenario: withholding lines were created with currency_id=USD and amount_currency
+        rounded to USD precision. Then _inverse_amount_currency recalculated balance from the
+        rounded USD amount, producing a different ARS balance (e.g. 84,894.75 → 60 USD → 84,900).
+
+        Expected behavior:
+        - Withholding line balance must be the exact ARS amount (no rounding loss).
+        - No automatic balancing line should be needed for the rounding difference.
+        - Withholding lines should use company currency (ARS) when payment is in foreign currency.
+        """
+        usd = self.other_currency
+
+        usd_bank_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank USD Test 2",
+                "type": "bank",
+                "code": "BUS2",
+                "company_id": self.company_ri.id,
+                "currency_id": usd.id,
+            }
+        )
+
+        # Create vendor bill in USD
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.env.ref("l10n_ar_tax.res_partner_adhoc_caba").id,
+                "move_type": "in_invoice",
+                "company_id": self.company_ri.id,
+                "currency_id": usd.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 500,
+                        }
+                    ),
+                ],
+                "invoice_date": self.today,
+                "l10n_latam_document_number": "1-200",
+            }
+        )
+        invoice.action_post()
+
+        # Create fiscal position with withholding
+        fiscal_pos = self.env["account.fiscal.position"].create(
+            {
+                "name": "IIBB CABA FC Rounding",
+                "l10n_ar_afip_responsibility_type_ids": [(6, 0, [self.env.ref("l10n_ar.res_IVARI").id])],
+                "sequence": 10,
+                "auto_apply": True,
+                "country_id": self.env.ref("base.ar").id,
+                "company_id": self.company_ri.id,
+                "state_ids": [(6, 0, [self.env.ref("base.state_ar_c").id])],
+            }
+        )
+        self.env["account.fiscal.position.l10n_ar_tax"].create(
+            {
+                "fiscal_position_id": fiscal_pos.id,
+                "default_tax_id": self.tax_wth_test_1.id,
+                "tax_type": "withholding",
+            }
+        )
+
+        # Create payment WITHOUT force_amount_company_currency
+        action_context = invoice.action_register_payment()["context"]
+        payment = (
+            self.env["account.payment"]
+            .with_context(**action_context)
+            .create(
+                {
+                    "journal_id": usd_bank_journal.id,
+                    "amount": invoice.amount_total,
+                    "date": self.today,
+                }
+            )
+        )
+
+        self.assertTrue(payment.l10n_ar_withholding_line_ids, "Withholdings should have been computed")
+        withholding_amount = payment.withholdings_amount
+        self.assertGreater(withholding_amount, 0)
+
+        # Verify there is no force_amount_company_currency
+        self.assertFalse(payment.force_amount_company_currency)
+
+        # Post the payment to generate the journal entry with move lines
+        payment.action_post()
+
+        self.assertTrue(payment.move_id, "Payment should have a journal entry after posting")
+
+        withholding_tax_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+
+        # CRITICAL: the withholding balance must be exactly the ARS amount, not a rounded USD→ARS roundtrip
+        total_withholding_balance = abs(sum(withholding_tax_lines.mapped("balance")))
+        self.assertAlmostEqual(
+            total_withholding_balance,
+            withholding_amount,
+            places=2,
+            msg="Withholding balance must exactly match the computed ARS amount. "
+            "Before the fix, _inverse_amount_currency would recalculate balance from "
+            "a rounded USD amount, producing a different value.",
+        )
+
+        # Verify withholding lines use company currency (ARS) when payment is in foreign currency
+        for wth_line in withholding_tax_lines:
+            self.assertEqual(
+                wth_line.currency_id,
+                payment.company_id.currency_id,
+                "Withholding move lines should use company currency (ARS) "
+                "when the payment is in foreign currency to avoid rounding issues.",
+            )
+
+        # Verify no automatic balancing line was needed
+        auto_balance_lines = payment.move_id.line_ids.filtered(
+            lambda l: "Automatic Balancing" in (l.name or "") or "automatic balancing" in (l.name or "").lower()
+        )
+        self.assertFalse(
+            auto_balance_lines,
+            "No automatic balancing line should be needed when withholding "
+            "balances are exact (no rounding loss from currency conversion).",
+        )
+
     def test_create_vendor_payment_with_receiptbook_and_withholdings(self):
         """1. Create vendor bill for CABA partner and post.
         2. Create IIBB CABA fiscal position for company '(AR) Responsable Inscripto (Unit Tests)' with CABA withholding tax.


### PR DESCRIPTION
Se corrigen dos bugs relacionados en la generación del asiento contable de pagos en moneda extranjera cuando hay retenciones argentinas:

1. Líneas de retención con balance incorrecto por redondeo (roundtrip): Las withholding lines se creaban con currency_id=USD y amount_currency redondeado a precisión USD. Luego _inverse_amount_currency de Odoo recalculaba el balance desde ese USD redondeado, produciendo un valor distinto al original en ARS (ej: 84,894.75 → 60 USD → 84,900 ARS). Esto generaba una "Automatic Balancing Line" espuria.

   Fix: cuando el pago es en moneda extranjera, las líneas de retención (impuesto, base y contrapartida de base) ahora usan moneda de compañía (ARS) con amount_currency=balance, evitando el roundtrip destructivo.

2. Doble ajuste de balance con force_amount_company_currency: Cuando el usuario forzaba el monto en moneda de compañía (campo custom para ajustes de redondeo), account_payment_pro ya establecía el balance correcto en liquidez/contrapartida. Luego l10n_ar_tax volvía a sumar/ restar el wth_balance, duplicando el ajuste. Resultado: la línea de banco tomaba el payment_total en vez del monto forzado, y la contrapartida se inflaba con retenciones sumadas dos veces.

   Fix: se condicionan los ajustes de balance en _prepare_move_lines_per_type a que NO exista force_amount_company_currency (has_forced_amount).

Adicionalmente se ajusta _prepare_move_lines_per_type para manejar correctamente que las withholding lines ahora pueden estar en moneda distinta a la del pago: se usa raw_wth_amount_currency para revertir el ajuste de liquidez y wth_amount_currency_pay (convertido) para la contrapartida.

Se agregan dos tests:
- test_force_amount_company_currency_with_withholdings
- test_foreign_currency_withholding_balance_precision