### PR TITLE
[IMP] l10n_ar_tax: split payment receipt report by layer

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -2,8 +2,6 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from collections import defaultdict
-
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -533,23 +531,7 @@ class AccountPayment(models.Model):
     def _get_payment_bundle_key(self):
         if self.company_id.country_id.code == "AR" and self.env.context.get("print_in_bundles"):
             return f"{self.company_id.id}-{self.partner_id.id}-{self.payment_type}-{self.currency_id.id if self.currency_id != self.company_currency_id else self.counterpart_currency_id.id}"
-        return self.id
-
-    def _get_payment_bundles(self):
-        """Returns a dictionary of payment bundles, where the key is a tuple
-        of (company_id, partner_id, payment_type, currency_id) and the value
-        is a recordset of account.payment."""
-        bundles = defaultdict(lambda: self.env["account.payment"])
-        for rec in self:
-            bundles[rec._get_payment_bundle_key()] += rec
-        return bundles
-
-    def _select_bundle(self, bundles):
-        """Selects a bundle from the dictionary of payment bundles based on
-        the current record's company_id, partner_id, payment_type, and
-        currency_id."""
-        self.ensure_one()
-        return bundles.get(self._get_payment_bundle_key())
+        return super()._get_payment_bundle_key()
 
     def _compute_to_pay_move_lines(self):
         # When creating payments from the bulk payment wizard, we explicitly set

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -1,27 +1,25 @@
 <odoo>
 
-    <template id="report_payment_receipt" inherit_id="account.report_payment_receipt">
-        <t t-foreach="docs" position="before">
-            <t t-set="payment_bundles" t-value="docs._get_payment_bundles()"/>
-        </t>
-        <t t-call="account.report_payment_receipt_document" position="attributes">
-            <attribute name="t-call">#{ o._get_name_receipt_report('account.report_payment_receipt_document') }</attribute>
-        </t>
-        <t t-set="lang" position="after">
-            <t t-set="payment_bundle" t-value="o._select_bundle(payment_bundles)"/>
-        </t>
-    </template>
+    <!-- Primary AR payment receipt document template.
+         Inherits from account_payment_pro.report_payment_receipt_document_pro and adds:
+         - Argentine header variables (custom_header, document_letter, etc.)
+         - Partner VAT / AFIP responsibility info
+         - Withholding rows in the payments table
+         - show_amount_col extended to include withholdings condition
+         - Pending receivables table (customers only, controlled by group)
+         - Signature / memo footer -->
+    <template id="report_payment_receipt_document"
+              inherit_id="account_payment_pro.report_payment_receipt_document_pro"
+              primary="True"
+              priority="16">
 
-    <!-- we force priority greater than 16 so that it dont break inheritance of report_saleorder_document_inherit_sale_stock. with this we are loosing the incoterm field added but that sale_stock view -->
-    <template id="report_payment_receipt_document" inherit_id="account.report_payment_receipt_document" primary="True" priority="16" >
-        <t t-set="o" position="after">
+        <!-- ── Argentine header variables ──────────────────────────────────────── -->
+        <xpath expr="//t[@t-set='report_name']" position="replace">
+            <t t-set="report_name" t-value="o.payment_type == 'outbound' and 'Orden de pago' or 'Recibo'"/>
             <t t-set="custom_header" t-value="'l10n_ar.custom_header'"/>
-            <t t-set="report_date" t-value="o.date"/>
             <t t-set="document_letter" t-value="'X'"/>
             <t t-set="document_legend" t-value="'Doc. no válido como factura'"/>
-            <t t-set="report_number" t-value="o.name"/>
-            <t t-set="report_name" t-value="o.payment_type == 'outbound' and 'Orden de pago' or 'Recibo'"/>
-            <t t-set="header_address" t-value="(o._fields.get('receiptbook_id') and o.receiptbook_id and o.receiptbook_id.report_partner_id or o.company_id.partner_id or '')"/>
+            <t t-set="header_address" t-value="o._get_receipt_header_address()"/>
             <t t-set="custom_footer">
                 <div class="row">
                     <div name="footer_left_column" class="col-8">
@@ -39,207 +37,45 @@
                     </div>
                 </div>
             </t>
-        </t>
-        <div class="page" position="replace">
-            <div class="page">
-                <div id="informations" class="row mt8 mb8">
-                    <div class="col-6">
+        </xpath>
 
