### PR TITLE
[IMP] l10n_ar_tax: hacemos almacenado el campo withholding_id en account.move.line

### DIFF
--- a/l10n_ar_tax/models/account_move_line.py
+++ b/l10n_ar_tax/models/account_move_line.py
@@ -1,11 +1,12 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    withholding_id = fields.Many2one("l10n_ar.payment.withholding", compute="_compute_withholding")
+    withholding_id = fields.Many2one("l10n_ar.payment.withholding", compute="_compute_withholding", store=True)
 
+    @api.depends("tax_line_id", "payment_id.l10n_ar_withholding_line_ids.tax_id")
     def _compute_withholding(self):
         for rec in self:
             if rec.tax_line_id and rec.payment_id:


### PR DESCRIPTION
Tarea: 65064

Esto lo necesitamos para poder hacer que el tax report de iibb de arba en la sección "Purchase Withholdings A-122R not reported via ARBA webservice" solo muestre las retenciones que no fueron informadas vía webservice, y para eso withholding_id tiene que sea almacenada para agregarlo en el domain_formula.