### PR TITLE
[FIX] l10n_ar_tax: fix receive en suppliers, send on customers

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-01 20:27+0000\n"
-"PO-Revision-Date: 2025-11-05 21:15+0000\n"
+"POT-Creation-Date: 2026-04-07 15:02+0000\n"
+"PO-Revision-Date: 2026-04-07 15:02+0000\n"
 "Last-Translator: ADHOC - Bot <transbot@adhoc.com.ar>, 2025\n"
 "Language-Team: Spanish (https://app.transifex.com/adhoc/teams/46451/es/)\n"
 "Language: es\n"
@@ -24,17 +24,17 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
 msgid "%s | CUIT %s not present on padron ARBA"
-msgstr ""
+msgstr "%s | CUIT %s no presente en el padrón ARBA"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.arba_alicout_query
 msgid "&lt;?xml version = \"1.0\" encoding = \"utf-8\"?&gt;"
-msgstr ""
+msgstr "&lt;?xml version = \"1.0\" encoding = \"utf-8\"?&gt;"
 
 #. module: l10n_ar_tax
 #: model:ir.actions.report,print_report_name:l10n_ar_tax.action_report_withholding_certificate
 msgid "'Certificado de Retención Slip - %s' % (object.name or '')"
-msgstr ""
+msgstr "'Certificado de Retención - %s' % (object.name or '')"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -44,7 +44,7 @@ msgstr "(Chequera electrónica)"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
 msgid "(del excedente"
-msgstr ""
+msgstr "(del excedente"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
@@ -61,13 +61,13 @@ msgstr "- Venc."
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "- Santander Rio"
-msgstr ""
+msgstr "- Santander Río"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__001
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__001
 msgid "001: Art. 5º 1er. párrafo (Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "001: Art. 5º 1er. párrafo (Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__001
@@ -78,7 +78,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__002
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__002
 msgid "002: Art. 5º inciso 1)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "002: Art. 5º inciso 1)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__002
@@ -89,7 +89,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__003
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__003
 msgid "003: Art. 5° inciso 2)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "003: Art. 5° inciso 2)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__003
@@ -100,7 +100,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__004
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__004
 msgid "004: Art. 5º inciso 4)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "004: Art. 5º inciso 4)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__004
@@ -111,7 +111,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__005
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__005
 msgid "005: Art. 5° inciso 5)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "005: Art. 5° inciso 5)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__005
@@ -122,7 +122,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__006
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__006
 msgid "006: Art. 6º inciso a)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "006: Art. 6º inciso a)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__006
@@ -133,7 +133,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__007
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__007
 msgid "007: Art. 6º inciso b)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "007: Art. 6º inciso b)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__007
@@ -144,7 +144,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__008
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__008
 msgid "008: Art. 6º inciso c)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "008: Art. 6º inciso c)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__008
@@ -155,7 +155,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_percepcion__009
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_articulo_inciso_calculo_retencion__009
 msgid "009: Art. 12º)(Res. Gral. 15/97 y Modif.)"
-msgstr ""
+msgstr "009: Art. 12º)(Res. Gral. 15/97 y Modif.)"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__api_codigo_articulo_retencion__009
@@ -399,13 +399,13 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax_group__l10n_ar_tribute_afip_code__06
 msgid "06 - VAT perception or Withholding"
-msgstr ""
+msgstr "06 - Percepción de IVA"
 
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
 msgid "404 Not Found error."
-msgstr ""
+msgstr "Error 404: No encontrado."
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -430,7 +430,7 @@ msgstr "<span>Fecha Venc.</span>"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "<span>Importe</span>"
-msgstr ""
+msgstr "<span>Importe</span>"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -480,7 +480,7 @@ msgstr "<strong>Cliente: </strong>"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_withholding_certificate_document
 msgid "<strong>Datos de la retención practicada</strong>"
-msgstr ""
+msgstr "<strong>Datos de la retención practicada</strong>"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -499,12 +499,12 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__webservice__agip
 msgid "AGIP (Regimen General)"
-msgstr ""
+msgstr "AGIP (Régimen General)"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
 msgid "API"
