### PR TITLE
[REF] l10n_ar_tax: payment report refactor

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -2,8 +2,6 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from collections import defaultdict
-
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -119,14 +117,16 @@ class AccountPayment(models.Model):
     def _onchange_withholdings(self):
         # solo queremos re-computar en pagos de proveedor
         for rec in self.filtered(
-            lambda x: x.partner_type == "supplier"
-            and x.payment_method_code
-            not in [
-                "in_third_party_checks",
-                "out_third_party_checks",
-                "return_third_party_checks",
-                "new_third_party_checks",
-            ]
+            lambda x: (
+                x.partner_type == "supplier"
+                and x.payment_method_code
+                not in [
+                    "in_third_party_checks",
+                    "out_third_party_checks",
+                    "return_third_party_checks",
+                    "new_third_party_checks",
+                ]
+            )
         ):
             # payment_difference está en B2 (destination_currency_id).
             # Necesitamos convertirlo a A (moneda del journal) para ajustar rec.amount.
@@ -515,24 +515,3 @@ class AccountPayment(models.Model):
         if self.company_id.country_id.code == "AR" and not self.is_internal_transfer:
             return "l10n_ar_tax.report_payment_receipt_document"
         return super()._get_name_receipt_report(report_xml_id)
-
-    def _get_payment_bundle_key(self):
-        if self.company_id.country_id.code == "AR" and self.env.context.get("print_in_bundles"):
-            return f"{self.company_id.id}-{self.partner_id.id}-{self.payment_type}-{self.currency_id.id if self.currency_id != self.company_currency_id else self.counterpart_currency_id.id}"
-        return self.id
-
-    def _get_payment_bundles(self):
-        """Returns a dictionary of payment bundles, where the key is a tuple
-        of (company_id, partner_id, payment_type, currency_id) and the value
-        is a recordset of account.payment."""
-        bundles = defaultdict(lambda: self.env["account.payment"])
-        for rec in self:
-            bundles[rec._get_payment_bundle_key()] += rec
-        return bundles
-
-    def _select_bundle(self, bundles):
-        """Selects a bundle from the dictionary of payment bundles based on
-        the current record's company_id, partner_id, payment_type, and
-        currency_id."""
-        self.ensure_one()
-        return bundles.get(self._get_payment_bundle_key())

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -1,26 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="report_payment_receipt_document" inherit_id="account_payment_pro.report_payment_receipt_document" primary="True" priority="20">
+        <xpath expr="//t[@t-set='report_name']" position="attributes">
+            <attribute name="t-value">o.payment_type == 'outbound' and 'Orden de pago' or 'Recibo'</attribute>
+        </xpath>
 
-    <template id="report_payment_receipt" inherit_id="account.report_payment_receipt">
-        <t t-foreach="docs" position="before">
-            <t t-set="payment_bundles" t-value="docs._get_payment_bundles()"/>
-        </t>
-        <t t-call="account.report_payment_receipt_document" position="attributes">
-            <attribute name="t-call">#{ o._get_name_receipt_report('account.report_payment_receipt_document') }</attribute>
-        </t>
-        <t t-set="lang" position="after">
-            <t t-set="payment_bundle" t-value="o._select_bundle(payment_bundles)"/>
-        </t>
-    </template>
-
-    <!-- we force priority greater than 16 so that it dont break inheritance of report_saleorder_document_inherit_sale_stock. with this we are loosing the incoterm field added but that sale_stock view -->
-    <template id="report_payment_receipt_document" inherit_id="account.report_payment_receipt_document" primary="True" priority="16" >
-        <t t-set="o" position="after">
+        <xpath expr="//t[@t-set='report_name']" position="after">
             <t t-set="custom_header" t-value="'l10n_ar.custom_header'"/>
-            <t t-set="report_date" t-value="o.date"/>
             <t t-set="document_letter" t-value="'X'"/>
             <t t-set="document_legend" t-value="'Doc. no válido como factura'"/>
