### PR TITLE
[FIX] l10n_ar_tax: use report_partner info in reports headers if exists

### DIFF
--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -21,7 +21,7 @@
             <t t-set="document_legend" t-value="'Doc. no válido como factura'"/>
             <t t-set="report_number" t-value="o.name"/>
             <t t-set="report_name" t-value="o.partner_type == 'supplier' and 'Orden de pago' or 'Recibo'"/>
-            <t t-set="header_address" t-value="o.company_id.partner_id"/>
+            <t t-set="header_address" t-value="o.receiptbook_id and o.receiptbook_id._fields.get('report_partner_id') and o.receiptbook_id.report_partner_id or o.company_id.partner_id"/>
 
             <t t-set="custom_footer">
                 <div class="row">


### PR DESCRIPTION
Estoy reincorporando [esta línea](https://github.com/ingadhoc/odoo-argentina/pull/821/files#diff-6ff32299860b771624486584cc51a42e295084bc15af1ff6fd964ae76a3bffebL11-L12) que elimnamos en 17 al mover de l10n_ar_ux a l10n_ar_withholding_ux. Ahí tomaba en cuenta los valores del contacto de reporte para las facturas. 