-                        <!-- IDENTIFICACION (ADQUIRIENTE-LOCATARIO-PRESTARIO) -->
+        <!-- ── show_amount_col: also show extra column when withholdings exist in a foreign-currency bundle ── -->
+        <xpath expr="//t[@name='show_amount_col_def']" position="replace">
+            <t name="show_amount_col_def" t-set="show_amount_col" t-value="any(doc.currency_id != o.destination_currency_id for doc in payment_bundle) or bool(payment_bundle.l10n_ar_withholding_line_ids.filtered('amount') and o.destination_currency_id != o.company_currency_id)"/>
+        </xpath>
 
-                        <!-- (14) Apellido uy Nombre: Denominicacion o Razon Soclial -->
-                        <strong><span t-if="o.partner_type == 'supplier'">Supplier: </span><span t-if="o.partner_type == 'customer'">Customer: </span></strong><span t-field="o.partner_id.commercial_partner_id.name"/>
+        <!-- ── Partner info: add VAT Cond (AFIP responsibility) and CUIT ──────── -->
+        <xpath expr="//span[@name='partner_info_extra']" position="replace">
+            <!-- (16) Responsabilidad AFIP -->
+            <br/><strong>VAT Cond: </strong><span t-field="o.partner_id.l10n_ar_afip_responsibility_type_id"/>
+            <!-- (17) CUIT -->
+            <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
+                <br/><strong><t t-out="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-out="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
+            </t>
+        </xpath>
 
-                        <!-- (15) Domicilio Comercial -->
-                        <br/>
-                        <span t-out="o.partner_id" t-options='{"widget": "contact", "fields": ["address"], "no_marker": True, "no_tag_br": True}'/>
+        <!-- ── Withholding rows inside the payments table ───────────────────────── -->
+        <xpath expr="//t[@name='withholding_rows']" position="replace">
+            <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids.filtered('amount')" t-as="line">
+                <tr>
+                    <td>
+                        <span t-if="line.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="line.tax_id.invoice_label or 'Retención Ganancias'"/>
+                        <span t-else="" t-out="line.tax_id.invoice_label or line.tax_id.name"/>
+                    </td>
+                    <td class="text-right" t-if="show_amount_col">
+                        <!-- Withholding in ARS (company_currency) -->
+                        <span class="text-nowrap" t-out="line.amount" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
+                    </td>
+                    <td class="text-right o_price_total">
+                        <!-- Withholding converted to destination currency (B2) -->
+                        <span class="text-nowrap" t-out="line.payment_id.destination_currency_id.round(line.amount / line.payment_id._get_withholding_rate())" t-options='{"widget": "monetary", "display_currency": line.payment_id.destination_currency_id}'/>
+                    </td>
+                </tr>
+            </t>
+        </xpath>
 
