### PR TITLE
[IMP] l10n_ar_tax: limitar auto-detección de posición fiscal AR a NC con reversión

### DIFF
--- a/l10n_ar_tax/README.rst
+++ b/l10n_ar_tax/README.rst
@@ -18,6 +18,7 @@ Este módulo imlementa:
 
 * Add tags on ar taxes repartition lines.
 * Add fiscal position demo records.
+* Permite marcar posiciones fiscales argentinas para que solo se auto-detecten en notas de crédito creadas como reversión, evitando aplicarlas en notas de crédito manuales.
 * Importador de Padrón PARP ret y perc SF - Santa Fe y ARBA. Especificación: "Api - Rg 37 2025 Anexo I.pdf" y archivo de ejemplo de padrón "PARP_999999_ejemplo_padron_santa_fe.csv" para el mes de marzo 2026. Ambos archivos se encuentran en la carpeta "doc/padron_santa_fe" de este módulo. Configuraciones manuales: duplicar impuesto de retención y percepción aplicada de Santa Fe y colocarle alícuota 5% al de retención y 6% al de percepción; dichos impuestos tienen alícuota 'castigo', es decir, si el contribuyente no se encuentra en el padrón y no está exento entonces se le aplicará dicha alícuota. Dichos impuestos con alícuota castigo deben ser asignados como impuesto por defecto en la posición fiscal correspondiente y en dicha posición fiscal elegir webservice: padron.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas

--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -1,25 +1,25 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* l10n_ar_tax
-# 
-# Translators:
-# Camila Vives, 2025
-# Mariana Torres <mt@adhoc.com.ar>, 2025
-# Juan José Scarafía <scarafia.juanjose@gmail.com>, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-03 05:05+0000\n"
-"PO-Revision-Date: 2024-12-05 18:38+0000\n"
-"Last-Translator: Juan José Scarafía <scarafia.juanjose@gmail.com>, 2025\n"
-"Language-Team: Spanish (https://app.transifex.com/adhoc/teams/46451/es/)\n"
+"POT-Creation-Date: 2026-05-22 12:41+0000\n"
+"PO-Revision-Date: 2026-05-22 12:41+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: \n"
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "%s | CUIT %s not present on padron ARBA"
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model:ir.actions.report,print_report_name:l10n_ar_tax.action_report_withholding_certificate
@@ -387,6 +387,12 @@ msgid "033: Art.125 - inciso H - (Código Fiscal - mera compra)"
 msgstr ""
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "404 Not Found error."
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "<span class=\"text-center\">Signature and Clarification</span>"
 msgstr "<span class=\"text-center\">Firma y Aclaración</span>"
@@ -510,7 +516,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
 msgid ""
 "ARBA: por lo general no es necesario cargarlo aquí ya que las alícuotas se obtienen automáticamente mediante webservice.\n"
-"                                Si igualmente desea cargarlo, debe subir el archivo zip que descarga de arba y que tiene nombre de forma \"PadronRGSMMAAAA.zip"
+"                                Si igualmente desea cargarlo, debe subir el archivo zip que descarga de arba y que tiene nombre de forma \"PadronRGSMMAAAA.zip\""
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -532,6 +538,11 @@ msgstr "Ajuste / Anticipo (no gravado)"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__amount
 msgid "Amount"
 msgstr "Importe"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__webservice__padron
+msgid "Archivo de padrón"
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_l10n_ar_partner_tax
@@ -558,6 +569,15 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__api_articulo_inciso_calculo_retencion
 msgid "Artículo/Inciso para el cálculo retención"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
+msgid ""
+"Atención: La deuda se está cancelando en moneda extranjera. Podría ser "
+"necesario actualizar las bases de las retenciones teniendo en cuenta la "
+"diferencia de cambio, puede ajustar la base imponible de las mismas antes de"
+" validar."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -629,6 +649,12 @@ msgid "Config Settings"
 msgstr "Ajustes de configuración"
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/l10n_ar_payment_withholding.py:0
+msgid "Configurar impuesto"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
@@ -646,6 +672,11 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__create_date
 msgid "Created on"
 msgstr "Creado el"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__company_currency_id
+msgid "Currency"
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
@@ -682,10 +713,35 @@ msgstr "Nombre a Mostrar"
 
 #. module: l10n_ar_tax
 #. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position.py:0
