### PR TITLE
[IMP] l10n_ar_tax: ignore dynamic_fiscal_position_id in account.tax n…

### DIFF
--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -138,3 +138,10 @@ class AccountTax(models.Model):
                         "The total percentage (%s) should be greater than 0 and less than or equal to 100.", tax.ratio
                     )
                 )
+
+    @api.model
+    @api.readonly
+    def name_search(self, name="", domain=None, operator="ilike", limit=100):
+        ctx = dict(self.env.context)
+        ctx.pop("dynamic_fiscal_position_id", None)
+        return super(AccountTax, self.with_context(**ctx)).name_search(name, domain, operator, limit)


### PR DESCRIPTION
…ame_search

Changes the default Odoo behavior so that the name_search for taxes always ignores the dynamic_fiscal_position_id context key. This allows users to search and select any tax in vendor bills, regardless of the partner's fiscal position or previous use of the 'Search more...' modal.

Change note: Se modifica el comportamiento estándar para que la búsqueda de impuestos en líneas de factura de proveedor no filtre por posición fiscal, permitiendo encontrar cualquier impuesto al tipear, sin importar la posición fiscal ni el uso previo del modal de búsqueda avanzada.