-            <t t-set="report_number" t-value="o.name"/>
-            <t t-set="report_name" t-value="o.payment_type == 'outbound' and 'Orden de pago' or 'Recibo'"/>
             <t t-set="header_address" t-value="(o._fields.get('receiptbook_id') and o.receiptbook_id and o.receiptbook_id.report_partner_id or o.company_id.partner_id or '')"/>
             <t t-set="custom_footer">
                 <div class="row">
@@ -39,208 +27,50 @@
                     </div>
                 </div>
             </t>
-        </t>
-        <div class="page" position="replace">
-            <div class="page">
-                <div id="informations" class="row mt8 mb8">
-                    <div class="col-6">
+        </xpath>
 
-                        <!-- IDENTIFICACION (ADQUIRIENTE-LOCATARIO-PRESTARIO) -->
-
-                        <!-- (14) Apellido uy Nombre: Denominicacion o Razon Soclial -->
-                        <strong><span t-if="o.partner_type == 'supplier'">Supplier: </span><span t-if="o.partner_type == 'customer'">Customer: </span></strong><span t-field="o.partner_id.commercial_partner_id.name"/>
-
-                        <!-- (15) Domicilio Comercial -->
-                        <br/>
-                        <span t-out="o.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True, "no_tag_br": True}'/>
-
-                        <!-- (16) Responsabilidad AFIP -->
-                        <strong>VAT Cond: </strong><span t-field="o.partner_id.l10n_ar_afip_responsibility_type_id"/>
-
-                        <!-- (17) CUIT -->
-                        <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
-                            <br/><strong><t t-out="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-out="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
-                        </t>
-
-                    </div>
-                </div>
+        <xpath expr="//div[@name='payment_pro_partner_info']" position="replace">
+            <div class="col-6" name="payment_pro_partner_info">
+                <strong>
+                    <span t-if="o.partner_type == 'supplier'">Supplier: </span>
+                    <span t-if="o.partner_type == 'customer'">Customer: </span>
+                </strong>
+                <span t-field="o.partner_id.commercial_partner_id.name"/>
+                <br/>
+                <span t-out="o.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True, "no_tag_br": True}'/>
+                <br/>
+                <strong>VAT Cond: </strong><span t-field="o.partner_id.l10n_ar_afip_responsibility_type_id"/>
+                <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
+                    <br/>
+                    <strong><t t-out="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong>
+                    <span t-out="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
+                </t>
             </div>
