### PR TITLE
[IMP] l10n_ar_ux: improve error message for invalid identification number format

### DIFF
--- a/l10n_ar_ux/i18n/es.po
+++ b/l10n_ar_ux/i18n/es.po
@@ -417,6 +417,26 @@ msgstr ""
 "jurisdicciones. "
 
 #. module: l10n_ar_ux
+#. odoo-python
+#: code:addons/l10n_ar_ux/models/res_partner.py:0
+msgid ""
+"The identification number entered (%(vat)s) contains invalid characters or "
+"additional symbols.\n"
+"\n"
+"How to fix it:\n"
+"- Make sure the number contains only digits.\n"
+"- Remove any spaces, hyphens, dots or extra symbols at the start or end.\n"
+"- Correct format example: 20251984825"
+msgstr ""
+"El número de identificación introducido (%(vat)s) contiene caracteres no "
+"permitidos o símbolos adicionales.\n"
+"\n"
+"Cómo solucionarlo:\n"
+"- Asegurate de que el número solo contenga dígitos.\n"
+"- Borrá cualquier espacio, guión, punto u otro símbolo al inicio o final.\n"
+"- Ejemplo de formato correcto: 20251984825"
+
+#. module: l10n_ar_ux
 #: model:ir.model.fields,field_description:l10n_ar_ux.field_res_country_state__jurisdiction_code
 msgid "Jurisdiction Code"
 msgstr "Código de jurisdicción"

--- a/l10n_ar_ux/models/res_partner.py
+++ b/l10n_ar_ux/models/res_partner.py
@@ -127,3 +127,18 @@ class ResPartner(models.Model):
         for partner in l10n_ar_partners:
             if id_number := partner._get_id_number_sanitize():
                 partner.vat = str(id_number)
+
+    def _get_id_number_sanitize(self):
+        try:
+            return super()._get_id_number_sanitize()
+        except ValueError:
+            raise ValidationError(
+                _(
+                    "The identification number entered (%(vat)s) contains invalid characters or additional symbols.\n\n"
+                    "How to fix it:\n"
+                    "- Make sure the number contains only digits.\n"
+                    "- Remove any spaces, hyphens, dots or extra symbols at the start or end.\n"
+                    "- Correct format example: 20251984825",
+                    vat=self.vat,
+                )
+            )


### PR DESCRIPTION
## Summary

When saving a partner with a CUIL (or any non-vat AR identification type using the CUIT/CUIL compact validator) containing special characters (e.g. `:20251984825`), `stdnum.ar.cuit.compact()` does not strip colons, causing `int()` to raise a raw `ValueError`. This propagated as an unhandled server error (500 page) instead of a user-friendly validation message.

This PR overrides `_get_id_number_sanitize` in `l10n_ar_ux` to catch the `ValueError` and raise a `ValidationError` with a clear explanation of what went wrong and how to fix it.

**Root cause:** `stdnum.ar.cuit.compact()` only strips spaces and dashes — other chars like `:` remain, making `int()` fail. This affects CUIL (code `86`) and any non-vat AR type using that code path.

**Not affected:** CUIT (code `80`, `is_vat=True`) already goes through `base_vat._check_vat` which raises its own `ValidationError`.

## Changes

- `l10n_ar_ux/models/res_partner.py`: override `_get_id_number_sanitize` with `try/except ValueError → ValidationError`
- `l10n_ar_ux/i18n/es.po`: Spanish translation for the new message

## Test plan

- [ ] Save a partner with CUIL = `:20251984825` → shows friendly error "The identification number entered (:20251984825) contains invalid characters..."
- [ ] Save a partner with CUIL = `20251984825` (valid) → saves correctly
- [ ] Save a partner with CUIT = `:20251984825` → still shows base_vat message (unaffected)

Task: https://www.adhoc.inc/odoo/action-project.action_view_all_task/67981