### PR TITLE
[IMP] l10n_ar_tax: hide irrelevant fields on fiscal position view

### DIFF
--- a/l10n_ar_tax/views/account_fiscal_position_view.xml
+++ b/l10n_ar_tax/views/account_fiscal_position_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
             <notebook>
-                <page string="Perceptions and Withholdings" invisible="'AR'not in fiscal_country_codes">
+                <page string="Perceptions and Withholdings" invisible="'AR' not in fiscal_country_codes">
                     <field name="l10n_ar_tax_ids">
                         <list editable="bottom">
                             <field name="tax_type"/>
@@ -17,6 +17,21 @@
                     </field>
                 </page>
             </notebook>
+            <xpath expr="//field[@name='foreign_vat']" position="attributes">
+                <attribute name="invisible" add="'AR' in fiscal_country_codes" separator="or"/>
+            </xpath>
+            <xpath expr="//field[@name='country_group_id']" position="attributes">
+                <attribute name="invisible" add="'AR' in fiscal_country_codes" separator="or"/>
+            </xpath>
+            <xpath expr="//label[@for='zip_from']" position="attributes">
+                <attribute name="invisible" add="'AR' in fiscal_country_codes" separator="or"/>
+            </xpath>
+            <xpath expr="//div[field[@name='zip_from']]" position="attributes">
+                <attribute name="invisible" add="'AR' in fiscal_country_codes" separator="or"/>
+            </xpath>
+            <xpath expr="//page[@name='account_mapping']" position="attributes">
+                <attribute name="invisible" add="'AR' in fiscal_country_codes" separator="or"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This pull request updates the visibility logic for several fields and sections in the `account_fiscal_position_view.xml` file. The main change ensures that specific fields and UI elements are hidden when Argentina ('AR') is present in the `fiscal_country_codes`.

Visibility adjustments for Argentina:

* Added conditions to set the `invisible` attribute for the following elements when 'AR' is in `fiscal_country_codes`:
  - `foreign_vat` field
  - `country_group_id` field
  - Label and container for `zip_from` field
  - The entire `account_mapping` page
  
  Loc USA
  
<img width="1837" height="826" alt="image" src="https://github.com/user-attachments/assets/c9564565-2fc6-471b-9b2d-6fbf3a7c310f" />

Loc AR
<img width="1837" height="613" alt="image" src="https://github.com/user-attachments/assets/5c47e244-ef23-4053-b3e6-e2a90340ef63" />
