### PR TITLE
[FIX] l10n_ar_tax_backward_compatibility: respetar tax_override_data

### DIFF
--- a/l10n_ar_tax_backward_compatibility/models/account_move.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_move.py
@@ -44,13 +44,24 @@ class AccountMove(models.Model):
         if not amounts_by_group:
             return tax_totals
 
+        # Overrides manuales (account_invoice_tax.tax_override_data). Si el módulo
+        # no está instalado el campo no existe, así que accedemos de forma segura.
+        overrides = move.tax_override_data if "tax_override_data" in move._fields else False
+        overrides = overrides or {}
+
         # 2.Reemplazar valores en los tax_groups
         for g in tax_groups:
             group_id = g["id"]
-            if group_id in amounts_by_group:
-                vals = amounts_by_group[group_id]
-                g["tax_amount_currency"] = abs(vals["amount_currency"])
-                g["tax_amount"] = abs(vals["amount"])
+            if group_id not in amounts_by_group:
+                continue
+            # Si algún impuesto del grupo tiene un override manual, lo respetamos:
+            # super()._compute_tax_totals() ya dejó ese valor en el grupo, no lo
+            # pisamos con el monto de las (solo) líneas inactivas.
+            if any(str(tax_id) in overrides for tax_id in g.get("involved_tax_ids", [])):
+                continue
+            vals = amounts_by_group[group_id]
+            g["tax_amount_currency"] = abs(vals["amount_currency"])
+            g["tax_amount"] = abs(vals["amount"])
 
         # 3. Recalcular subtotales
         subtotal["tax_amount_currency"] = sum(g["tax_amount_currency"] for g in tax_groups)


### PR DESCRIPTION
_replace_inactive_tax_amounts pisaba el tax_amount del grupo con la suma de las (solo) líneas de impuesto inactivas, descartando el override manual que account_invoice_tax ya había aplicado en super()._compute_tax_totals().

En facturas con un impuesto partido entre una repartition line activa y otra inactiva, esto mostraba el total parcial (solo la parte inactiva) en lugar del total real, e ignoraba por completo tax_override_data.

Ahora, si algún impuesto del grupo tiene un override manual en tax_override_data, no se pisa el valor: se mantiene el que dejó super(). El acceso al campo es seguro (account_invoice_tax no es dependencia dura).