+msgid "Editar contacto"
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position.py:0
+msgid ""
+"El contacto '%(name)s' (id: %(id)s) tiene múltiples impuestos vigentes para "
+"el grupo de impuestos '%(tax_group)s' en la fecha '%(date)s' y compañía "
+"'%(company)s'. Ver solapa 'Contabilidad' de la vista formulario del "
+"contacto."
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
 #: code:addons/l10n_ar_tax/models/l10n_ar_payment_withholding.py:0
 msgid ""
 "El impuesto de retención %s no tiene un tipo de cálculo definido. Por favor,"
 " defina el tipo de cálculo en la configuración del impuesto."
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/l10n_ar_payment_withholding.py:0
+msgid ""
+"El impuesto de retención '%s' (id: %s) es de tipo escala de ganancias y no "
+"tiene definida una escala (campo l10n_ar_scale_id). Por favor, defina una "
+"escala en la configuración del impuesto."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -699,11 +755,8 @@ msgid "Email composition wizard"
 msgstr "Asistente de redacción de correo electrónico"
 
 #. module: l10n_ar_tax
-#. odoo-python
-#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
-msgid ""
-"Error when contacting rentascordoba.gob.ar. The server answered: \n"
-"%s"
+#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_move_form
+msgid "Esta utilizando la posición fiscal"
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -718,6 +771,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__file_padron
 msgid "File"
 msgstr "Archivo"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__filename
+msgid "File Name"
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_withholding_certificate_document
@@ -762,21 +820,18 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ar_tax
-#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_caba
-msgid "IIBB CABA"
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid ""
+"If enabled, the perception taxes of this fiscal position only apply to "
+"credit notes when the amount is exactly equal to the related invoice and "
+"both are in the same month."
 msgstr ""
+"Si está activado, los impuestos de percepción de esta posición fiscal solo "
+"se aplican en notas de crédito cuando el monto es exactamente igual al de la"
+" factura relacionada y ambas están en el mismo mes."
 
 #. module: l10n_ar_tax
-#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_caba_and_proffits
-msgid "IIBB CABA + ganancias"
-msgstr ""
-
-#. module: l10n_ar_tax
-#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_cordoba
-msgid "IIBB Córdoba"
-msgstr ""
-
-#. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,help:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid ""
 "If no sequence provided then it will be required for you to enter "
@@ -784,6 +839,27 @@ msgid ""
 msgstr ""
 "Si no se proporciona una secuencia, será necesario ingresar el número de "
 "retención al registrar una."
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_payment_minimum_threshold
+msgid ""
+"If the amount of each payment does not exceed this value, the "
+"withholding/perception is not applied."
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_minimum_threshold
+msgid ""
+"If the calculated withholding/perception amount is lower than this "
+"threshold, it is 0.0."
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_base_minimum_threshold
+msgid ""
+"If the computed base for the regime does not exceed this value, the "
+"withholding/perception is not applied."
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_withholding_certificate_document
@@ -857,13 +933,46 @@ msgid "Matched Amount Untaxed"
 msgstr "Importe Conciliado No Gravado"
 
 #. module: l10n_ar_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.res_config_settings_view_form
-msgid "Muestra las ND y NC en los recibos de pago, como movimientos a parte."
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_base_minimum_threshold
+msgid "Minimum Base"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_payment_minimum_threshold
+msgid "Minimum Payment"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_minimum_threshold
+msgid "Minimum Threshold"
 msgstr ""
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__res_partner__drei__no_activo
 msgid "No Activo"
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid ""
+"No hay padrón subido para la fecha indicada %s a %s. Debe subirlo en "
+"'Contabilidad / Configuración / AFIP / Padrón de Alícuotas por compañía' o "
+"cargar la alícuota manualmente en el contacto para el período en curso."
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid ""
+"No pudimos obtener la alicuota del webservice de rentascordoba.\n"
+"\n"
+"Para asignar la alícuota de Córdoba a un contacto, siga estos pasos:\n"
+"1) Consulte la alícuota del contacto en: https://www.rentascordoba.gob.ar/gestiones/consulta-alicuota\n"
+"2) Cree manualmente la alícuota en la vista formulario del Contacto (solapa 'Contabilidad').\n"
+"\n"
+"En caso de dudas o si el problema persiste, comuníquese con nuestro equipo de Servicio de Asistencia.\n"
+"Detalle del error:\n"
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -888,6 +997,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_non_taxable_amount
+msgid "Non Taxable Amount"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__name
 msgid "Number"
 msgstr "Número"