-                        <!-- (16) Responsabilidad AFIP -->
-                        <strong>VAT Cond: </strong><span t-field="o.partner_id.l10n_ar_afip_responsibility_type_id"/>
-
-                        <!-- (17) CUIT -->
-                        <t t-if="o.partner_id.vat and o.partner_id.l10n_latam_identification_type_id.name and o.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
-                            <br/><strong><t t-out="o.partner_id.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-out="o.partner_id.l10n_ar_formatted_vat or o.partner_id.vat"/>
-                        </t>
-
-                    </div>
-                </div>
-            </div>
-            <br/>
-            <table class="table table-sm o_main_table" name="payments_table">
-                <!--
-                    show_amount_col: muestra columna "Importe" (moneda natural) cuando:
-                    - algún pago del bundle usa una moneda distinta a destination_currency_id (B), o
-                    - hay retenciones y B != C (ARS), ya que las retenciones siempre están en ARS.
-                -->
-                <t t-set="show_amount_col" t-value="any(doc.currency_id != o.destination_currency_id for doc in payment_bundle) or bool(payment_bundle.l10n_ar_withholding_line_ids.filtered('amount') and o.destination_currency_id != o.company_currency_id)"/>
-                <thead>
-                    <tr>
-                        <th><span>Payments</span></th>
-                        <th class="text-right" t-if="show_amount_col"><span>Importe</span></th>
-                        <th class="text-right">
-                            <span>Amount</span><span t-if="show_amount_col"> (<span t-field="o.destination_currency_id.name"/>)</span>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <t t-foreach="payment_bundle" t-as="doc">
-                        <t t-foreach="doc._get_latam_checks()" t-as="check">
-                            <tr>
-                                <td>
-                                    <span t-out="'Cheque nro %s' % (check.name)">Check nro 123456</span>
-                                    <span t-if="check.bank_id" t-out="' - %s' % (check.bank_id.name)"> - Santander Rio</span>
-                                    <span t-out="' (%s)' % (check.payment_method_line_id.name)"> (Electronic checkbook)</span>
-                                    <span t-if="check.payment_date"> - Exp. <span t-field="check.payment_date"/></span>
-                                </td>
-                                <td class="text-right" t-if="show_amount_col">
-                                    <!-- moneda natural del cheque = A (moneda del diario) -->
-                                    <span class="text-nowrap" t-out="check.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
-                                </td>
-                                <td class="text-right o_price_total">
-                                    <!-- B2 = A * counterpart_rate cuando B1==B2; si no, A / accounting_rate -->
-                                    <span class="text-nowrap" t-out="doc.destination_currency_id.round(check.amount * (doc.counterpart_rate or 1.0) if doc.counterpart_currency_id == doc.destination_currency_id else (check.amount / doc.accounting_rate if doc.accounting_rate else check.amount))" t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
-                                </td>
-                            </tr>
-                        </t>
-                    </t>
-                    <t t-foreach="payment_bundle.l10n_ar_withholding_line_ids.filtered('amount')" t-as="line">
-                        <tr>
-                            <td>
-                                <span t-if="line.tax_id.l10n_ar_tax_type in ['earnings', 'earnings_scale']" t-out="line.tax_id.invoice_label or 'Retención Ganancias'"/>
-                                <span t-else="" t-out="line.tax_id.invoice_label or line.tax_id.name"/>
-                            </td>
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- moneda natural de la retención = ARS (company_currency) -->
-                                <span class="text-nowrap" t-out="line.amount" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- B = C / rate del pago específico (preciso en bundles con distintas tasas) -->
-                                <span class="text-nowrap" t-out="line.payment_id.destination_currency_id.round(line.amount / line.payment_id._get_withholding_rate())" t-options='{"widget": "monetary", "display_currency": line.payment_id.destination_currency_id}'/>
-                            </td>
-                        </tr>
-                    </t>
-                    <!-- si queremos imprimir solo cuando tenemos apuntes tal vez este approach puede ser mas consistente -->
-                    <!-- <t t-foreach="o.l10n_ar_withholding_ids" t-as="line">
-                        <t t-set='sign' t-value="o.payment_type == 'outbound' and -1 or 1"/>
-                        <tr>
-                            <td>
-                                <span t-field='line.tax_line_id.name'/>
-                            </td>
-                            <td class="text-right" t-if="o.other_currency">
-                                <span t-out="line.amount_currency * sign" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <span t-out="line.balance * sign" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                            </td>
-                        </tr>
-                    </t> -->
-                    <t t-foreach="payment_bundle.filtered('write_off_amount')" t-as="doc">
-                        <tr>
-                            <td>
-                                <span t-out="doc.write_off_type_id.label or doc.write_off_type_id.name"/>
-                            </td>
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- write_off_amount ya está en B; se muestra igual en ambas columnas -->
-                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <span class="text-nowrap" t-field="doc.write_off_amount"/>
-                            </td>
-                        </tr>
-                    </t>
-                    <t t-set="all_same_type" t-value="len(set(payment_bundle.mapped('payment_type'))) == 1"/>
-
-                    <t t-foreach="payment_bundle.filtered(lambda x: not x._is_latam_check_payment() and x.amount != 0.0)" t-as="doc" id="payment_bundle_doc">
-                        <!-- display_amount_a: importe en A (moneda del diario); amount_signed lleva el signo -->
-                        <t t-set="display_amount_a" t-value="abs(doc.amount_signed) if all_same_type else doc.amount_signed"/>
-                        <!-- display_amount_b: importe en B2 (destination_currency_id); si B1!=B2 convertir A→B2 -->
-                        <t t-set="display_amount_b_raw" t-value="doc.counterpart_currency_amount if doc.counterpart_currency_id == doc.destination_currency_id else (doc.amount / doc.accounting_rate if doc.accounting_rate else doc.amount)"/>
-                        <t t-set="display_amount_b" t-value="abs(display_amount_b_raw) if all_same_type else (display_amount_b_raw if doc.payment_type == 'inbound' else -display_amount_b_raw)"/>
-                        <tr>
-                            <td>
-                                <span t-field="doc.journal_id.name"/>
-                                <span t-field="doc.payment_method_line_id.name"/>
-                            </td>
-
-                            <td class="text-right" t-if="show_amount_col">
-                                <!-- moneda natural del pago = A (moneda del diario) -->
-                                <span class="text-nowrap"
-                                    t-out="display_amount_a"
-                                    t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
-                            </td>
-
-                            <td class="text-right o_price_total">
-                                <span class="text-nowrap"
-                                    t-out="display_amount_b"
-                                    t-options='{"widget": "monetary", "display_currency": doc.destination_currency_id}'/>
-                            </td>
-                        </tr>
-                    </t>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td><strong><span>Total Paid</span></strong></td>
-                        <td t-if="show_amount_col"/>
-                        <td class="text-right">
-                            <!-- payment_total en B; incluye counterpart_currency_amount + write_off + withholdings_amount -->
-                            <strong><span class="text-nowrap" t-field="o.payment_total"/></strong>
-                        </td>
-                    </tr>
-                </tfoot>
-            </table>
-            <br/>
-            <t t-set="matched_lines" t-value="payment_bundle.with_context(matched_payment_ids=payment_bundle.ids).mapped('matched_move_line_ids')"/>
-            <table class="table table-sm o_main_table" name="matching_table">
-                <thead>
-                    <tr>
-                        <th><span>Imputed Vouchers</span></th>
-                        <th class="text-center"><span>Exp. Date</span></th>
-                        <th class="text-right"><span>Original Amount</span></th>
-                        <th class="text-right"><span>Imputed Amount</span></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <t t-foreach="matched_lines" t-as="line">
-                        <tr>
-                            <td><span t-field='line.move_id.display_name'/></td>
-                            <td class="text-center">
-                                <span class="text-nowrap" t-field="line.date_maturity"/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- Original amount in the line's currency (= B for invoice lines) -->
-                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.amount_currency" t-options='{"widget": "monetary", "display_currency": line.currency_id}'/>
-                            </td>
-                            <td class="text-right o_price_total">
-                                <!-- payment_matched_amount is already expressed in B (destination_currency_id) -->
-                                <span class="text-nowrap" t-out="(o.payment_type == 'outbound' and -1.0 or 1.0) * line.payment_matched_amount" t-options='{"widget": "monetary", "display_currency": line.payment_matched_currency_id}'/>
-                            </td>
-
-                        </tr>
-                        <span class="reversal_move_lines"/>
-                    </t>
-                    <tr t-if="sum(payment_bundle.mapped('unmatched_amount'))">
-                        <td>On account</td>
-                        <td class="text-center"/>
-                        <td class="text-right o_price_total"/>
-                        <td class="text-right o_price_total">
-                            <!-- unmatched_amount is in B (destination_currency_id) -->
-                            <span class="text-nowrap" t-out="sum(payment_bundle.mapped('unmatched_amount'))" t-options="{'widget': 'monetary', 'display_currency': o.destination_currency_id}" />
-                        </td>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td colspan="3"><strong><span>Total Imputed</span></strong></td>
-                        <td class="text-right">
-                            <!-- o.matched_amount + o.unmatched_amount = abs(o.payment_total), que en bundles
-                                 ya acumula todos los link_payments gracias al override de payment_total -->
-                            <strong><span class="text-nowrap" t-out="o.matched_amount + o.unmatched_amount" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/></strong>
-                        </td>
-                    </tr>
-                </tfoot>
-            </table>
-            <br/>
+        <!-- ── Pending receivables table (customers, controlled by group) ─────── -->
+        <xpath expr="//span[@name='pending_table']" position="replace">
             <table class="table table-sm o_main_table" name="open_table" t-if="o.partner_type=='customer'" groups="l10n_ar_ux.group_include_pending_receivable_documents">
                 <thead>
                     <tr>
