### PR TITLE
[IMP] l10n_ar_tax: bulk payment wizard with withholdings support

### DIFF
--- a/l10n_ar_tax/models/account_move_line.py
+++ b/l10n_ar_tax/models/account_move_line.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountMoveLine(models.Model):
@@ -43,3 +44,31 @@ class AccountMoveLine(models.Model):
                     vals["display_type"] = "product"
 
         return super().create(vals_list)
+
+    def action_register_payment(self, ctx=None):
+        to_pay_partners = self.mapped("move_id.commercial_partner_id") or self.mapped("partner_id")
+        company_pay_pro = len(self.mapped("company_id").ids) == 1 and self.mapped("company_id").use_payment_pro
+        payment_pro = self.env.context.get("force_payment_pro")
+
+        # Payment pro con múltiples partners → wizard account.payment.register con retenciones
+        if payment_pro is not False and (payment_pro or company_pay_pro) and len(to_pay_partners) > 1:
+            to_pay_move_lines = self.filtered(
+                lambda r: not r.reconciled and r.account_id.account_type in ["asset_receivable", "liability_payable"]
+            )
+            if not to_pay_move_lines:
+                raise UserError(_("Nothing to be paid on selected entries"))
+            return {
+                "name": _("Register Payment"),
+                "type": "ir.actions.act_window",
+                "res_model": "account.payment.register",
+                "view_mode": "form",
+                "views": [[False, "form"]],
+                "target": "new",
+                "context": {
+                    "active_model": "account.move.line",
+                    "active_ids": to_pay_move_lines.ids,
+                    "default_company_id": self.company_id.id,
+                    "payment_pro": True,
+                },
+            }
+        return super().action_register_payment(ctx=ctx)

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -540,3 +540,11 @@ class AccountPayment(models.Model):
         currency_id."""
         self.ensure_one()
         return bundles.get(self._get_payment_bundle_key())
+
+    def _compute_to_pay_move_lines(self):
+        # When creating payments from the bulk payment wizard, we explicitly set
+        # to_pay_move_line_ids to the selected lines only, so we skip auto-computation
+        # to avoid _add_all() adding unrelated lines of different currencies.
+        if self.env.context.get("skip_to_pay_compute"):
+            return
+        return super()._compute_to_pay_move_lines()

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_withholding_thresholds
 from . import test_payment_withholding_multimoneda
 from . import test_payment_withholding_checks_multimoneda
 from . import test_padron_cleanup_cron
+from . import test_payment_register_pro_wizard

--- a/l10n_ar_tax/tests/test_payment_register_pro_wizard.py
+++ b/l10n_ar_tax/tests/test_payment_register_pro_wizard.py
@@ -1,0 +1,108 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentRegisterProWizard(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.today = fields.Date.today()
+        cls.company = cls.env.company
+        cls.company.use_payment_pro = True
+        cls.company_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
+        )
+        cls.partner_ri = cls.env["res.partner"].create(
+            dict(name="RI Partner", vat="34278580484", country_id=cls.env.ref("base.ar").id)
+        )
+
+    def _make_invoice(self, partner, amount=100):
+        inv = self.env["account.move"].create(
+            {
+                "partner_id": partner.id,
+                "invoice_date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.company_journal.id,
+                "company_id": self.company.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                        }
+                    )
+                ],
+            }
+        )
+        inv.action_post()
+        return inv
+
+    def test_action_register_payment_single_partner_opens_account_payment(self):
+        """Single partner: action_register_payment should open `account.payment` form."""
+        invoice = self._make_invoice(self.partner_ri, 120)
+        action = invoice.action_register_payment()
+        self.assertEqual(action.get("res_model"), "account.payment")
+        self.assertEqual(action.get("target"), "current")
+        ctx = action.get("context") or {}
+        self.assertIn("default_to_pay_move_line_ids", ctx)
+        self.assertTrue(ctx.get("default_to_pay_move_line_ids"))
+
+    def test_action_register_payment_multiple_partners_opens_register_wizard(self):
+        """Multiple partners: should open `account.payment.register` wizard with `payment_pro` context."""
+        partner_other = self.env.ref("base.res_partner_12")
+        invoice_1 = self._make_invoice(self.partner_ri, 50)
+        invoice_2 = self._make_invoice(partner_other, 75)
+
+        action = (invoice_1 + invoice_2).line_ids.action_register_payment()
+        self.assertEqual(action.get("res_model"), "account.payment.register")
+        self.assertEqual(action.get("target"), "new")
+        ctx = action.get("context") or {}
+        self.assertTrue(ctx.get("payment_pro"))
+        self.assertIn("active_ids", ctx)
+        self.assertTrue(ctx.get("active_ids"))
+
+    def test_create_payments_and_grouping(self):
+        """Create payments from register wizard and assert payments are posted and grouped per partner when enabled."""
+        partner_other = self.env.ref("base.res_partner_12")
+        invoices = self.env["account.move"]
+        amounts = [30, 40, 50, 60]
+        partners = [self.partner_ri, self.partner_ri, partner_other, partner_other]
+        for amt, partner in zip(amounts, partners):
+            invoices |= self._make_invoice(partner, amt)
+
+        action = invoices.line_ids.action_register_payment()
+        ctx = action.get("context") or {}
+        wiz = self.env["account.payment.register"].with_context(**ctx).create({})
+
+        payments = wiz._create_payments()
+        payments = self.env["account.payment"].browse(payments.ids if hasattr(payments, "ids") else [])
+
+        self.assertTrue(payments, "Payments should be created")
+        for p in payments:
+            self.assertIn(p.state, ["posted", "in_process", "paid"], "Payment should be posted or paid")
+
+        # Test grouping
+        invoices2 = self.env["account.move"]
+        for amt, partner in zip([10, 20, 30, 40], [self.partner_ri, self.partner_ri, partner_other, partner_other]):
+            invoices2 |= self._make_invoice(partner, amt)
+
+        action2 = invoices2.line_ids.action_register_payment()
+        ctx2 = action2.get("context") or {}
+        wiz2 = self.env["account.payment.register"].with_context(**ctx2).create({})
+        if hasattr(wiz2, "group_payment"):
+            wiz2.group_payment = True
+        else:
+            wiz2 = self.env["account.payment.register"].with_context(**{**ctx2, "group_payment": True}).create({})
+
+        payments2 = wiz2._create_payments()
+        payments2 = self.env["account.payment"].browse(payments2.ids if hasattr(payments2, "ids") else [])
+        self.assertTrue(payments2, "Payments should be created when grouping")
+
+        partners_created = payments2.mapped("partner_id")
+        self.assertEqual(len(payments2), len(partners_created), "There should be one payment per partner when grouping")

--- a/l10n_ar_tax/wizard/account_payment_register.py
+++ b/l10n_ar_tax/wizard/account_payment_register.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 
-from odoo import Command, api, fields, models
+from odoo import Command, _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -18,10 +18,37 @@ class AccountPaymentRegister(models.TransientModel):
         readonly=False,
         domain=[("l10n_ar_tax_ids.tax_type", "=", "withholding")],
     )
+    fiscal_position_mode = fields.Selection(
+        [("automatic", "Automatic"), ("manual", "Manual")],
+        default="automatic",
+        required=True,
+    )
+    is_payment_pro = fields.Boolean(
+        default=lambda self: bool(self.env.context.get("payment_pro")),
+    )
 
-    @api.depends("line_ids", "partner_id")
+    def _is_check_or_bundle(self, payment_method_code, check_subtype=False):
+        if check_subtype == "move_check":
+            codes = ["in_third_party_checks", "out_third_party_checks", "return_third_party_checks"]
+        elif check_subtype == "new_check":
+            codes = ["new_third_party_checks", "own_checks"]
+        else:
+            codes = [
+                "in_third_party_checks",
+                "out_third_party_checks",
+                "return_third_party_checks",
+                "new_third_party_checks",
+                "own_checks",
+                "payment_bundle",
+            ]
+        return payment_method_code in codes
+
+    @api.depends("line_ids", "partner_id", "fiscal_position_mode")
     def _compute_fiscal_position_id(self):
         for rec in self:
+            # En modo manual el usuario elige la FP directamente; no recomputamos
+            if rec.fiscal_position_mode == "manual":
+                continue
             if (
                 rec.partner_type != "supplier"
                 or rec.country_code != "AR"
@@ -60,3 +87,126 @@ class AccountPaymentRegister(models.TransientModel):
                 )
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_ids = withholdings
+
+    @api.depends("is_payment_pro")
+    def _compute_available_journal_ids(self):
+        super()._compute_available_journal_ids()
+        for wizard in self:
+            if not wizard.is_payment_pro:
+                continue
+            # Exclude journals that have NO method outside check/bundle (purely check/bundle journals).
+            # Mixed journals (e.g. Bank with Manual + own_checks) are kept;
+            # the method filter below removes individual check/bundle lines.
+            wizard.available_journal_ids = wizard.available_journal_ids.filtered(
+                lambda j: any(
+                    not wizard._is_check_or_bundle(code)
+                    for code in (
+                        j.inbound_payment_method_line_ids.payment_method_id.mapped("code")
+                        + j.outbound_payment_method_line_ids.payment_method_id.mapped("code")
+                    )
+                )
+            )
+
+    @api.depends("is_payment_pro")
+    def _compute_payment_method_line_fields(self):
+        super()._compute_payment_method_line_fields()
+        for wizard in self:
+            if not wizard.is_payment_pro:
+                continue
+            wizard.available_payment_method_line_ids = wizard.available_payment_method_line_ids.filtered(
+                lambda l: not wizard._is_check_or_bundle(l.payment_method_id.code)
+            )
+
+    def _get_debt_line_ids_cmd(self, batch_result):
+        valid_types = {"asset_receivable", "liability_payable"}
+        debt_lines = batch_result["lines"].filtered(lambda l: l.account_id.account_type in valid_types)
+        return [Command.set(debt_lines.ids)] if debt_lines else []
+
+    def _create_payment_vals_from_wizard(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_wizard(batch_result)
+        if not self.is_payment_pro:
+            return payment_vals
+        # Strip withholding write_off entries — the payment's l10n_ar_withholding_line_ids
+        # creates the journal lines via _prepare_move_withholding_lines at action_post time.
+        payment_vals["write_off_line_vals"] = [
+            v
+            for v in payment_vals.get("write_off_line_vals", [])
+            if not v.get("tax_repartition_line_id") and not v.get("tax_ids")
+        ]
+        # Embed to_pay_move_line_ids so l10n_ar_fiscal_position_id resolves at payment
+        # creation time, triggering withholding computation before action_post.
+        debt_cmd = self._get_debt_line_ids_cmd(batch_result)
+        if debt_cmd:
+            payment_vals.setdefault("to_pay_move_line_ids", debt_cmd)
+        return payment_vals
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_batch(batch_result)
+        if not self.is_payment_pro:
+            return payment_vals
+        # Same as wizard path: embed to_pay_move_line_ids for multi-partner batches.
+        debt_cmd = self._get_debt_line_ids_cmd(batch_result)
+        if debt_cmd:
+            payment_vals.setdefault("to_pay_move_line_ids", debt_cmd)
+        return payment_vals
+
+    def _init_payments(self, to_process, edit_mode=False):
+        if self.env.context.get("payment_pro_draft"):
+            for vals in to_process:
+                for key in ("write_off_line_vals", "force_balance", "line_ids"):
+                    vals["create_vals"].pop(key, None)
+        payments = super()._init_payments(to_process, edit_mode=edit_mode)
+        if not self.is_payment_pro:
+            return payments
+        # Flush pending stored computed fields (l10n_ar_withholding_line_ids,
+        # withholdings_amount) triggered by to_pay_move_line_ids set at creation.
+        self.env.flush_all()
+        # amount must equal (to_pay_amount - withholdings_amount) so that:
+        #   payment_total = amount + withholdings_amount == to_pay_amount
+        # For single-partner, l10n_ar_withholding already reduces the wizard amount;
+        # for multi-partner batches the wizard carries no withholdings, so we correct here.
+        for vals in to_process:
+            payment = vals["payment"]
+            withholdings = getattr(payment, "withholdings_amount", 0.0)
+            if not withholdings:
+                continue
+            net = payment.to_pay_amount - withholdings
+            if net > 0 and not payment.currency_id.is_zero(net - payment.amount):
+                payment.write({"amount": net, "amount_exact": net})
+        return payments
+
+    def _post_payments(self, to_process, edit_mode=False):
+        if not self.env.context.get("payment_pro_draft"):
+            return super()._post_payments(to_process, edit_mode=edit_mode)
+
+    def _reconcile_payments(self, to_process, edit_mode=False):
+        valid_types = {"asset_receivable", "liability_payable"}
+        for vals in to_process:
+            payment = vals["payment"]
+            if payment.company_id.use_payment_pro:
+                debt_lines = vals["to_reconcile"].filtered(lambda l: l.account_id.account_type in valid_types)
+                if debt_lines and not payment.to_pay_move_line_ids:
+                    payment.to_pay_move_line_ids = [Command.set(debt_lines.ids)]
+        if not self.env.context.get("payment_pro_draft"):
+            return super()._reconcile_payments(to_process, edit_mode=edit_mode)
+
+    def _create_payments(self):
+        payments = super(AccountPaymentRegister, self.with_context(skip_to_pay_compute=True))._create_payments()
+        if self.fiscal_position_mode == "manual" and self.l10n_ar_fiscal_position_id:
+            payments.l10n_ar_fiscal_position_id = self.l10n_ar_fiscal_position_id
+        return payments
+
+    def action_create_and_confirm(self):
+        return self.action_create_payments()
+
+    def action_create_draft(self):
+        payments = self.with_context(payment_pro_draft=True)._create_payments()
+        return {
+            "name": _("Payments"),
+            "type": "ir.actions.act_window",
+            "res_model": "account.payment",
+            "view_mode": "list,form",
+            "domain": [("id", "in", payments.ids)],
+            "context": {"create": False},
+            "target": "current",
+        }

--- a/l10n_ar_tax/wizard/account_payment_register_views.xml
+++ b/l10n_ar_tax/wizard/account_payment_register_views.xml
@@ -4,10 +4,46 @@
         <field name="name">account.payment.register.form</field>
         <field name="model">account.payment.register</field>
         <field name="inherit_id" ref="account.view_account_payment_register_form"/>
+        <field name="priority">100</field>
         <field name="arch" type="xml">
-            <group name="group2">
-                <field name="l10n_ar_fiscal_position_id" options="{'no_create': True}" invisible="partner_type != 'supplier' or country_code != 'AR' or not can_edit_wizard or (can_group_payments and not group_payment)"/>
+            <group name="group2" position="inside">
+                <field name="is_payment_pro" invisible="1" force_save="1"/>
+                <field name="payment_type" invisible="1"/>
+                <field name="country_code" invisible="1"/>
+                <!-- Modo automático/manual de posición fiscal (solo cuando payment_pro) -->
+                <label for="fiscal_position_mode" invisible="not is_payment_pro"/>
+                <field name="fiscal_position_mode" widget="radio" nolabel="1" invisible="not is_payment_pro"/>
+                <!-- FP editable:
+                     - payment_pro: visible solo cuando modo manual
+                     - normal: visible con las condiciones originales (supplier AR, etc.) -->
+                <field name="l10n_ar_fiscal_position_id"
+                    options="{'no_create': True}"
+                    invisible="(is_payment_pro and fiscal_position_mode != 'manual') or (not is_payment_pro and (partner_type != 'supplier' or country_code != 'AR' or not can_edit_wizard or (can_group_payments and not group_payment)))"/>
             </group>
+            <!-- Footer personalizado para modo payment_pro -->
+            <footer position="replace">
+                <footer>
+                    <!-- Botones estándar (solo cuando NO es payment_pro) -->
+                    <button string="Create Payments" name="action_create_payments" type="object"
+                            class="oe_highlight" data-hotkey="q"
+                            invisible="is_payment_pro or total_payments_amount == 1"/>
+                    <button string="Create Payment" name="action_create_payments" type="object"
+                            class="oe_highlight" data-hotkey="q"
+                            invisible="is_payment_pro or total_payments_amount != 1"/>
+                    <!-- Botones payment_pro -->
+                    <button name="action_create_and_confirm"
+                            string="Create and Confirm"
+                            type="object"
+                            class="oe_highlight"
+                            invisible="not is_payment_pro"/>
+                    <button name="action_create_draft"
+                            string="Create as Draft"
+                            type="object"
+                            class="btn-secondary"
+                            invisible="not is_payment_pro"/>
+                    <button string="Discard" class="btn btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </footer>
         </field>
     </record>
 


### PR DESCRIPTION
- Add `is_payment_pro`, `fiscal_position_mode` (automatic/manual) and related methods to `account.payment.register` in l10n_ar_tax
- Filter out check/bundle journals and payment methods when `is_payment_pro`
- Override `_create_payment_vals_from_wizard/batch` to strip withholding write_off lines and embed `to_pay_move_line_ids` per batch
- Override `_init_payments` to adjust payment amount after withholdings
- Override `_post_payments` / `_reconcile_payments` to handle draft mode
- Override `_create_payments` with `skip_to_pay_compute` context and apply manual fiscal position to created payments
- Add `action_create_and_confirm` and `action_create_draft` actions
- Update register wizard view: add `fiscal_position_mode` radio, conditional `l10n_ar_fiscal_position_id` field and payment_pro footer buttons
- Add `action_register_payment` override in `account.move.line` for multi-partner case: open `account.payment.register` with `payment_pro` ctx
- Add `_compute_to_pay_move_lines` override in `account.payment` to skip auto-computation when `skip_to_pay_compute` context is set
- Add tests: single-partner opens account.payment form, multi-partner opens register wizard, create payments with grouping

Change note: Se incorpora al módulo `l10n_ar_tax` el wizard de pago masivo con retenciones (antes en `account_payment_pro`). Al seleccionar facturas de múltiples proveedores con Payment Pro activo, se abre el wizard `account.payment.register` con soporte de posición fiscal automática/manual, filtrado de journals de cheques y creación de pagos en modo confirmado o borrador.