@@ -901,6 +1015,11 @@ msgstr "Observaciones:"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "On account"
 msgstr "A cuenta"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid "Only applies to NC with total refund (AR)"
+msgstr "Solo aplica en NC con devolución exacta (AR)"
 
 #. module: l10n_ar_tax
 #. odoo-python
@@ -939,6 +1058,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__partner_type
+msgid "Partner Type"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model,name:l10n_ar_tax.model_account_payment_register
 msgid "Pay"
 msgstr "Pagar"
@@ -964,9 +1088,30 @@ msgid "Payments"
 msgstr "Pagos"
 
 #. module: l10n_ar_tax
+#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_caba
+msgid "Percepciones CABA"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_cordoba
+msgid "Percepciones Córdoba"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_caba_cordoba_perc
+msgid "Percepciones Córdoba + CABA"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__tax_type__perception
 msgid "Perception"
 msgstr "Percepción"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_bank_statement_line__perceptions_fiscal_positon
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_move__perceptions_fiscal_positon
+msgid "Perceptions Fiscal Positon"
+msgstr ""
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_position_form
@@ -1005,11 +1150,6 @@ msgid "Ref"
 msgstr "Referencia"
 
 #. module: l10n_ar_tax
-#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
-msgid "Regímen"
-msgstr ""
-
-#. module: l10n_ar_tax
 #: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_fiscal_position_l10n_ar_tax__webservice__rentas_cordoba
 msgid "Rentas Cordoba"
 msgstr ""
@@ -1017,6 +1157,16 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_proffits
 msgid "Ret. ganancias"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_caba_and_proffits
+msgid "Retenciones CABA + Ganancias"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:account.fiscal.position,name:l10n_ar_tax.fiscal_position_cordoba_caba_and_proffits
+msgid "Retención IIBB Córdoba + CABA + GANANCIAS"
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1028,6 +1178,14 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_partner_form
 msgid "Sale Perceptions"
 msgstr "Percepciones de Venta"
+
+#. module: l10n_ar_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
+msgid ""
+"Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP"
+" (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API "
+"y que tiene nombre de forma \"PARP_999999.zip\""
+msgstr ""
 
 #. module: l10n_ar_tax
 #. odoo-python
@@ -1088,7 +1246,7 @@ msgstr "El código del estado."
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
-msgid "Timeout error when getting data from rentascordoba.gob.ar"
+msgid "Timeout error when getting data."
 msgstr ""
 
 #. module: l10n_ar_tax
@@ -1102,11 +1260,17 @@ msgid "Tribute AFIP Code"
 msgstr "Código tributo AFIP"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_non_taxable_amount
+msgid "Until this base amount, the tax is not applied."
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_payment__withholdable_advanced_amount
 msgid "Used for withholdings calculation"
 msgstr "Utilizado para el cálculo de retenciones"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid "WTH Sequence"
 msgstr "Secuencia de retención"
@@ -1133,6 +1297,11 @@ msgid "Withholding"
 msgstr "Retención"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_payment__withholding_warning
+msgid "Withholding Warning"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_form
 msgid "Withholdings"
 msgstr "Retenciones"
@@ -1149,12 +1318,6 @@ msgstr "Líneas de Retenciones"
 
 #. module: l10n_ar_tax
 #. odoo-python
-#: code:addons/l10n_ar_tax/models/account_payment.py:0
-msgid "Withholdings must be done in \"%s\" currency"
-msgstr "Las retenciones deberán realizarse en la moneda \"%s\" "
-
-#. module: l10n_ar_tax
-#. odoo-python
 #: code:addons/l10n_ar_tax/models/res_company.py:0
 msgid "You must configure CIT password on company %s"
 msgstr "Debe configurar la contraseña de CIT en la empresa %s"
@@ -1167,6 +1330,19 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
 msgid "aquí"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.actions.server,name:l10n_ar_tax.cron_clean_old_padron_files_ir_actions_server