@@ -274,6 +110,10 @@
                     </tr>
                 </tfoot>
             </table>
+        </xpath>
+
+        <!-- ── Signature / memo footer ─────────────────────────────────────────── -->
+        <xpath expr="//span[@name='payment_footer']" position="replace">
             <table>
                 <div class="float-left">
                     <span t-if="o.company_id.l10n_ar_report_signature" t-field="o.memo"/>
@@ -285,11 +125,14 @@
                     </t>
                 </div>
             </table>
-        </div>
+        </xpath>
+
     </template>
 
+    <!-- Optional: show reversal moves as sub-rows under their matched line.
+         Inactive by default; activate via Settings > Technical. -->
     <template id="report_payment_receipt_reversal_moves" active="False" inherit_id="l10n_ar_tax.report_payment_receipt_document">
-       <xpath expr="//span[hasclass('reversal_move_lines')]" position="replace">
+        <xpath expr="//t[hasclass('reversal_move_lines')]" position="replace">
             <t t-foreach="line.move_id.reversal_move_ids" t-as="reversal_move_id">
                 <t t-set="imputed_amount" t-value="[item['amount'] for item in reversal_move_id.sudo()._get_all_reconciled_invoice_partials() if item['aml_id'] == line.id]"/>
                 <tr>
@@ -297,35 +140,14 @@
                     <td class="text-center">
                         <span class="text-nowrap" t-field="reversal_move_id.invoice_date"/>
                     </td>
