### PR TITLE
[IMP] l10n_ar_tax: add monthly cron to clean old padron files

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -26,6 +26,7 @@
     "category": "Accounting & Finance",
     "data": [
         "security/ir.model.access.csv",
+        "data/ir_cron_data.xml",
         "views/report_withholding_certificate_templates.xml",
         "views/account_payment_view.xml",
         "views/res_company_jurisdiction_padron_view.xml",

--- a/l10n_ar_tax/data/ir_cron_data.xml
+++ b/l10n_ar_tax/data/ir_cron_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="cron_clean_old_padron_files" model="ir.cron">
+        <field name="name">l10n_ar_tax: Clean old padron files</field>
+        <field name="model_id" ref="model_res_company_jurisdiction_padron"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_clean_old_padron_files()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">months</field>
+    </record>
+
+</odoo>

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -174,3 +174,19 @@ class ResCompanyJurisdictionPadron(models.Model):
                     else:
                         aliquot_ret = aliquot and aliquot.replace(",", ".")
         return nro, aliquot_ret, aliquot_per
+
+    @api.model
+    def _cron_clean_old_padron_files(self):
+        """Delete old padron files to reduce storage usage."""
+        last_year_date = fields.Date.subtract(fields.Date.start_of(fields.Date.context_today(self), "month"), years=1)
+        if old_padrons := self.search(
+            [
+                ("l10n_ar_padron_to_date", "<", last_year_date),
+            ]
+        ):
+            _logger.info(
+                "Padron cleanup: deleting %s old padrones older than %s",
+                len(old_padrons),
+                last_year_date,
+            )
+            old_padrons.unlink()

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_arba
+from . import test_padron_cleanup_cron
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_validation
 from . import test_withholding_thresholds

--- a/l10n_ar_tax/tests/test_padron_cleanup_cron.py
+++ b/l10n_ar_tax/tests/test_padron_cleanup_cron.py
@@ -1,0 +1,46 @@
+import base64
+
+from dateutil.relativedelta import relativedelta
+from odoo import fields
+from odoo.tests import common
+
+
+class TestPadronCleanupCron(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.padron_model = cls.env["res.company.jurisdiction.padron"]
+        cls.state_arba = cls.env.ref("base.state_ar_b")
+        cls.state_santa_fe = cls.env.ref("base.state_ar_s")
+        cls.company = cls.env.company
+        cls.dummy_file = base64.b64encode(b"dummy padron").decode()
+
+    def _create_padron(self, state, to_date):
+        return self.padron_model.create(
+            {
+                "company_id": self.company.id,
+                "state_id": state.id,
+                "file_padron": self.dummy_file,
+                "filename": "padron.txt",
+                "l10n_ar_padron_from_date": to_date + relativedelta(days=-30),
+                "l10n_ar_padron_to_date": to_date,
+            }
+        )
+
+    def test_cron_deletes_only_old_padrons(self):
+        """Create 2 old and 2 new padrones, then verify the cron deletes only the 2 old ones."""
+        threshold_date = fields.Date.start_of(fields.Date.context_today(self.padron_model), "month") + relativedelta(
+            years=-1
+        )
+
+        old_arba = self._create_padron(self.state_arba, threshold_date + relativedelta(days=-1))
+        old_santa_fe = self._create_padron(self.state_santa_fe, threshold_date + relativedelta(days=-10))
+        new_arba = self._create_padron(self.state_arba, threshold_date + relativedelta(days=1))
+        new_santa_fe = self._create_padron(self.state_santa_fe, threshold_date + relativedelta(days=30))
+
+        self.padron_model._cron_clean_old_padron_files()
+
+        self.assertFalse(old_arba.exists())
+        self.assertFalse(old_santa_fe.exists())
+        self.assertTrue(new_arba.exists())
+        self.assertTrue(new_santa_fe.exists())


### PR DESCRIPTION
1) Add _cron_clean_old_padron_files method to delete old records.
2) Create cron in data (noupdate="1") with monthly execution.
3) Add test_cron_deletes_only_old_padrons test ( odoo-argentina/l10n_ar_tax/tests/test_padron_cleanup_cron.py ) to verify old records are deleted after cron execution.
Task Adhoc side: 65316