-msgstr ""
+msgstr "API"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_tax_search
@@ -520,33 +520,30 @@ msgstr "AR Retención de Proveedor"
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__webservice__arba
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.res_config_settings_view_form
 msgid "ARBA"
-msgstr ""
+msgstr "ARBA"
 
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/res_company.py:0
 msgid "ARBA Error %s(%s): %s"
-msgstr ""
+msgstr "Error ARBA %s(%s): %s"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
 msgid ""
-"ARBA: por lo general no es necesario cargarlo aquí ya que las alícuotas se "
-"obtienen automáticamente mediante webservice.\n"
-"                                Si igualmente desea cargarlo, debe subir el "
-"archivo zip que descarga de arba y que tiene nombre de forma "
-"\"PadronRGSMMAAAA.zip\""
+"ARBA: por lo general no es necesario cargarlo aquí ya que las alícuotas se obtienen automáticamente mediante webservice.\n"
+"                                Si igualmente desea cargarlo, debe subir el archivo zip que descarga de arba y que tiene nombre de forma \"PadronRGSMMAAAA.zip\""
 msgstr ""
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Plantilla de plan contable"
+msgstr "Plantilla de plan de cuentas"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__res_partner__drei__activo
 msgid "Activo"
-msgstr ""
+msgstr "Activo"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_payment__withholdable_advanced_amount
@@ -557,17 +554,17 @@ msgstr "Ajuste / Anticipo (no gravado)"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_register_withholding__amount
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__amount
 msgid "Amount"
-msgstr "Importe"
+msgstr "Cantidad"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__webservice__padron
 msgid "Archivo de padrón"
-msgstr ""
+msgstr "Archivo de padrón"
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_l10n_ar_partner_tax
 msgid "Argentinean Partner Taxes"
-msgstr "Impuestos de contactos argentinos"
+msgstr "Impuestos argentinos del contacto"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_partner__l10n_ar_partner_perception_ids
@@ -579,40 +576,40 @@ msgstr "Impuestos de Percepción Argentinos"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_partner__l10n_ar_partner_tax_ids
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_users__l10n_ar_partner_tax_ids
 msgid "Argentinean Withholding Taxes"
-msgstr "Impuestos de Retención Argentinos"
+msgstr "Impuestos de retención de Argentina"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__api_articulo_inciso_calculo_percepcion
 msgid "Artículo/Inciso para el cálculo percepción"
-msgstr ""
+msgstr "Artículo/Inciso para el cálculo percepción"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__api_articulo_inciso_calculo_retencion
 msgid "Artículo/Inciso para el cálculo retención"
-msgstr ""
+msgstr "Artículo/Inciso para el cálculo retención"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_register_withholding__base_amount
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__base_amount
 msgid "Base Amount"
-msgstr "Importe Base"
+msgstr "Cantidad base"
 
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_payment.py:0
 msgid "Base Ret Cont: "
-msgstr ""
+msgstr "Base Ret Cont: "
 
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_payment.py:0
 msgid "Base Ret: "
-msgstr ""
+msgstr "Base Ret: "
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
 msgid "Base imponible del pago excedente"
-msgstr ""
+msgstr "Base imponible del pago excedente"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_config_settings__arba_cit
@@ -637,7 +634,7 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_res_company
 msgid "Companies"
-msgstr "Compañías"
+msgstr "Empresas"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__company_id
@@ -688,7 +685,7 @@ msgstr "Creado el"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__company_currency_id
 msgid "Currency"
-msgstr ""
+msgstr "Moneda"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -749,15 +746,16 @@ msgstr ""
 msgid ""
 "El contacto '%(name)s' (id: %(id)s) tiene múltiples impuestos vigentes para "
 "el grupo de impuestos '%(tax_group)s' en la fecha '%(date)s' y compañía "
-"'%(company)s'. Ver solapa 'Contabilidad' de la vista formulario del contacto."
+"'%(company)s'. Ver solapa 'Contabilidad' de la vista formulario del "
+"contacto."
 msgstr ""
 
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/l10n_ar_payment_withholding.py:0
 msgid ""
