### PR TITLE
[FIX] l10n_ar_tax: posición fiscal archivada al pagar a proveedor.

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -56,7 +56,8 @@ class AccountPayment(models.Model):
             rec.l10n_ar_fiscal_position_id = (
                 self.env["account.fiscal.position"]
                 .with_company(rec.company_id)
-                .with_context(l10n_ar_withholding=True)
+                # TODO revisar porque llega active_test=False acá
+                .with_context(l10n_ar_withholding=True, active_test=True)
                 ._get_fiscal_position(address)
             )
 


### PR DESCRIPTION
Video mostrando el bug en runbot adhoc 18:
https://drive.google.com/file/d/1dCjlN57u3GPFHPg2xgCHzGvVPYHWpyfv/view El fix consiste en que al hacer un pago de proveedor no se compute una posición fiscal que esté archivada.
Ticket: 112768