+msgid "l10n_ar_tax: Clean old padron files"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_move_form
+msgid ""
+"que tiene impuestos de percepciones. Como las alicuotas podrían variar según"
+" la fecha del comprobante, cambiar la fecha o validar la factura re-"
+"computará los impuestos."
 msgstr ""
 
 #. module: l10n_ar_tax

--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -6,6 +6,14 @@ class AccountFiscalPosition(models.Model):
     _inherit = "account.fiscal.position"
 
     l10n_ar_tax_ids = fields.One2many("account.fiscal.position.l10n_ar_tax", "fiscal_position_id")
+    l10n_ar_require_related_invoice = fields.Boolean(
+        string="Only applies to NC with total refund (AR)",
+        help=(
+            "If enabled, the perception taxes of this fiscal position only apply "
+            "to credit notes when the amount is exactly equal to the related invoice "
+            "and both are in the same month."
+        ),
+    )
 
     def _l10n_ar_add_taxes(self, partner, company, date, tax_type, payment=None):
         # TODO deberiamos unificar mucho de este codigo con _get_tax_domain, _compute_withholdings y _check_tax_group_overlap
@@ -63,10 +71,12 @@ class AccountFiscalPosition(models.Model):
         """Aquellas retenciones/percepciones en la posición fiscal que tengan un impuesto por defecto de retención
         entonces deberán tener tipo 'retención' y si son de percepción entonces deberán tener tipo 'percepcion'."""
         if wrong_tax_type_records := self.l10n_ar_tax_ids.filtered(
-            lambda x: x.tax_type == "withholding"
-            and x.default_tax_id.type_tax_use != "none"
-            or x.tax_type == "perception"
-            and x.default_tax_id.type_tax_use == "none"
+            lambda x: (
+                x.tax_type == "withholding"
+                and x.default_tax_id.type_tax_use != "none"
+                or x.tax_type == "perception"
+                and x.default_tax_id.type_tax_use == "none"
+            )
         ):
             raise ValidationError(
                 self.env._(
@@ -94,7 +104,7 @@ class AccountFiscalPosition(models.Model):
         """
         if self._context.get("l10n_ar_withholding") and self.env.company.country_id.code == "AR":
             return [
-                ("l10n_ar_tax_ids", lambda fpos: (any(tax.tax_type == "withholding" for tax in fpos.l10n_ar_tax_ids)))
+                ("l10n_ar_tax_ids", lambda fpos: any(tax.tax_type == "withholding" for tax in fpos.l10n_ar_tax_ids))
             ] + super()._get_fpos_ranking_functions(partner)
         elif not self._context.get("l10n_ar_withholding") and self.env.company.country_id.code == "AR":
 

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -35,7 +35,12 @@ class AccountMove(models.Model):
         # En Odoo 18+, cuando el guardado viene de un formulario (UI), los 'tax_ids' de las líneas
         # suelen estar presentes en los 'vals' (dentro de 'invoice_line_ids').
         # Si el usuario editó las líneas, no queremos re-ejecutar nuestra lógica de refresco automático.
-        if "invoice_date" in vals and "invoice_line_ids" not in vals:
+        if (
+            "invoice_date" in vals
+            and "invoice_line_ids" not in vals
+            or self.state == "draft"
+            and self.fiscal_position_id.l10n_ar_require_related_invoice
+        ):
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
@@ -45,7 +50,11 @@ class AccountMove(models.Model):
         IMPORTANTE: este metodo solo esta pensado para cambiar alicuota de MISMA fiscal position (por cambio en fecha o partner) pero no para cambiar los impuestos.
         Para ello nos basamos en los impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
         reemplazamos por los nuevos impuestos.
-        NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes
+        NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes.
+
+        Para posiciones fiscales con l10n_ar_require_related_invoice=True:
+        - En NC: solo aplica si es devolución total (mismo monto) en el mismo mes que la factura relacionada.
+        - Si no cumple → elimina los impuestos de percepción de las líneas.
         """
         for move in self.filtered(
             lambda x: x.is_sale_document(include_receipts=True) and x.perceptions_fiscal_positon and x.state == "draft"
@@ -53,14 +62,64 @@ class AccountMove(models.Model):
             fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"
             ).mapped("default_tax_id.tax_group_id")
-            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
-                move.partner_id, move.company_id, move.date, "perception"
-            )
-            # Solo queremos que se recomputen los impuestos en facturas de cliente/proveedor
-            for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
-                to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
-                if to_unlink._origin != new_taxes:
-                    line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+            if move.move_type == "out_refund" and move.fiscal_position_id.l10n_ar_require_related_invoice:
+                related = move._found_related_invoice()
+                if (
+                    related
+                    and move.invoice_date
+                    and related.invoice_date
+                    and move.invoice_date.year == related.invoice_date.year
+                    and move.invoice_date.month == related.invoice_date.month
+                    and move.currency_id.is_zero(related.amount_untaxed - move.amount_untaxed)
+                ):
+                    new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                        move.partner_id, move.company_id, related.date, "perception"
+                    )
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink._origin != new_taxes:
+                            line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+                elif move._l10n_ar_so_invoice_same_untaxed():
+                    # Existe una factura vinculada en la orden de venta con el mismo importe sin
+                    # impuestos: calculamos las percepciones normalmente (como si la posición fiscal
+                    # no tuviera l10n_ar_require_related_invoice).
+                    new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                        move.partner_id, move.company_id, move.date, "perception"
+                    )
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink._origin != new_taxes:
+                            line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+                else:
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink:
+                            line.tax_ids = line.tax_ids - to_unlink
+            else:
+                new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                    move.partner_id, move.company_id, move.date, "perception"
+                )
+                # Solo queremos que se recomputen los impuestos en facturas de cliente/proveedor
+                for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
+                    to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                    if to_unlink._origin != new_taxes:
+                        line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+
+    def _l10n_ar_so_invoice_same_untaxed(self):
+        """Factura(s) de cliente posteada(s) vinculada(s) a la(s) misma(s) orden(es) de venta de esta
+        NC, con el mismo importe sin impuestos. Se usa para decidir si, pese a no cumplirse la
+        condición de devolución total contra la factura original (reversed_entry_id), igual
+        corresponde calcular las percepciones. Vacío si el módulo sale no está instalado.
+        """
+        self.ensure_one()
+        if "sale_line_ids" not in self.env["account.move.line"]._fields:
+            return self.env["account.move"]
+        orders = self.invoice_line_ids.sale_line_ids.order_id
+        return orders.invoice_ids.filtered(
+            lambda m: m.move_type == "out_invoice"
+            and m.state == "posted"
+            and self.currency_id.is_zero(m.amount_untaxed - self.amount_untaxed)
+        )[:1]
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una factura porque puede ser que la factura venga de otro periodo

