### PR TITLE
[FIX] l10n_ar_tax: sum all bundle payments in bundled receipt totals

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -517,6 +517,17 @@ class AccountPayment(models.Model):
                 {"l10n_ar_withholding_line_ids"}
             )
 
+    def _get_bundle_payment_total(self, payment_bundle):
+        """Total to display in the bundled receipt 'Total Paid' footer.
+        Sums payment_total across all payments in the bundle.
+        Override in modules where the first payment already aggregates the rest (e.g. l10n_ar_payment_bundle).
+        """
+        return sum(payment_bundle.mapped("payment_total"))
+
+    def _get_bundle_imputed_total(self, payment_bundle):
+        """Total to display in the bundled receipt 'Total Imputed' footer."""
+        return sum(payment_bundle.mapped("matched_amount")) + sum(payment_bundle.mapped("unmatched_amount"))
+
     def _get_name_receipt_report(self, report_xml_id):
         """Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document
         Basically it allows different localizations to define it's own report

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -112,6 +112,15 @@
             </table>
         </xpath>
 
+        <!-- ── Bundle receipt totals: sum all payments in the bundle ───────────── -->
+        <xpath expr="//span[@t-field='o.payment_total']" position="replace">
+            <span class="text-nowrap" t-out="o._get_bundle_payment_total(payment_bundle)" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/>
+        </xpath>
+
+        <xpath expr="//table[@name='matching_table']//tfoot//span[hasclass('text-nowrap')]" position="replace">
+            <span class="text-nowrap" t-out="o._get_bundle_imputed_total(payment_bundle)" t-options='{"widget": "monetary", "display_currency": o.destination_currency_id}'/>
+        </xpath>
+
         <!-- ── Signature / memo footer ─────────────────────────────────────────── -->
         <xpath expr="//span[@name='payment_footer']" position="replace">
             <table>


### PR DESCRIPTION
## Problem

When printing a **Payment receipt bundled** by selecting multiple payments from the list view, the **Total Paid** and **Total Imputed** footers only showed the value of the first payment in the group, ignoring all others.

Root cause: `report_payment_receipt_bundle` sets `o = payment_bundle[0]` (first payment), and the document template used `t-field="o.payment_total"` and `o.matched_amount + o.unmatched_amount` — both reading only from that first record.

## Solution

Add two methods to `account.payment`:

- `_get_bundle_payment_total(payment_bundle)` → `sum(payment_bundle.mapped('payment_total'))`
- `_get_bundle_imputed_total(payment_bundle)` → `sum(matched) + sum(unmatched)` across the bundle

Replace the hardcoded field reads in `report_payment_receipt_document` with calls to these methods. Both footers ("Total Paid" and "Total Imputed") now correctly reflect the sum of all selected payments.

The `l10n_ar_payment_bundle` module overrides these methods to avoid double-counting when `o` is a main payment (whose `payment_total` already aggregates its linked payments). See companion PR in `ingadhoc/account-payment`.

## Test plan

- Select 2+ customer payments with the same partner from the list view
- Print → Payment receipt bundled
- Verify **Total Paid** = sum of all selected payment amounts
- Verify **Total Imputed** = sum of all matched/unmatched amounts
- Print a single payment receipt (non-bundled) — verify totals are unchanged