### PR TITLE
[FIX] l10n_ar_tax: avoid premature _synchronize_to_moves on draft move during action_post

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -296,29 +296,28 @@ class AccountPayment(models.Model):
 
     def action_post(self):
         for rec in self:
-            commands = []
             for line in rec.l10n_ar_withholding_line_ids:
                 if not line.name or line.name == "/":
                     if line.tax_id.l10n_ar_withholding_sequence_id:
-                        commands.append(
-                            Command.update(
-                                line.id,
-                                {
-                                    "name": line.tax_id.l10n_ar_withholding_sequence_id.next_by_id()
-                                    if line.amount
-                                    else "/"
-                                },
-                            )
-                        )
+                        line.write({
+                            "name": line.tax_id.l10n_ar_withholding_sequence_id.next_by_id()
+                            if line.amount else "/"
+                        })
                     else:
                         raise UserError(
                             _("Please enter withholding number for tax %s or configure a sequence on that tax")
                             % line.tax_id.name
                         )
-                if commands:
-                    rec.l10n_ar_withholding_line_ids = commands
-
-        return super().action_post()
+        res = super().action_post()
+        for rec in self.filtered(lambda p: p.move_id.state == "posted"):
+            for line in rec.l10n_ar_withholding_line_ids.filtered(lambda l: l.name and l.name != "/"):
+                __, __, tax_repartition_line_id, __ = line._tax_compute_all_helper()
+                ml = rec.move_id.line_ids.filtered(
+                    lambda ml: ml.tax_repartition_line_id.id == tax_repartition_line_id
+                )
+                if ml:
+                    ml.with_context(check_move_validity=False).write({"name": line.name})
+        return res
 
     @api.model
     def _get_trigger_fields_to_synchronize(self):


### PR DESCRIPTION
## Problem

When registering bulk payments for Factura A (RI→RI with withholdings) using a Credit Card journal, the system raised: *"Solo puede conciliar los asientos publicados"*.

**Root cause:** In `action_post()`, writing withholding sequence names via `Command.update` on `l10n_ar_withholding_line_ids` passes through `account.payment.write()`, which triggers `_synchronize_to_moves({'l10n_ar_withholding_line_ids'})` on the draft `account.move`. This reconstructs all move lines, leaving the move in an inconsistent state. When `account_ux` then forces `.state = 'paid'` (credit card only), it triggers a second `move.action_post()` on a move that is still in draft — causing `_reconcile_after_post()` to fail.

Why only credit card: `account_ux` is the only place that forces `state='paid'`, triggering the second post attempt.
Why only Factura A: withholdings create `l10n_ar_withholding_line_ids`; without them the premature sync never fires.

## Solution

Replace `Command.update` on the parent payment with `line.write({'name': ...})` on the child `l10n_ar.payment.withholding` model directly. This bypasses `account.payment.write()` entirely — the ORM never detects a trigger field change on the payment, so `_synchronize_to_moves` is never called prematurely. The original `account.move` (created at `payment.create()` time) reaches `move.action_post()` intact.

After `super().action_post()` (move is now posted), move line labels are updated directly via `tax_repartition_line_id` lookup with `check_move_validity=False` — no sync triggered on an already-posted move.

Also fixes a pre-existing indentation bug where `if commands:` was inside the `for line` loop, causing `Command.update` to be applied multiple times for payments with more than one withholding line.

## Files changed

- `l10n_ar_tax/models/account_payment.py`: `action_post()` override