### PR TITLE
l10n_ar_tax: agregar vista lista para l10n_ar.partner.tax sin menú

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -35,6 +35,7 @@
         "views/account_move_views.xml",
         "views/report_payment_receipt_templates.xml",
         "views/l10n_ar_payment_withholding_views.xml",
+        "views/l10n_ar_partner_tax_views.xml",
         "views/account_fiscal_position_view.xml",
         "wizard/account_payment_register_views.xml",
         "wizard/res_config_settings_views.xml",

--- a/l10n_ar_tax/views/l10n_ar_partner_tax_views.xml
+++ b/l10n_ar_tax/views/l10n_ar_partner_tax_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="l10n_ar_partner_tax_list_view">
+        <field name="name">l10n_ar.partner.tax.list</field>
+        <field name="model">l10n_ar.partner.tax</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="partner_id"/>
+                <field name="tax_id"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="from_date"/>
+                <field name="to_date"/>
+                <field name="ref"/>
+            </list>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="action_l10n_ar_partner_tax">
+        <field name="name">Partner Taxes (AR)</field>
+        <field name="res_model">l10n_ar.partner.tax</field>
+        <field name="view_mode">list</field>
+        <field name="view_id" ref="l10n_ar_partner_tax_list_view"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary

- Agrega vista lista (`ir.ui.view`) para el modelo `l10n_ar.partner.tax`
- Agrega acción de ventana (`ir.actions.act_window`) invocable por código/botones
- No incluye entrada de menú (`ir.ui.menu`) — la vista no es accesible por navegación directa

## Test plan

- [ ] Instalar/actualizar el módulo `l10n_ar_tax`
- [ ] Verificar que no aparece ningún ítem de menú nuevo para este modelo
- [ ] Verificar que la acción `action_l10n_ar_partner_tax` puede invocarse vía URL o botón programático y muestra la lista correctamente