### PR TITLE
[ADD] l10n_ar_tax: add constraint to require partner when computing withholdings

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -5,7 +5,7 @@
 from collections import defaultdict
 
 from odoo import Command, _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountPayment(models.Model):
@@ -59,6 +59,12 @@ class AccountPayment(models.Model):
                 .with_context(l10n_ar_withholding=True, active_test=True)
                 ._get_fiscal_position(address)
             )
+
+    @api.constrains("l10n_ar_withholding_line_ids", "partner_id")
+    def _check_partner_for_withholdings(self):
+        for rec in self:
+            if rec.l10n_ar_withholding_line_ids and not rec.partner_id:
+                raise ValidationError(_("Partner must be set on the payment to compute withholdings"))
 
     def _get_withholding_rate(self):
         """Tasa efectiva B->C para convertir base de retención a ARS.

--- a/l10n_ar_ux/i18n/es.po
+++ b/l10n_ar_ux/i18n/es.po
@@ -125,7 +125,7 @@ msgstr ""
 
 #. module: l10n_ar_ux
 #: model:ir.model.fields,field_description:l10n_ar_ux.field_account_payment__l10n_ar_partner_vat
-msgid "CUIT del destinatario"
+msgid "CUIT"
 msgstr ""
 
 #. module: l10n_ar_ux

--- a/l10n_ar_ux/i18n/l10n_ar_ux.pot
+++ b/l10n_ar_ux/i18n/l10n_ar_ux.pot
@@ -120,7 +120,7 @@ msgstr ""
 
 #. module: l10n_ar_ux
 #: model:ir.model.fields,field_description:l10n_ar_ux.field_account_payment__l10n_ar_partner_vat
-msgid "CUIT del destinatario"
+msgid "CUIT"
 msgstr ""
 
 #. module: l10n_ar_ux

--- a/l10n_ar_ux/models/account_payment.py
+++ b/l10n_ar_ux/models/account_payment.py
@@ -4,7 +4,7 @@ from odoo import fields, models
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 
-    l10n_ar_partner_vat = fields.Char(related="partner_id.l10n_ar_vat", string="CUIT del destinatario")
+    l10n_ar_partner_vat = fields.Char(related="partner_id.l10n_ar_vat", string="CUIT")
 
     def _get_name_receipt_report(self, report_xml_id):
         """Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document


### PR DESCRIPTION

- Implement _check_partner_for_withholdings constraint method
- Constraint triggers when l10n_ar_withholding_line_ids or partner_id change
- Prevents saving payments with withholding lines but no partner set
- Error message: "Partner must be set on the payment to compute withholdings"

Change note: Ahora el sistema requiere que se especifique el contacto/proveedor en un pago antes de poder calcular retenciones.
Esto previene errores al procesar pagos con retenciones sin tener definido el proveedor correspondiente.