### PR TITLE
[FIX] l10n_ar_tax: deletion of withholding lines

### DIFF
--- a/l10n_ar_tax/__init__.py
+++ b/l10n_ar_tax/__init__.py
@@ -12,7 +12,12 @@ _logger = logging.getLogger(__name__)
 
 def monkey_patch_synchronize_to_moves():
     def _synchronize_to_moves(self, changed_fields):
-        return super(AccountPayment, self)._synchronize_to_moves(changed_fields)
+        # dynamic_unlink=True allows deletion of withholding move lines with display_type='tax'
+        # that are classified as write-off lines by _seek_for_lines. Without it,
+        # _prevent_automatic_line_deletion raises a ValidationError even in draft state.
+        # This is safe: _synchronize_to_moves only runs on draft moves (posted are skipped),
+        # and this is a programmatic sync, not a user UI deletion.
+        return super(AccountPayment, self.with_context(dynamic_unlink=True))._synchronize_to_moves(changed_fields)
 
     AccountPayment._synchronize_to_moves = _synchronize_to_moves
 


### PR DESCRIPTION
## Problema

Al volver a borrador un pago con retenciones ARBA y luego intentar eliminar una línea de retención, Odoo lanzaba un error de validación: "You cannot delete a tax line as it would impact the tax report."

## Fix

Se agrega `dynamic_unlink=True` al contexto al llamar al `_synchronize_to_moves` standard. Es el mismo patrón que usa Odoo core en `account/models/account_move.py` para operaciones equivalentes.

Es seguro: `_synchronize_to_moves` ya omite los pagos confirmados (`if pay.move_id.state == 'posted': continue`), por lo que solo actúa en asientos en borrador donde el borrado es intencional.
