### PR TITLE
[FIX] l10n_ar_tax: allow _synchronize_to_moves to delete withholding tax lines

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -416,6 +416,13 @@ class AccountPayment(models.Model):
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_line_ids = withholdings
 
+    def _synchronize_to_moves(self, changed_fields):
+        # _recompute_tax_lines runs after _synchronize_to_moves rebuilds the payment lines
+        # and explicitly sets display_type='tax' on withholding lines (they have
+        # tax_repartition_line_id).
+        self = self.with_context(dynamic_unlink=True)
+        return super()._synchronize_to_moves(changed_fields)
+
     def compute_to_pay_amount_for_check(self):
         checks_payments = self.filtered(
             lambda x: x.payment_method_code in ["in_third_party_checks", "out_third_party_checks"]


### PR DESCRIPTION
  When a payment is reset to draft, _synchronize_to_moves rebuilds the move
  lines, which triggers _recompute_tax_lines. Because withholding lines carry
  tax_repartition_line_id, _recompute_tax_lines explicitly sets display_type='tax'
  on them (account_move.py:3103-3107). On the next sync (e.g. changing the
  withholding amount), _synchronize_to_moves tries to delete those writeoff_lines
  via (2, id), but _prevent_automatic_line_deletion blocks it because
  display_type='tax' and the move has base lines with tax_ids.

  Fix: pass dynamic_unlink=True when calling super()._synchronize_to_moves, the
  same signal _recompute_tax_lines itself uses (account_move.py:3119) to authorise
  deletion of tax lines it manages.

  This does not break other protections:
  - payment_term lines: _seek_for_lines() classifies them as counterpart_lines (by account_type), so they are never in writeoff_lines and never reach (2, id)
  - invoice tax lines: _synchronize_to_moves only runs on payment moves (move_type='entry') and explicitly skips posted moves; invoice tax lines are only present on invoice-type moves
  - standard payments without withholding: no display_type='tax' lines exist in writeoff_lines, so dynamic_unlink has no observable effect