### PR TITLE
[FIX] l10n_ar_tax: fix header address logic in payment receipt report

### DIFF
--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -21,7 +21,8 @@
             <t t-set="document_legend" t-value="'Doc. no válido como factura'"/>
             <t t-set="report_number" t-value="o.name"/>
             <t t-set="report_name" t-value="o.partner_type == 'supplier' and 'Orden de pago' or 'Recibo'"/>
-            <t t-set="header_address" t-value="o.receiptbook_id and o.receiptbook_id._fields.get('report_partner_id') and o.receiptbook_id.report_partner_id or o.company_id.partner_id"/>
+            <t t-set="header_address" t-value="(o._fields.get('receiptbook_id') and o.receiptbook_id and o.receiptbook_id.report_partner_id or o.company_id.partner_id or '')"/>
+
 
             <t t-set="custom_footer">
                 <div class="row">


### PR DESCRIPTION
- Update header_address assignment in report_payment_receipt_templates.xml to avoid errors if receiptbook_id or report_partner_id are missing

Change note: Se corrigió la lógica que determina la dirección en el encabezado de los recibos de pago, evitando errores cuando faltan datos en la configuración del talonario. El cambio impacta únicamente en la impresión de recibos.