### PR TITLE
[FIX] l10n_ar_tax: arba ws cuando el cuit no está en el padrón

### DIFF
--- a/l10n_ar_tax/models/res_company.py
+++ b/l10n_ar_tax/models/res_company.py
@@ -56,6 +56,13 @@ class ResCompany(models.Model):
             error_type = root.find(".//tipoError").text
             error_code = root.find(".//codigoError").text
             error_msg = root.find(".//mensajeError").text.replace("<![CDATA[", "").replace("]]/>", "")
+            if error_code == "11":
+                # ARBA code 11 means CUIT not present in padron: do not block flow.
+                return {
+                    "CodigoError": error_code,
+                    "CodigoHash": root.find(".//codigoHash").text if root.find(".//codigoHash") is not None else "",
+                    "MensajeError": error_msg,
+                }
             raise UserError(_("ARBA Error %s(%s): %s") % (error_type, error_code, error_msg))
         if root.tag == "COMPROBANTE":
             try:


### PR DESCRIPTION
Ticket: 118208
Si el cuit no se encuentra en el padrón de ARBA entonces lanzamos un raise que dice que el cuit no está presente en arba pero en realidad no queremos que se lance ese raise, por lo tanto en este commit lo que hacemos es que permita cargar la factura y al cliente se le asigne la alícuota por defecto de la posición fiscal.