### PR TITLE
[IMP] l10n_ar_tax: agregar vista lista para l10n_ar.partner.tax sin menú

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -35,6 +35,7 @@
         "views/account_move_views.xml",
         "views/report_payment_receipt_templates.xml",
         "views/l10n_ar_payment_withholding_views.xml",
+        "views/l10n_ar_partner_tax_views.xml",
         "views/account_fiscal_position_view.xml",
         "wizard/account_payment_register_views.xml",
         "wizard/res_config_settings_views.xml",

--- a/l10n_ar_tax/views/l10n_ar_partner_tax_views.xml
+++ b/l10n_ar_tax/views/l10n_ar_partner_tax_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="l10n_ar_partner_tax_list_view">
+        <field name="name">l10n_ar.partner.tax.list</field>
+        <field name="model">l10n_ar.partner.tax</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="partner_id"/>
+                <field name="tax_id"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+                <field name="from_date"/>
+                <field name="to_date"/>
+                <field name="ref"/>
+            </list>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
1) Agrega vista lista (ir.ui.view) para el modelo l10n_ar.partner.tax 
2) No incluye entrada de menú (ir.ui.menu) — la vista no es accesible por navegación directa

**Beneficio**: poder hacer modificaciones masivas a los impuestos de los contactos usando la vista lista del modelo l10n_ar.partner.tax .
**Aclaración**: No agregamos menú porque no queremos que el usuario acceda fácilmente a esta vista para evitar modificaciones accidentales.

Ticket Adhoc: 119394