### PR TITLE
[REV] l10n_ar_tax: revert auto-sync amount onchange

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -112,22 +112,6 @@ class AccountPayment(models.Model):
             rec.amount_exact = rec.amount
             # rec.unreconciled_amount = rec.to_pay_amount - rec.selected_debt
 
-    @api.onchange("withholdings_amount")
-    def _onchange_amount(self):
-        by_pass_withholding = self.filtered(
-            lambda x: (
-                x.partner_type == "supplier"
-                and x.payment_method_code
-                not in [
-                    "in_third_party_checks",
-                    "out_third_party_checks",
-                    "return_third_party_checks",
-                    "new_third_party_checks",
-                ]
-            )
-        )
-        super(AccountPayment, self - by_pass_withholding)._onchange_amount()
-
     @api.onchange("partner_id")
     def _onchange_partner_id(self):
         for rec in self:


### PR DESCRIPTION
This reverts commit d4a375bc9382a3b2cbd14889080d9e7ebe732690.

The _onchange_amount method that auto-synced amount with to_pay_amount when adding/removing invoices had a fundamental execution order problem:

1. Our onchange executes FIRST → syncs amount = to_pay_amount
2. l10n_ar_tax withholding calculations execute AFTER → modify amount
3. But we already overwrote the amount in step 1

This caused withholding amounts to be incorrect in supplier payments.

Multiple detection strategies were attempted:
- Check _origin state (unreliable in tests and new records)
- Detect payment_difference == 0 (breaks when withholdings apply)
- Compare old vs new line counts (too fragile)
- Field flags (too complex)

No robust solution exists because:
- We cannot predict if withholdings will be calculated later
- We cannot distinguish "user customization" from "withholding adjustment"
- Onchange execution order is not controllable

The original issue (#118451) where amount doesn't update when removing invoices is acceptable compared to breaking withholding calculations.

Users can manually adjust the amount if needed after removing invoices.

Closes #118451