### PR TITLE
[IMP] l10n_ar_tax: padrón Santa Fe, subir archivo comprimido zip

### DIFF
--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import logging
 import os
 import re
@@ -85,23 +86,16 @@ class ResCompanyJurisdictionPadron(models.Model):
         self.ensure_one()
         return self.state_id and self.state_id.jurisdiction_code == "921"
 
-    def _read_parp_from_binary(self, cuit):
-        """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
-        PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (aliquot_ret, aliquot_per)
-        """
+    def _read_parp_lines(self, lines, cuit):
         aliquot_ret = False
         aliquot_per = False
         is_in_padron = False
-        # Decode binary field to bytes
-        file_content = base64.b64decode(self.file_padron)
-        # Convert bytes to string
-        csv_text = file_content.decode("latin-1")
-        # Split by lines and process
-        for line in csv_text.split("\n"):
+        for line in lines:
             if not line:
                 continue
-            values = line.split(";")
+            values = [value.strip() for value in line.split(";")]
+            if len(values) <= 8:
+                continue
             # CUIT is at index 3, compare as strings
             if values[3] == cuit:
                 # Percepción at index 7, Retención at index 8
@@ -111,6 +105,38 @@ class ResCompanyJurisdictionPadron(models.Model):
                 is_in_padron = True
                 break
         return is_in_padron, aliquot_ret, aliquot_per
+
+    def _find_parp_file(self, rootdir):
+        fallback_match = False
+        for subdir, dirs, files in os.walk(rootdir):
+            for filename in files:
+                lower_filename = filename.lower()
+                if lower_filename.endswith((".csv", ".txt")):
+                    if "parp" in lower_filename:
+                        return os.path.join(subdir, filename)
+                    if not fallback_match:
+                        fallback_match = os.path.join(subdir, filename)
+        return fallback_match
+
+    def _read_parp_from_binary(self, cuit):
+        """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
+        or from ZIP if the binary is a ZIP file.
+        PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
+        Returns: (aliquot_ret, aliquot_per)
+        """
+        file_content = base64.b64decode(self.file_padron)
+        # is a ZIP file
+        if zipfile.is_zipfile(io.BytesIO(file_content)):
+            self.descompress_file(self.file_padron)
+            path_file = self._find_parp_file("/tmp/")
+            if not path_file:
+                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+            with open(path_file, encoding="latin-1") as fp:
+                return self._read_parp_lines(fp.readlines(), cuit)
+
+        # is a CSV file directly
+        csv_text = file_content.decode("latin-1")
+        return self._read_parp_lines(csv_text.split("\n"), cuit)
 
     def find_file(self, rootdir, type_code):
         res = False

--- a/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
+++ b/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
@@ -40,7 +40,7 @@
                             <li>ARBA: por lo general no es necesario cargarlo aquí ya que las alícuotas se obtienen automáticamente mediante webservice.
                                 Si igualmente desea cargarlo, debe subir el archivo zip que descarga de arba y que tiene nombre de forma "PadronRGSMMAAAA.zip"
                             </li>
-                            <li>Santa Fe: debe subir el archivo con formato csv que descarga del padrón PARP (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API y que tiene nombre de forma "PARP_999999.csv"
+                            <li>Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API y que tiene nombre de forma "PARP_999999.zip"
                             </li>
                         </ul>
                     </p>


### PR DESCRIPTION
Tarea: 65847
Permitimos subir archivo comprimido zip para cargar el padrón de Santa Fe, el objetivo es que al ser comprimido ocupe menos espacio que un archivo csv en base de datos. El proceso de carga es el mismo que el utilizado para los archivos csv, pero ahora se descomprime el archivo zip y se procesa el contenido. Por ahora también permitimos subir archivos csv, pero la idea es que a futuro solo se permita subir archivos zip.