### PR TITLE
[FIX] l10n_ar_tax: use context_today instead of Date.today() for with…

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -458,7 +458,7 @@ class AccountPayment(models.Model):
     def _compute_l10n_ar_withholding_line_ids(self):
         # metodo completamente analogo a payment.register._compute_l10n_ar_withholding_ids
         for rec in self.filtered(lambda x: x.partner_type == "supplier"):
-            date = rec.date or fields.Date.today()
+            date = rec.date or fields.Date.context_today(rec)
             withholdings = [Command.clear()]
             if rec.l10n_ar_fiscal_position_id.l10n_ar_tax_ids:
                 taxes = rec.l10n_ar_fiscal_position_id._l10n_ar_add_taxes(

--- a/l10n_ar_tax/wizard/account_payment_register.py
+++ b/l10n_ar_tax/wizard/account_payment_register.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
-from datetime import datetime
 
 from odoo import Command, api, fields, models
 
@@ -52,7 +51,7 @@ class AccountPaymentRegister(models.TransientModel):
         # super()._compute_l10n_ar_withholding_ids()
         # taxes = self.l10n_ar_withholding_ids.mapped('tax_id')
         for rec in self:
-            date = fields.Date.from_string(rec.payment_date) or datetime.date.today()
+            date = rec.payment_date or fields.Date.context_today(rec)
 
             withholdings = [Command.clear()]
             if rec.l10n_ar_fiscal_position_id.l10n_ar_tax_ids:


### PR DESCRIPTION
…holding date fallback

fields.Date.today() returns the current date in UTC, which can differ from the user's local date (e.g. at 22:00 ART = 01:00 UTC next day). Replace with fields.Date.context_today() to respect the user's timezone.

Also simplify payment_register: payment_date is already a Date field so fields.Date.from_string() is redundant, and its datetime import is now unused.