-"El impuesto de retención %s no tiene un tipo de cálculo definido. Por favor, "
-"defina el tipo de cálculo en la configuración del impuesto."
+"El impuesto de retención %s no tiene un tipo de cálculo definido. Por favor,"
+" defina el tipo de cálculo en la configuración del impuesto."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -812,7 +810,7 @@ msgstr "Archivo"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__filename
 msgid "File Name"
-msgstr ""
+msgstr "Nombre de Archivo"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_withholding_certificate_document
@@ -860,14 +858,14 @@ msgid ""
 "If no sequence provided then it will be required for you to enter "
 "withholding number when registering one."
 msgstr ""
-"Si no se proporciona una secuencia, será necesario ingresar el número de "
-"retención al registrar una."
+"Si no se ingresa ninguna secuencia, se le pedirá ingresar un número de "
+"retención al registrar uno."
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_payment_minimum_threshold
 msgid ""
-"If the amount of each payment does not exceed this value, the withholding/"
-"perception is not applied."
+"If the amount of each payment does not exceed this value, the "
+"withholding/perception is not applied."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -876,6 +874,8 @@ msgid ""
 "If the calculated withholding/perception amount is lower than this "
 "threshold, it is 0.0."
 msgstr ""
+"Si el monto de retención calculado es más chico que el importe mínimo de "
+"retención entonces el monto de retención es 0.0."
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_base_minimum_threshold
@@ -922,7 +922,7 @@ msgstr "Jurisdicción"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position__l10n_ar_tax_ids
 msgid "L10N Ar Tax"
-msgstr ""
+msgstr "Impuestos Argentina"
 
 #. module: l10n_ar_tax
 #. odoo-python
@@ -952,17 +952,17 @@ msgstr "Importe Conciliado No Gravado"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_base_minimum_threshold
 msgid "Minimum Base"
-msgstr ""
+msgstr "Base Mínima"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_payment_minimum_threshold
 msgid "Minimum Payment"
-msgstr ""
+msgstr "Pago Mínimo"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_minimum_threshold
 msgid "Minimum Threshold"
-msgstr ""
+msgstr "Retención mínima"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__res_partner__drei__no_activo
@@ -985,13 +985,10 @@ msgid ""
 "No pudimos obtener la alicuota del webservice de rentascordoba.\n"
 "\n"
 "Para asignar la alícuota de Córdoba a un contacto, siga estos pasos:\n"
-"1) Consulte la alícuota del contacto en: https://www.rentascordoba.gob.ar/"
-"gestiones/consulta-alicuota\n"
-"2) Cree manualmente la alícuota en la vista formulario del Contacto (solapa "
-"'Contabilidad').\n"
+"1) Consulte la alícuota del contacto en: https://www.rentascordoba.gob.ar/gestiones/consulta-alicuota\n"
+"2) Cree manualmente la alícuota en la vista formulario del Contacto (solapa 'Contabilidad').\n"
 "\n"
-"En caso de dudas o si el problema persiste, comuníquese con nuestro equipo "
-"de Servicio de Asistencia.\n"
+"En caso de dudas o si el problema persiste, comuníquese con nuestro equipo de Servicio de Asistencia.\n"
 "Detalle del error:\n"
 msgstr ""
 
@@ -1005,8 +1002,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
 msgid ""
-"No se puede obtener automáticamente la alicuota para la fecha %s. Por favor, "
-"ingrese la misma manualmente en el partner."
+"No se puede obtener automáticamente la alicuota para la fecha %s. Por favor,"
+" ingrese la misma manualmente en el partner."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1019,7 +1016,7 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_non_taxable_amount
 msgid "Non Taxable Amount"
-msgstr ""
+msgstr "Monto no imponible"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__name
@@ -1061,15 +1058,14 @@ msgstr "Página: <span class=\"page\"/> / <span class=\"topage\"/>"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
 msgid ""
-"Para TXT de SIRCAR debe completar el campo regímen con el que corresponda "
-"según tabla definida por la jurisdicción.<br/>\n"
+"Para TXT de SIRCAR debe completar el campo regímen con el que corresponda según tabla definida por la jurisdicción.<br/>\n"
 "                Puede consultar la tabla"
 msgstr ""
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__partner_type
 msgid "Partner Type"