--- a/l10n_ar_tax/views/account_fiscal_position_view.xml
+++ b/l10n_ar_tax/views/account_fiscal_position_view.xml
@@ -6,8 +6,11 @@
         <field name="model">account.fiscal.position</field>
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet/group/group[2]/field[@name='auto_apply']" position="after">
+                <field name="l10n_ar_require_related_invoice" invisible="'AR' not in fiscal_country_codes or not auto_apply"/>
+            </xpath>
             <notebook>
-                <page string="Perceptions and Withholdings" invisible="'AR'not in fiscal_country_codes">
+                <page string="Perceptions and Withholdings" invisible="'AR' not in fiscal_country_codes">
                     <field name="l10n_ar_tax_ids">
                         <list editable="bottom">
                             <field name="tax_type"/>


### PR DESCRIPTION
Cambia el enfoque de control de percepciones en notas de crédito:
- Agrega campo l10n_ar_require_related_invoice en account.fiscal.position:
  cuando está activo, los impuestos de percepción solo se aplican en NC que:
  1) tienen una factura relacionada (_found_related_invoice → reversed_entry_id),
  2) el monto subtotal es exactamente igual (devolución total), y
  3) la fecha está dentro del mismo mes que la factura original.
  Si alguna condición no se cumple, se eliminan las percepciones de las líneas. Si hay algún cambio de importes en la nc no se recomputa automáticamente las percepciones, hay que hacer click en "Update Taxes".
- Para posiciones fiscales sin este campo (default False), el comportamiento es
  idéntico al anterior (backward compatible).
Tarea Adhoc: 57361