-                    <td class="text-right o_price_total" >
+                    <td class="text-right o_price_total">
                         <span class="text-nowrap" t-out="(o.partner_type == 'supplier' and 1.0 or -1.0) * sum(imputed_amount)" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'/>
                     </td>
-                    <td class="text-right o_price_total" >
-                    </td>
+                    <td class="text-right o_price_total"/>
                 </tr>
-
             </t>
-
         </xpath>
     </template>
 
-  <template id="report_payment_receipt_bundle">
-        <t t-call="web.html_container">
-            <t t-foreach="docs.with_context(print_in_bundles=True)._get_payment_bundles().values()" t-as="payment_bundle">
-                <t t-set="o" t-value="payment_bundle[0]"/>
-                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
-                <t t-call="#{o._get_name_receipt_report('account.report_payment_receipt_document')}" t-lang="lang"/>
-            </t>
-        </t>
-  </template>
-  <record id="action_report_receipt_bundle" model="ir.actions.report">
-        <field name="name">Payment Receipt bundled</field>
-        <field name="model">account.payment</field>
-        <field name="report_type">qweb-pdf</field>
-        <field name="report_name">l10n_ar_tax.report_payment_receipt_bundle</field>
-        <field name="report_file">l10n_ar_tax.report_payment_receipt_bundle</field>
-        <field name="binding_model_id" ref="model_account_payment"/>
-        <field name="binding_type">report</field>
-        <field name="binding_view_types">list</field>
-    </record>
+
 </odoo>


### PR DESCRIPTION
## Summary

- Reescribe `l10n_ar_tax/views/report_payment_receipt_templates.xml` para heredar del nuevo template primario de `account_payment_pro` usando puntos de extensión nombrados (`partner_info_extra`, `withholding_rows`, `pending_table`, `payment_footer`, `show_amount_col_def`)
- Elimina `_get_payment_bundles` y `_select_bundle` de `l10n_ar_tax` (ahora viven en `account_payment_pro`)
- Reemplaza el hack `o._fields.get('receiptbook_id')` por el método `_get_receipt_header_address()` definido en `account_payment_pro`
- Mueve `report_payment_receipt_bundle` y `action_report_receipt_bundle` a `l10n_ar_payment_bundle` (PR complementario en account-payment)

## Depends on
PR en `account-payment` con los cambios en `account_payment_pro`, `account_payment_pro_receiptbook` y `l10n_ar_payment_bundle`.

## Test plan
- [ ] Imprimir recibo de pago cliente (inbound) — verificar header AR, VAT Cond, CUIT
- [ ] Imprimir recibo de pago proveedor (outbound) con retenciones — verificar filas de retenciones y columna de importe
- [ ] Imprimir con talonario de recibo — verificar que `header_address` usa `receiptbook_id.report_partner_id`
- [ ] Imprimir desde lista con "Payment Receipt bundled" — verificar template bundle agrupa por empresa/partner/tipo/moneda
- [ ] Pago en moneda extranjera (USD) — verificar columna `show_amount_col` aparece correctamente