### PR TITLE
[FIX] l10n_ar_purchase: dirección de envío en reportes de órdenes de compra

### DIFF
--- a/l10n_ar_purchase/views/purchase_report_templates.xml
+++ b/l10n_ar_purchase/views/purchase_report_templates.xml
@@ -105,6 +105,12 @@
                         <br/>
                         <span t-field="o.dest_address_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;], &quot;no_marker&quot;: true, &quot;no_tag_br&quot;: True}"/>
                     </t>
+                    <t t-elif="o.picking_type_id and o.picking_type_id.warehouse_id and o.picking_type_id.warehouse_id.partner_id">
+                        <br/><strong>Shipping address:</strong>
+                        <span t-field="o.picking_type_id.warehouse_id.name"/>
+                        <br/>
+                        <span t-field="o.picking_type_id.warehouse_id.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;], &quot;no_marker&quot;: true, &quot;no_tag_br&quot;: True}"/>
+                    </t>
 
                 </div>
 
@@ -196,6 +202,12 @@
                         <span t-field="o.dest_address_id.name"/>
                         <br/>
                         <span t-field="o.dest_address_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;], &quot;no_marker&quot;: true, &quot;no_tag_br&quot;: True}"/>
+                    </t>
+                    <t t-elif="o.picking_type_id and o.picking_type_id.warehouse_id and o.picking_type_id.warehouse_id.partner_id">
+                        <br/><strong>Shipping address:</strong>
+                        <span t-field="o.picking_type_id.warehouse_id.name"/>
+                        <br/>
+                        <span t-field="o.picking_type_id.warehouse_id.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;], &quot;no_marker&quot;: true, &quot;no_tag_br&quot;: True}"/>
                     </t>
 
                 </div>


### PR DESCRIPTION
El reporte de compra de l10n_ar_purchase reemplaza la variable address en las plantillas heredadas. Eso impide que el bloque address_layout de web renderice information_block, porque ese layout está condicionado por la presencia de address.

Problema observado:

1. Cuando dest_address_id no está definido, la dirección de envío no se mostraba.
2. El comportamiento dependía indirectamente de la estructura del external layout y de herencias de purchase_stock.

Causa técnica:

1. En web.address_layout, el contenedor principal se renderiza con t-if sobre address.
2. Al hacer replace de address en l10n_ar_purchase, se anula el contenedor que también podía mostrar information_block.
3. Resultado: se pierde la salida visual del shipping address en escenarios sin dest_address_id.

Solución implementada:

1. Se mantiene el flujo actual para casos con dest_address_id.
2. Se agrega un fallback explícito con t-elif para tomar la dirección del depósito: o.picking_type_id -> warehouse_id -> partner_id
3. El fallback se aplicó en ambos templates: report_purchasequotation_document y report_purchaseorder_document.

Detalle técnico del fallback:

1. Condición: existencia de picking_type_id, warehouse_id y partner_id.
2. Render: Shipping address con nombre del warehouse.
Contact widget del partner del warehouse mostrando address.
3. Esto elimina la dependencia de information_block/address_layout para mostrar la dirección de envío en estos reportes localizados.

Impacto funcional:

1. Si existe dest_address_id, se mantiene la lógica original.
2. Si no existe dest_address_id, ahora se muestra la dirección de envío desde el depósito.
3. Se evita regresión visual causada por la personalización que reemplaza address.

Ticket Adhoc: 116548