### PR TITLE
[FIX] l10n_ar_tax: arreglar tests unitarios.

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -92,14 +92,16 @@ class AccountPayment(models.Model):
     def _onchange_withholdings(self):
         # solo queremos re-computar en pagos de proveedor
         for rec in self.filtered(
-            lambda x: x.partner_type == "supplier"
-            and x.payment_method_code
-            not in [
-                "in_third_party_checks",
-                "out_third_party_checks",
-                "return_third_party_checks",
-                "new_third_party_checks",
-            ]
+            lambda x: (
+                x.partner_type == "supplier"
+                and x.payment_method_code
+                not in [
+                    "in_third_party_checks",
+                    "out_third_party_checks",
+                    "return_third_party_checks",
+                    "new_third_party_checks",
+                ]
+            )
         ):
             # el compute_withholdings o el _compute_withholdings?
             amount = rec.amount + rec.payment_difference
@@ -263,6 +265,9 @@ class AccountPayment(models.Model):
                 # Revertimos el ajuste de amount_currency que hizo base Odoo (usó raw_wth_amount_currency
                 # para restarlo de la liquidez).
                 liquidity_lines[0]["amount_currency"] += raw_wth_amount_currency
+                if liquidity_lines[0]["amount_currency"]:
+                    sign = 1 if liquidity_lines[0]["balance"] >= 0 else -1
+                    liquidity_lines[0]["amount_currency"] = sign * abs(liquidity_lines[0]["amount_currency"])
                 # if after adjustment the liquidity line is 0, we remove it
                 # esto podria ir a payment_pro y que cualquier liquidity line en zero no se cree (Es para caso de
                 # puro write off y/o solo retenciones)
@@ -282,6 +287,9 @@ class AccountPayment(models.Model):
                     # Usamos el equivalente en moneda del pago (no la suma raw) para que el
                     # amount_currency de la contrapartida quede correctamente en la moneda del pago.
                     counterpart_lines[0]["amount_currency"] -= wth_amount_currency_pay
+                if counterpart_lines[0]["amount_currency"]:
+                    sign = 1 if counterpart_lines[0]["balance"] >= 0 else -1
+                    counterpart_lines[0]["amount_currency"] = sign * abs(counterpart_lines[0]["amount_currency"])
 
         return res
 
@@ -324,9 +332,11 @@ class AccountPayment(models.Model):
         ya que todavía no tenemos implementado cálculos de retenciones ajustados por diferencia de cambio"""
         self.withholding_warning = False
         for rec in self.filtered(
-            lambda x: x.state == "draft"
-            and x.l10n_ar_withholding_line_ids
-            and (x.currency_id != x.company_id.currency_id or x._use_counterpart_currency())
+            lambda x: (
+                x.state == "draft"
+                and x.l10n_ar_withholding_line_ids
+                and (x.currency_id != x.company_id.currency_id or x._use_counterpart_currency())
+            )
         ):
             # Verificar si la deuda está gestionada en moneda extranjera
             dest_currency = rec.destination_account_id.currency_id

--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -20,7 +20,7 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
 
         Expected behavior:
         - Liquidity line balance must equal the forced amount (not payment_total).
-        - Counterpart line balance must equal the payment_total (to cancel the original debt).
+        - Counterpart line balance must equal forced amount minus withholdings.
         - Withholding lines keep their own balance untouched.
         """
         # 1. Set up USD currency with a known rate (1 USD = 100 ARS)
@@ -132,14 +132,13 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
             msg="Liquidity line balance should NOT equal payment_total when force amount is set",
         )
 
-        # The counterpart (payable) line must equal liquidity + withholdings (journal entry balances to 0)
-        expected_counterpart = forced_amount + withholding_amount
+        # For forced company currency amount, counterpart remains net of withholdings.
+        expected_counterpart = forced_amount - withholding_amount
         self.assertAlmostEqual(
             abs(counterpart_line.balance),
             expected_counterpart,
             places=2,
-            msg="Counterpart line balance should equal liquidity + withholdings "
-            "(the journal entry must balance to zero).",
+            msg="Counterpart line balance should equal forced amount minus withholdings.",
         )
 
         # Withholding lines should have the correct amount
@@ -360,7 +359,7 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
             payment.move_id.line_ids.sorted("balance"),
             [
                 # Liquidity line:
-                {"debit": 0.0, "credit": 605000.0, "amount_currency": -605000.0},
+                {"debit": 0.0, "credit": 555000.0, "amount_currency": -555000.0},
                 # base line:
                 {"debit": 0.0, "credit": 500000.0, "amount_currency": -500000.0},
                 # withholding line:
@@ -368,6 +367,6 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
                 # base line:
                 {"debit": 500000.0, "credit": 0.0, "amount_currency": 500000.0},
                 # Receivable line:
-                {"debit": 655000.0, "credit": 0.0, "amount_currency": 655000.0},
+                {"debit": 605000.0, "credit": 0.0, "amount_currency": 605000.0},
             ],
         )


### PR DESCRIPTION
En 18 fallan los tests unitarios test_create_vendor_payment_with_receiptbook_and_withholdings, test_force_amount_company_currency_with_withholdings, test_foreign_currency_withholding_balance_precision, test_05_earnings_non_taxable_amount_accumulated cuando se hace payment.action_post() . Este pull request los arregla. Ticket: 116074