### PR TITLE
[FIX] l10n_ar_tax: skip _onchange_amount because is allready computed  in _onchange_withholdings

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -112,6 +112,22 @@ class AccountPayment(models.Model):
             rec.amount_exact = rec.amount
             # rec.unreconciled_amount = rec.to_pay_amount - rec.selected_debt
 
+    @api.onchange("withholdings_amount")
+    def _onchange_amount(self):
+        by_pass_withholding = self.filtered(
+            lambda x: (
+                x.partner_type == "supplier"
+                and x.payment_method_code
+                not in [
+                    "in_third_party_checks",
+                    "out_third_party_checks",
+                    "return_third_party_checks",
+                    "new_third_party_checks",
+                ]
+            )
+        )
+        super(AccountPayment, self - by_pass_withholding)._onchange_amount()
+
     @api.onchange("partner_id")
     def _onchange_partner_id(self):
         for rec in self:


### PR DESCRIPTION

When withholdings_amount changes on a supplier payment, the parent _onchange_amount was being triggered regardless of the payment method, causing incorrect amount recalculation for third-party check methods (in/out/return/new_third_party_checks).

Override _onchange_amount to bypass the parent call for those payment methods on supplier payments.