-msgstr ""
+msgstr "Tipo de Contacto"
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_account_payment_register
@@ -1084,14 +1080,12 @@ msgstr "Pago"
 #. module: l10n_ar_tax
 #: model:ir.actions.report,name:l10n_ar_tax.action_report_receipt_bundle
 msgid "Payment Receipt bundled"
-msgstr ""
+msgstr "Recibo de Pago agrupado"
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_l10n_ar_payment_register_withholding
-#, fuzzy
-#| msgid "Payment withholding lines"
 msgid "Payment register withholding lines"
-msgstr "Líneas de pago de retención"
+msgstr "Líneas de retención del registro de pago"
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_l10n_ar_payment_withholding
@@ -1127,7 +1121,7 @@ msgstr "Percepción"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_bank_statement_line__perceptions_fiscal_positon
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_move__perceptions_fiscal_positon
 msgid "Perceptions Fiscal Positon"
-msgstr ""
+msgstr "Posición Fiscal de Percepciones"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_position_form
@@ -1141,8 +1135,8 @@ msgid ""
 "Please enter withholding number for tax %s or configure a sequence on that "
 "tax"
 msgstr ""
-"Por favor ingrese un número de retención para el impuesto %s o configure una "
-"secuencia en ese impuesto"
+"Por favor ingrese un número de retención para el impuesto %s o configure una"
+" secuencia en ese impuesto"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
@@ -1167,7 +1161,7 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__ratio
 msgid "Ratio to apply to tax base amount."
-msgstr ""
+msgstr "Ratio a aplicar sobre el importe base del impuesto."
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__ref
@@ -1207,9 +1201,9 @@ msgstr "Percepciones de Venta"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
 msgid ""
-"Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP "
-"(Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API y "
-"que tiene nombre de forma \"PARP_999999.zip\""
+"Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP"
+" (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API "
+"y que tiene nombre de forma \"PARP_999999.zip\""
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1246,7 +1240,7 @@ msgstr "Impuesto"
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_account_tax_group
 msgid "Tax Group"
-msgstr ""
+msgstr "Grupo de impuestos"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position_l10n_ar_tax__tax_template_domain
@@ -1267,8 +1261,8 @@ msgstr "El código del estado."
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_tax.py:0
 msgid ""
-"The total percentage (%s) should be greater than 0 and less than or equal to "
-"100."
+"The total percentage (%s) should be greater than 0 and less than or equal to"
+" 100."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1296,7 +1290,7 @@ msgstr "Código tributo AFIP"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_non_taxable_amount
 msgid "Until this base amount, the tax is not applied."
-msgstr ""
+msgstr "Hasta este monto el impuesto no es aplicado."
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_payment__withholdable_advanced_amount
@@ -1307,7 +1301,7 @@ msgstr "Utilizado para el cálculo de retenciones"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid "WTH Sequence"
-msgstr "Secuencia de retención"
+msgstr "Secuencia de Retención"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__l10n_ar_tax_type
@@ -1317,12 +1311,12 @@ msgstr "Impuesto de Retencion"
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
 msgid "Watch previous withholdings"
-msgstr ""
+msgstr "Ver retenciones anteriores"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position_l10n_ar_tax__webservice
 msgid "Webservice"
-msgstr ""
+msgstr "Servicio Web"
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_move_line__withholding_id
@@ -1364,9 +1358,9 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_move_form
 msgid ""
-"que tiene impuestos de percepciones. Como las alicuotas podrían variar según "
-"la fecha del comprobante, cambiar la fecha o validar la factura re-computará "
-"los impuestos."
+"que tiene impuestos de percepciones. Como las alicuotas podrían variar según"
+" la fecha del comprobante, cambiar la fecha o validar la factura re-"
+"computará los impuestos."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1378,9 +1372,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.res_config_settings_view_form
 msgid "⇒ Verificar Clave ARBA"
 msgstr ""
-
-#~ msgid "<span>Amount currency</span>"
-#~ msgstr "<span>Importe divisa</span>"
-
-#~ msgid "Withholdings must be done in \"%s\" currency"
-#~ msgstr "Las retenciones deberán realizarse en la moneda \"%s\" "

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -419,7 +419,7 @@ class AccountPayment(models.Model):
             if rec.state != "posted":
                 continue
             matched_amount_untaxed = 0.0
