### PR TITLE
[FIX] l10n_ar_tax: Prevent withholding lines from becoming non-editable

### DIFF
--- a/l10n_ar_tax/models/account_move_line.py
+++ b/l10n_ar_tax/models/account_move_line.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+from collections import defaultdict
+
+from odoo import api, fields, models
 
 
 class AccountMoveLine(models.Model):
@@ -25,3 +27,19 @@ class AccountMoveLine(models.Model):
                 self.partner_id, self.company_id, date, "perception"
             )
         return taxes
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Force display_type='product' for Argentine withholdings to keep them editable
+        rep_id_to_vals = defaultdict(list)
+        for vals in vals_list:
+            if vals.get("display_type") == "tax" and (rep_id := vals.get("tax_repartition_line_id")):
+                rep_id_to_vals[rep_id].append(vals)
+
+        if rep_id_to_vals:
+            rep_lines = self.env["account.tax.repartition.line"].browse(rep_id_to_vals.keys())
+            for rep_line in rep_lines.filtered(lambda r: r.tax_id.l10n_ar_withholding_payment_type):
+                for vals in rep_id_to_vals[rep_line.id]:
+                    vals["display_type"] = "product"
+
+        return super().create(vals_list)


### PR DESCRIPTION
When creating payments with Argentine withholdings in foreign currency, the withholding line becomes non-editable, raising a ValidationError: "Tax lines cannot have taxes set on them. You should modify the base line instead."

Root cause:
During payment creation, account.move._sync_tax_lines() is triggered when the grouping_key of the withholding line changes between creation and recalculation (e.g., tax_tag_ids updated from [] to [tag_id]).

The flow:
1. Wizard creates withholding line with tax_repartition_line_id but no display_type → defaults to 'product' (editable)
2. During move.create(), _sync_tax_lines() detects grouping_key mismatch
3. Line is deleted and recreated with display_type='tax' (line 3461 of account_move.py)
4. Lines with display_type='tax' + tax_ids trigger ValidationError on edit

Solution:
Override account.move.line.create() to detect withholdings being created with display_type='tax' and force display_type='product' instead. This keeps them editable as functionally they are write-offs, not computed taxes.

The grouping_key mismatch commonly occurs when:
- tax_tag_ids differ (SIRE/AFIP reporting tags added during recomputation)
- account_id, analytic_distribution, or other grouping fields change
- invoice_currency_rate changes between creation and recalculation