-            <br/>
-            <table class="table table-sm o_main_table" name="payments_table">
-                <!--
-                    show_amount_col: muestra columna "Importe" (moneda natural) cuando:
-                    - algún pago del bundle usa una moneda distinta a destination_currency_id (B), o
-                    - hay retenciones y B != C (ARS), ya que las retenciones siempre están en ARS.
-                -->
-                <t t-set="show_amount_col" t-value="any(doc.currency_id != o.destination_currency_id for doc in payment_bundle) or bool(payment_bundle.l10n_ar_withholding_line_ids.filtered('amount') and o.destination_currency_id != o.company_currency_id)"/>
-                <thead>
-                    <tr>
-                        <th><span>Payments</span></th>
-                        <th class="text-right" t-if="show_amount_col"><span>Importe</span></th>
-                        <th class="text-right">
-                            <span>Amount</span><span t-if="show_amount_col"> (<span t-field="o.destination_currency_id.name"/>)</span>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <t t-foreach="payment_bundle" t-as="doc">
-                        <t t-foreach="doc._get_latam_checks()" t-as="check">
-                            <tr>
-                                <td>
-                                    <span t-out="'Cheque nro %s' % (check.name)">Check nro 123456</span>
-                                    <span t-if="check.bank_id" t-out="' - %s' % (check.bank_id.name)"> - Santander Rio</span>
-                                    <span t-if="doc.payment_method_code == 'own_checks'" t-out="' (%s)' % (check.payment_method_line_id.name)"> (Electronic checkbook)</span>
-                                    <span t-if="check.payment_date"> - Exp. <span t-field="check.payment_date"/></span>
-                                </td>
-                                <td class="text-right" t-if="show_amount_col">
-                                    <!-- moneda natural del cheque = A (moneda del diario) -->
-                                    <span class="text-nowrap" t-out="check.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
-                                </td>
-                                <td class="text-right o_price_total">
-                                    <!-- B2 = A * counterpart_rate cuando B1==B2; si no, A / accounting_rate -->
-                                    <span class="text-nowrap" t-out="doc.destination_currency_id.round(check.amount * (doc.counterpart_rate or 1.0) if doc.counterpart_currency_id == doc.destination_currency_id else (check.amount / doc.accounting_rate if doc.accounting_rate else check.amount))" t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
-                                </td>
-                            </tr>
-                        </t>
-                    </t>
-                    <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids.filtered('amount')" t-as="line">
-                        <tr>
-                            <td>
-                                <span t-if="line.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="line.tax_id.invoice_label or 'Retención Ganancias'"/>
-                                <span t-else="" t-out="line.tax_id.invoice_label or line.tax_id.name"/>
-                            </td>
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- moneda natural de la retención = ARS (company_currency) -->
-                                <span class="text-nowrap" t-out="line.amount" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- B = C / rate del pago específico (preciso en bundles con distintas tasas) -->
-                                <span class="text-nowrap" t-out="line.payment_id.destination_currency_id.round(line.amount / line.payment_id._get_withholding_rate())" t-options='{"widget": "monetary", "display_currency": line.payment_id.destination_currency_id}'/>
-                            </td>
-                        </tr>
-                    </t>
-                    <!-- si queremos imprimir solo cuando tenemos apuntes tal vez este approach puede ser mas consistente -->
-                    <!-- <t t-foreach="o.l10n_ar_withholding_ids" t-as="line">
-                        <t t-set='sign' t-value="o.payment_type == 'outbound' and -1 or 1"/>
-                        <tr>
-                            <td>
-                                <span t-field='line.tax_line_id.name'/>
-                            </td>
-                            <td class="text-right" t-if="o.other_currency">
-                                <span t-out="line.amount_currency * sign" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <span t-out="line.balance * sign" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                        </tr>
-                    </t> -->
-                    <t t-foreach="payment_bundle.filtered('write_off_amount')" t-as="doc">
-                        <tr>
-                            <td>
-                                <span t-out="doc.write_off_type_id.label or doc.write_off_type_id.name"/>
-                            </td>
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- write_off_amount ya está en B; se muestra igual en ambas columnas -->
-                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
-                            </td>
-                        </tr>
-                    </t>
-                    <t t-set="all_same_type" t-value="len(set(payment_bundle.mapped('payment_type'))) == 1"/>
+        </xpath>
 
