### PR TITLE
[FIX] l10n_ar_tax: skip move sync when assigning withholding sequences in action_post

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -316,7 +316,12 @@ class AccountPayment(models.Model):
                             % line.tax_id.name
                         )
                 if commands:
-                    rec.l10n_ar_withholding_line_ids = commands
+                    # Use skip_account_move_synchronization so the sequence
+                    # names are written before super() without triggering
+                    # _synchronize_to_moves() on the still-draft move.
+                    # _prepare_move_withholding_lines() reads line.name, so
+                    # the names must be set before the base action_post() runs.
+                    rec.with_context(skip_account_move_synchronization=True).l10n_ar_withholding_line_ids = commands
 
         return super().action_post()
 


### PR DESCRIPTION
## Problem

In `action_post()`, withholding sequence names must be written to `l10n_ar_withholding_line_ids` **before** calling `super()` so `_prepare_move_withholding_lines()` picks them up. However, that write triggered `_synchronize_to_moves()` on the draft move without any context guard, rebuilding the move lines prematurely. The base `action_post()` could then leave the move in draft, and `account_ux`'s credit-card `state='paid'` write fired a second `action_post()` on it — causing `_reconcile_after_post()` to raise "Solo puede conciliar los asientos publicados".

## Solution

Use `with_context(skip_account_move_synchronization=True)` when writing the sequence names, preventing the premature sync. Requires the symmetric guard added to `_synchronize_to_moves()` in companion PR ingadhoc/account-financial-tools#975.

## Test plan

1. Create vendor bill (Factura A, RI→RI) with withholding taxes configured.
2. Register bulk payment using a Credit Card journal.
3. Confirm the payment posts and reconciles without error.
4. Verify Factura C (no withholdings) + credit card and Factura A + bank journal still work.
5. Verify existing withholding flows (bank journal, single payment) still work correctly.

Closes https://www.adhoc.inc/odoo/helpdesk/all-tickets/119788