### PR TITLE
[FIX] l10n_ar_tax: skip move sync when assigning withholding sequence numbers

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -384,7 +384,12 @@ class AccountPayment(models.Model):
                             % line.tax_id.name
                         )
             if commands:
-                rec.l10n_ar_withholding_line_ids = commands
+                # Use skip_account_move_synchronization to prevent triggering
+                # _synchronize_to_moves() on a draft move. Names are already set
+                # on l10n_ar_withholding_line_ids before super(), so
+                # _prepare_move_withholding_lines() will pick them up correctly
+                # when the journal entry is built inside super().action_post().
+                rec.with_context(skip_account_move_synchronization=True).l10n_ar_withholding_line_ids = commands
 
         return super().action_post()
 


### PR DESCRIPTION
## Problema

Al registrar pagos masivos a proveedor con retenciones y journal de tarjeta de crédito, `_reconcile_after_post()` fallaba con:

> **Solo puede conciliar los asientos publicados**

## Causa raíz

`l10n_ar_tax.action_post()` asigna números de secuencia a `l10n_ar_withholding_line_ids` **antes** de llamar `super()`. Como el pago ya tiene `move_id` (el asiento fue creado en `account.payment.create()`), esa escritura dispara `_synchronize_to_moves({'l10n_ar_withholding_line_ids'})` sobre el move en `draft`. El sync reconstruye las líneas del asiento. Luego, cuando `base.write({'state': 'in_process'})` intenta `move.action_post()`, la interacción con `_sync_dynamic_lines()` puede impedir la publicación, dejando el move en draft.

## Solución (2 PRs)

**Este PR**: usar `skip_account_move_synchronization=True` al escribir los nombres, para que `_synchronize_to_moves()` se saltee esta escritura específica. Los nombres quedan en `l10n_ar_withholding_line_ids` antes del `super()`, así que `_prepare_move_withholding_lines()` los toma correctamente al construir el asiento.

**PR relacionado** en `ingadhoc/account-financial-tools`: agrega el check de `skip_account_move_synchronization` a `_synchronize_to_moves()` (simétrico con `_synchronize_business_models()`), habilitando este mecanismo.

## Por qué los nombres deben asignarse antes del super()

`_prepare_move_withholding_lines()` lee `l10n_ar_withholding_line_ids` al momento de crear el asiento. Si los nombres se asignan después del `super()`, el asiento ya está publicado y el sync no puede actualizar las líneas (`if pay.move_id.state == 'posted': continue`). Al asignarlos antes con el contexto de skip, los nombres están disponibles para `_prepare_move_withholding_lines()` sin disparar el sync problemático.

Ticket: #119788 — Gastrotex S.R.L.: No puedo emitir pagos de forma masiva