### PR TITLE
[IMP] l10n_ar_ux: add additional Argentine codes for invoices and references

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -90,3 +90,8 @@ class AccountMove(models.Model):
             line.balance = balance
         res = super()._post(soft=soft)
         return res
+
+    @api.model
+    def _get_l10n_ar_codes_used_for_inv_and_ref(self):
+        res = super()._get_l10n_ar_codes_used_for_inv_and_ref()
+        return res + ["33", "331"]


### PR DESCRIPTION
Agregamos los códigos 33 y 331 de los comprobantes de Liquidación Primaria y Secundaria de Granos, para que puedan elegirse como Tipo de documento en Notas de crédito.