-                    <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc" id="payment_bundle_doc">
-                        <!-- display_amount_a: importe en A (moneda del diario); amount_signed lleva el signo -->
-                        <t t-set="display_amount_a" t-value="abs(doc.amount_signed) if all_same_type else doc.amount_signed"/>
-                        <!-- display_amount_b: importe en B2 (destination_currency_id); si B1!=B2 convertir A→B2 -->
-                        <t t-set="display_amount_b_raw" t-value="doc.counterpart_currency_amount if doc.counterpart_currency_id == doc.destination_currency_id else (doc.amount / doc.accounting_rate if doc.accounting_rate else doc.amount)"/>
-                        <t t-set="display_amount_b" t-value="abs(display_amount_b_raw) if all_same_type else (display_amount_b_raw if doc.payment_type == 'inbound' else -display_amount_b_raw)"/>
-                        <tr>
-                            <td>
-                                <span t-field="doc.journal_id.name"/>
-                                <span t-field="doc.payment_method_line_id.name"/>
-                            </td>
+        <xpath expr="//table[@name='payments_table']//t[@t-set='show_amount_col']" position="attributes">
+            <attribute name="t-value">any(doc.currency_id != o.destination_currency_id for doc in payment_bundle) or bool(payment_bundle.l10n_ar_withholding_line_ids.filtered('amount') and o.destination_currency_id != o.company_currency_id)</attribute>
+        </xpath>
 
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- moneda natural del pago = A (moneda del diario) -->
-                                <span class="text-nowrap"
-                                    t-out="display_amount_a"
-                                    t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
-                            </td>
+        <xpath expr="//t[@t-set='payment_pro_extra_payment_lines']" position="before">
+            <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids.filtered('amount')" t-as="line">
+                <tr>
+                    <td>
+                        <span t-if="line.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="line.tax_id.invoice_label or 'Retención Ganancias'"/>
+                        <span t-else="" t-out="line.tax_id.invoice_label or line.tax_id.name"/>
+                    </td>
+                    <td class="text-right" t-if="show_amount_col">
+                        <span class="text-nowrap" t-out="line.amount" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+                    </td>
+                    <td class="text-right o_price_total">
+                        <span class="text-nowrap" t-out="line.payment_id.destination_currency_id.round(line.amount / line.payment_id._get_withholding_rate())" t-options='{"widget": "monetary", "display_currency": line.payment_id.destination_currency_id}'/>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
 
-                            <td class="text-right o_price_total">
-                                <span class="text-nowrap"
-                                    t-out="display_amount_b"
-                                    t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
-                            </td>
-                        </tr>
-                    </t>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td><strong><span>Total Paid</span></strong></td>
-                        <td t-if="show_amount_col"/>
-                        <td class="text-right">
-                            <!-- payment_total en B; incluye counterpart_currency_amount + write_off + withholdings_amount -->
-                            <strong><span class="text-nowrap" t-field="o.payment_total"/></strong>
-                        </td>
-                    </tr>
-                </tfoot>
-            </table>
-            <br/>
-            <t t-set="matched_lines" t-value="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')"/>
-            <table class="table table-sm o_main_table" name="matching_table">
-                <thead>
-                    <tr>
-                        <th><span>Imputed Vouchers</span></th>
-                        <th class="text-center"><span>Exp. Date</span></th>
-                        <th class="text-right"><span>Original Amount</span></th>
-                        <th class="text-right"><span>Imputed Amount</span></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <t t-foreach="matched_lines" t-as="line">
-                        <tr>
-                            <td><span t-field='line.move_id.display_name'/></td>
-                            <td class="text-center">
-                                <span class="text-nowrap" t-field="line.date_maturity"/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- Original amount in the line's currency (= B for invoice lines) -->
-                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- payment_matched_amount is already expressed in B (destination_currency_id) -->
-                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
-                            </td>
-
-                        </tr>
-                        <span class="reversal_move_lines"/>
-                    </t>
-                    <tr t-if="sum(payment_bundle.mapped('unmatched_amount'))">
-                        <td>On account</td>
-                        <td class="text-center"/>
-                        <td class="text-right o_price_total"/>
-                        <td class="text-right o_price_total">
-                            <!-- unmatched_amount is in B (destination_currency_id) -->
-                            <span class="text-nowrap" t-out="sum(payment_bundle.mapped('unmatched_amount'))" t-options="{'widget': 'monetary', 'display_currency': o.destination_currency_id}" />
-                        </td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td colspan="3"><strong><span>Total Imputed</span></strong></td>
-                        <td class="text-right">
-                            <!-- o.matched_amount + o.unmatched_amount = abs(o.payment_total), que en bundles
-                                 ya acumula todos los link_payments gracias al override de payment_total -->
-                            <strong><span class="text-nowrap" t-out="o.matched_amount + o.unmatched_amount" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/></strong>
-                        </td>
-                    </tr>
-                </tfoot>
-            </table>
-            <br/>
-            <table class="table table-sm o_main_table" name="open_table" t-if="o.partner_type=='customer'" groups="l10n_ar_ux.group_include_pending_receivable_documents">
+        <xpath expr="//t[@t-set='payment_pro_after_matching_table']" position="after">
+            <table class="table table-sm o_main_table" name="open_table" t-if="o.partner_type == 'customer'" groups="l10n_ar_ux.group_include_pending_receivable_documents">
                 <thead>
                     <tr>
                         <th><span>Pending Vouchers at </span><span t-out="datetime.datetime.today()" t-options='{"widget": "date"}'/></th>
