### PR TITLE
[FIX] l10n_ar_tax: resolve parent context error in payment withholding domain

### DIFF
--- a/l10n_ar_tax/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax/models/l10n_ar_payment_withholding.py
@@ -9,6 +9,7 @@ class l10nArPaymentWithholding(models.Model):
 
     payment_id = fields.Many2one("account.payment", required=True, ondelete="cascade")
     company_id = fields.Many2one(related="payment_id.company_id")
+    partner_type = fields.Selection(related="payment_id.partner_type")
     currency_id = fields.Many2one(related="payment_id.company_currency_id")
     l10n_ar_tax_type = fields.Selection(related="tax_id.l10n_ar_tax_type")
     name = fields.Char(string="Number")
@@ -32,7 +33,7 @@ class l10nArPaymentWithholding(models.Model):
     def _compute_base_amount(self):
         """practicamente mismo codigo que en l10n_ar.payment.register.withholding pero usamos campos "selected_debt_"""
         self.payment_id._compute_to_pay_amount()
-        for wth in self.filtered(lambda x: x.payment_id.partner_type == "supplier"):
+        for wth in self.filtered(lambda x: x.partner_type == "supplier"):
             # calculamos advance_amount
             # si el adelanto es negativo estamos pagando parcialmente una
             # factura y ocultamos el campo sin impuesto y el metodo _get_withholdable_advanced_amount nos devuelve
@@ -171,7 +172,7 @@ class l10nArPaymentWithholding(models.Model):
 
     @api.depends("base_amount", "tax_id")
     def _compute_amount(self):
-        for line in self.filtered(lambda r: r.payment_id.partner_type == "supplier"):
+        for line in self.filtered(lambda r: r.partner_type == "supplier"):
             # TODO: usar _get_withholding_tax no deberia ser necesario
             # si al pasar a draft modificamos la linea
             tax_id = line._get_withholding_tax()

--- a/l10n_ar_tax/views/l10n_ar_payment_withholding_views.xml
+++ b/l10n_ar_tax/views/l10n_ar_payment_withholding_views.xml
@@ -11,7 +11,7 @@
                             <field name="withholding_sequence_id" invisible="True"/>
                             <field name="company_id" invisible="True"/>
                             <field name="currency_id" invisible="True"/>
-                            <field name="tax_id" domain="[('l10n_ar_withholding_payment_type', '=', parent.partner_type), ('company_id', 'parent_of', parent.company_id)]" options="{'no_open': True, 'no_create': True}"/>
+                            <field name="tax_id" domain="[('l10n_ar_withholding_payment_type', '=', partner_type), ('company_id', '=', company_id)]" options="{'no_open': True, 'no_create': True}"/>
                             <field name="name" readonly="withholding_sequence_id"/>
                             <field name="base_amount"/>
                             <field name="amount"/>
@@ -25,7 +25,7 @@
         <field name="name">l10n_ar.payment.withholding.tree</field>
         <field name="model">l10n_ar.payment.withholding</field>
         <field name="arch" type="xml">
-            <list>
+            <list create="false">
                 <field name="payment_id"/>
                 <field name="withholding_sequence_id"/>
                 <field name="company_id" column_invisible="True"/>


### PR DESCRIPTION


The standalone form view for l10n_ar.payment.withholding was using `parent.partner_type` and `parent.company_id` in the tax_id domain, which fails when the form is opened as a dialog since `parent` is not defined in that context.

Added `partner_type` as a related field on the model (via `payment_id.partner_type`) so the domain can reference it directly without relying on `parent`.

Updated the form view domain to use `partner_type` and `company_id` instead of `parent.partner_type` and `parent.company_id`.