-            sign = rec.partner_type == "supplier" and -1.0 or 1.0
+            sign = rec.payment_type == "outbound" and -1.0 or 1.0
             for line in rec.matched_move_line_ids.with_context(matched_payment_ids=rec.ids):
                 invoice = line.move_id
                 factor = invoice and invoice._get_tax_factor() or 1.0
@@ -427,7 +427,7 @@ class AccountPayment(models.Model):
                 matched_amount_untaxed += line.payment_matched_amount * factor
             rec.matched_amount_untaxed = sign * matched_amount_untaxed
 
-    @api.depends("to_pay_move_line_ids", "destination_currency_id", "company_currency_id")
+    @api.depends("to_pay_move_line_ids", "destination_currency_id", "company_currency_id", "payment_type")
     def _compute_selected_debt_untaxed(self):
         for rec in self:
             selected_debt_untaxed = 0.0
@@ -437,7 +437,7 @@ class AccountPayment(models.Model):
                     selected_debt_untaxed += line.amount_residual_currency * factor
                 else:
                     selected_debt_untaxed += line.amount_residual * factor
-            rec.selected_debt_untaxed = selected_debt_untaxed * (-1.0 if rec.partner_type == "supplier" else 1.0)
+            rec.selected_debt_untaxed = selected_debt_untaxed * (-1.0 if rec.payment_type == "outbound" else 1.0)
 
     @api.depends("unreconciled_amount")
     def _compute_withholdable_advanced_amount(self):

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -20,7 +20,7 @@
             <t t-set="document_letter" t-value="'X'"/>
             <t t-set="document_legend" t-value="'Doc. no válido como factura'"/>
             <t t-set="report_number" t-value="o.name"/>
-            <t t-set="report_name" t-value="o.partner_type == 'supplier' and 'Orden de pago' or 'Recibo'"/>
+            <t t-set="report_name" t-value="o.payment_type == 'outbound' and 'Orden de pago' or 'Recibo'"/>
             <t t-set="header_address" t-value="o.receiptbook_id and o.receiptbook_id._fields.get('report_partner_id') and o.receiptbook_id.report_partner_id or o.company_id.partner_id"/>
 
             <t t-set="custom_footer">
@@ -208,11 +208,11 @@
                             </td>
                             <td class="text-right o_price_total">
                                 <!-- Original amount in the line's currency (= B for invoice lines) -->
-                                <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
                             </td>
                             <td class="text-right o_price_total">
                                 <!-- payment_matched_amount is already expressed in B (destination_currency_id) -->
-                                <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
+                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
                             </td>
                         </tr>
                     </t>

--- a/l10n_ar_ux/i18n/es.po
+++ b/l10n_ar_ux/i18n/es.po
@@ -140,7 +140,7 @@ msgstr ""
 
 #. module: l10n_ar_ux
 #: model:ir.model.fields,field_description:l10n_ar_ux.field_account_payment__l10n_ar_partner_vat
-msgid "CUIT del destinatario"
+msgid "CUIT"
 msgstr ""
 
 #. module: l10n_ar_ux


### PR DESCRIPTION
Lógica del fix
Con el refactor, payment_total pasó a ser siempre positivo (ya no usa amount_company_currency_signed_pro). Sin embargo, _compute_selected_debt seguía usando partner_type para el signo, lo cual producía selected_debt negativo en los casos invertidos (inbound+supplier, outbound+customer). Esto generaba un payment_difference enorme y desbalanceado.

Usar payment_type como base del signo funciona para los 4 combos porque amount_residual es negativo para créditos (AP normal, AR refund) y positivo para débitos (AR normal, AP refund):

Combo   amount_residual sign(outbound)  selected_debt
outbound+supplier       < 0     -1      > 0 ✓
inbound+customer        > 0     +1      > 0 ✓
outbound+customer       < 0     -1      > 0 ✓
inbound+supplier        > 0     +1      > 0 ✓
l10n_ar_payment_bundle — sin cambios necesarios
Este módulo no tiene lógica de signo propia basada en partner_type. Su _compute_payment_difference usa selected_debt, payment_total, withholdings_amount y write_off_amount del main payment, que ahora son todos positivos.