@@ -250,9 +80,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <t t-foreach="o.env['account.move.line'].search([('partner_id', '=', o.partner_id.commercial_partner_id.id), ('account_id.account_type', '=', o.partner_type=='customer' and 'asset_receivable' or 'liability_payable'), ('reconciled', '=', False), ('account_id.active', '=', True), ('move_id.state', '=', 'posted'), ('company_id', '=', o.company_id.id)])" t-as="line">
+                    <t t-foreach="o.env['account.move.line'].search([('partner_id', '=', o.partner_id.commercial_partner_id.id), ('account_id.account_type', '=', o.partner_type == 'customer' and 'asset_receivable' or 'liability_payable'), ('reconciled', '=', False), ('account_id.active', '=', True), ('move_id.state', '=', 'posted'), ('company_id', '=', o.company_id.id)])" t-as="line">
                         <tr>
-                            <td><span t-field='line.move_id.display_name'/></td>
+                            <td><span t-field="line.move_id.display_name"/></td>
                             <td class="text-center">
                                 <span class="text-nowrap" t-field="line.date_maturity"/>
                             </td>
@@ -269,63 +99,24 @@
                     <tr>
                         <td colspan="3"><strong><span>Total Pending</span></strong></td>
                         <td class="text-right">
-                            <strong><span class="text-nowrap" t-out="sum(o.env['account.move.line'].search([('partner_id', '=', o.partner_id.commercial_partner_id.id), ('account_id.account_type', '=', o.partner_type=='customer' and 'asset_receivable' or 'liability_payable'), ('reconciled', '=', False), ('account_id.active', '=', True), ('move_id.state', '=', 'posted'), ('company_id', '=', o.company_id.id)]).mapped('amount_residual'))" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></strong>
+                            <strong><span class="text-nowrap" t-out="sum(o.env['account.move.line'].search([('partner_id', '=', o.partner_id.commercial_partner_id.id), ('account_id.account_type', '=', o.partner_type == 'customer' and 'asset_receivable' or 'liability_payable'), ('reconciled', '=', False), ('account_id.active', '=', True), ('move_id.state', '=', 'posted'), ('company_id', '=', o.company_id.id)]).mapped('amount_residual'))" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/></strong>
                         </td>
                     </tr>
                 </tfoot>
             </table>
-            <table>
-                <div class="float-left">
-                    <span t-if="o.company_id.l10n_ar_report_signature" t-field="o.memo"/>
+
+            <div class="row" name="l10n_ar_report_signature" t-if="o.company_id.l10n_ar_report_signature">
+                <div class="col-8">
+                    <span t-field="o.memo"/>
                 </div>
-                <div class="float-right" style="heigth:100px;width:200px;text-align:center;">
-                    <t t-if="o.company_id.l10n_ar_report_signature">
-                        <span t-field="o.company_id.l10n_ar_report_signature" t-options='{"widget": "image"}'/>
-                        <span t-field="o.company_id.l10n_ar_report_signed_by"/>
-                    </t>
+                <div class="col-4 text-center" style="height: 100px;">
+                    <span t-field="o.company_id.l10n_ar_report_signature" t-options='{"widget": "image"}'/>
+                    <br/>
+                    <span t-field="o.company_id.l10n_ar_report_signed_by"/>
                 </div>
-            </table>
-        </div>
-    </template>
-
-    <template id="report_payment_receipt_reversal_moves" active="False" inherit_id="l10n_ar_tax.report_payment_receipt_document">
-       <xpath expr="//span[hasclass('reversal_move_lines')]" position="replace">
-            <t t-foreach="line.move_id.reversal_move_ids" t-as="reversal_move_id">
-                <t t-set="imputed_amount" t-value="[item['amount'] for item in reversal_move_id.sudo()._get_all_reconciled_invoice_partials() if item['aml_id'] == line.id]"/>
-                <tr>
-                    <td><span style="padding-left: 20px;">└</span> <span t-field='reversal_move_id.display_name'/></td>
-                    <td class="text-center">
-                        <span class="text-nowrap" t-field="reversal_move_id.invoice_date"/>
-                    </td>
-                    <td class="text-right o_price_total" >
-                        <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and 1.0 or -1.0) * sum(imputed_amount)" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
-                    </td>
-                    <td class="text-right o_price_total" >
-                    </td>
-                </tr>
-
-            </t>
-
+            </div>
         </xpath>
-    </template>
 
-  <template id="report_payment_receipt_bundle">
-        <t t-call="web.html_container">
-            <t t-foreach="docs.with_context(print_in_bundles=True)._get_payment_bundles().values()" t-as="payment_bundle">
-                <t t-set="o" t-value="payment_bundle[0]"/>
-                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
-                <t t-call="#{o._get_name_receipt_report('account.report_payment_receipt_document')}" t-lang="lang"/>
-            </t>
-        </t>
-  </template>
-  <record id="action_report_receipt_bundle" model="ir.actions.report">
-        <field name="name">Payment Receipt bundled</field>
-        <field name="model">account.payment</field>
-        <field name="report_type">qweb-pdf</field>
-        <field name="report_name">l10n_ar_tax.report_payment_receipt_bundle</field>
-        <field name="report_file">l10n_ar_tax.report_payment_receipt_bundle</field>
-        <field name="binding_model_id" ref="model_account_payment"/>
-        <field name="binding_type">report</field>
-        <field name="binding_view_types">list</field>
-    </record>
+        <xpath expr="//div[@name='payment_pro_observations']" position="replace"/>
+    </template>
 </odoo>


### PR DESCRIPTION
**account_payment_pro (nuevo módulo base para el reporte)**
- Nuevo account_payment_pro/models/account_payment_report.py: métodos base _get_name_receipt_report, _get_payment_bundle_key, _get_payment_bundles, _select_bundle 
- Modificado account_payment_pro/models/init.py: agrega from . import account_payment_report 
- Nuevo account_payment_pro/views/report_payment_receipt_templates.xml: layout base del recibo (multimoneda, cheques LATAM, write-off, imputaciones) Modificado account_payment_pro/manifest.py: agrega el nuevo archivo de vista 

 **l10n_ar_payment_bundle (responsable del agrupado/bundled)**

- Nuevo l10n_ar_payment_bundle/views/report_payment_receipt_templates.xml: herencia del report_payment_receipt para setear payment_bundles, template report_payment_receipt_bundle + acción de reporte
- Modificado l10n_ar_payment_bundle/models/account_payment.py: agrega override de _get_payment_bundle_key (lógica AR-específica, antes en l10n_ar_tax) 
- Modificado l10n_ar_payment_bundle/manifest.py: agrega el nuevo archivo de vista 

**l10n_ar_tax (solo Argentina/AFIP/retenciones)**

- Reemplazado l10n_ar_tax/views/report_payment_receipt_templates.xml: ahora hereda de account_payment_pro.report_payment_receipt_document en lugar de account.report_payment_receipt_document
- Modificado l10n_ar_tax/models/account_payment.py: eliminados _get_payment_bundle_key, _get_payment_bundles, _select_bundle y el import de defaultdict (ya no necesario)