### PR TITLE
[FIX] l10n_ar_tax: keep manual withholding lines when resetting payment to draft

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -69,3 +69,33 @@ class AccountMove(models.Model):
         recs = super().copy(default=default)
         recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs
+
+    def button_draft(self):
+        """Ticket 119846.
+
+        En los asientos de pago con retenciones AR las líneas de retención (con
+        ``tax_repartition_line_id``) y sus bases las arma a mano
+        ``account.payment._prepare_move_withholding_lines``, con importes que el motor de
+        impuestos estándar de Odoo NO puede reproducir: los calcula la lógica l10n_ar (escalas y
+        acumulado de ganancias, mínimos) o los carga el operador. El caso testigo es la retención
+        de IVA, un impuesto ``fixed`` con ``amount = 0`` cuyo importe ingresa el operador mirando
+        el IVA de las facturas; ``compute_all`` devuelve 0 para ese impuesto.
+
+        Al pasar a borrador, el sync dinámico del asiento (``_sync_tax_lines`` /
+        ``_sync_unbalanced_lines``) se reactiva —solo corre sobre moves no posteados— y recompone
+        las líneas desde la base: la retención ``fixed/0`` recomputa a 0, cae en el filtro de
+        importe cero de ``account.tax._prepare_tax_lines``, se descarta, y el asiento queda
+        desbalanceado, forzando una "Automatic Balancing Line". No alcanza con preservar importes
+        (``round_from_tax_lines``): el importe manual no es derivable del cómputo del impuesto, así
+        que el motor no puede representarlo.
+
+        Posteado no rompe porque ambos manejadores saltean ``state == 'posted'``. Replicamos eso
+        en la transición a borrador: con ``skip_invoice_sync`` salteamos el recompute dinámico solo
+        para los moves de pago con retenciones. Esas líneas las gobierna
+        ``account.payment._synchronize_to_moves``, que las reconstruye ante cualquier edición
+        posterior del pago.
+        """
+        wth_moves = self.filtered(lambda m: m.move_type == "entry" and m.origin_payment_id.l10n_ar_withholding_line_ids)
+        if wth_moves:
+            super(AccountMove, wth_moves.with_context(skip_invoice_sync=True)).button_draft()
+        return super(AccountMove, self - wth_moves).button_draft()

--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -10,6 +10,138 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
             [("company_id", "=", self.company_ri.id), ("type", "=", "bank")], limit=1
         )
 
+    def test_reset_to_draft_keeps_manual_withholding_line(self):
+        """Regression for ticket 119846 (reset to draft drops a manual-amount withholding line).
+
+        Faithful reproduction of the sinax case: a supplier payment with a withholding whose tax
+        is ``fixed`` with ``amount = 0`` (e.g. "Retención IVA"), where the withheld amount is
+        entered manually by the operator. ``account.tax.compute_all`` returns 0 for such a tax,
+        so when the payment is reset to draft the standard dynamic tax sync recomputes the
+        withholding tax line to 0, drops it via the zero-amount filter, leaves the entry
+        unbalanced and inserts an "Automatic Balancing Line".
+
+        Posting works (both dynamic-sync managers skip posted moves); only reset to draft was
+        affected. The fix forces ``round_from_tax_lines=True`` for payment moves with
+        withholdings so the manually entered amount on the existing tax line is preserved instead
+        of recomputed from the base.
+        """
+        manual_wth_amount = 50000.0
+        manual_tax = self.tax_wth_test_1
+
+        # 1. Vendor bill in ARS (company currency) for a CABA partner
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.env.ref("l10n_ar_tax.res_partner_adhoc_caba").id,
+                "move_type": "in_invoice",
+                "company_id": self.company_ri.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 500000,
+                        }
+                    ),
+                ],
+                "invoice_date": self.today,
+                "l10n_latam_document_number": "1-1198461",
+            }
+        )
+        invoice.action_post()
+
+        # 2. Fiscal position with the manual (fixed/0) withholding for this partner
+        fiscal_pos = self.env["account.fiscal.position"].create(
+            {
+                "name": "Ret IVA manual 119846",
+                "l10n_ar_afip_responsibility_type_ids": [(6, 0, [self.env.ref("l10n_ar.res_IVARI").id])],
+                "sequence": 10,
+                "auto_apply": True,
+                "country_id": self.env.ref("base.ar").id,
+                "company_id": self.company_ri.id,
+                "state_ids": [(6, 0, [self.env.ref("base.state_ar_c").id])],
+            }
+        )
+        self.env["account.fiscal.position.l10n_ar_tax"].create(
+            {
+                "fiscal_position_id": fiscal_pos.id,
+                "default_tax_id": manual_tax.id,
+                "tax_type": "withholding",
+            }
+        )
+
+        # 3. Register the payment and enter the withholding amount manually
+        action_context = invoice.action_register_payment()["context"]
+        payment = (
+            self.env["account.payment"]
+            .with_context(**action_context)
+            .create(
+                {
+                    "journal_id": self.company_bank_journal.id,
+                    "amount": invoice.amount_total,
+                    "date": self.today,
+                }
+            )
+        )
+        wth_line = payment.l10n_ar_withholding_line_ids.filtered(lambda l: l.tax_id == manual_tax)
+        self.assertTrue(wth_line, "The withholding line should have been created")
+
+        # Turn the resolved withholding into a manual one (fixed/0, like the real "Retención IVA"
+        # tax 301): the standard engine now computes 0 for it, and the operator enters the amount.
+        manual_tax.write({"amount_type": "fixed", "amount": 0.0})
+        wth_line.amount = manual_wth_amount
+
+        # 4. Post and confirm the manual amount materialised on the journal entry
+        payment.action_post()
+        self.assertEqual(payment.move_id.state, "posted")
+        posted_wth_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+        self.assertTrue(posted_wth_lines, "Posted move must have a withholding tax line")
+        self.assertAlmostEqual(
+            abs(sum(posted_wth_lines.mapped("balance"))),
+            manual_wth_amount,
+            places=2,
+            msg="The manually entered withholding amount must be on the posted journal entry",
+        )
+        posted_wth_count = len(posted_wth_lines)
+        posted_wth_balance = sum(posted_wth_lines.mapped("balance"))
+        self.assertTrue(
+            payment.company_currency_id.is_zero(sum(payment.move_id.line_ids.mapped("balance"))),
+            "Posted journal entry must balance to zero",
+        )
+
+        # 5. Reset the payment to draft
+        payment.action_draft()
+        self.assertEqual(payment.move_id.state, "draft")
+
+        # 6a. No automatic balancing line should have been inserted
+        auto_balance_lines = payment.move_id.line_ids.filtered(
+            lambda l: "automatic balancing" in (l.name or "").lower() or "balance automático" in (l.name or "").lower()
+        )
+        self.assertFalse(
+            auto_balance_lines,
+            "Resetting to draft must NOT insert an automatic balancing line: the manual "
+            "withholding line must be preserved, not recomputed to 0 and dropped.",
+        )
+
+        # 6b. The journal entry must still balance to zero
+        self.assertTrue(
+            payment.company_currency_id.is_zero(sum(payment.move_id.line_ids.mapped("balance"))),
+            "Journal entry must still balance to zero after reset to draft",
+        )
+
+        # 6c. The manual withholding line must survive with its amount intact
+        draft_wth_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+        self.assertEqual(
+            len(draft_wth_lines),
+            posted_wth_count,
+            "The manual withholding line must survive the reset to draft (none dropped).",
+        )
+        self.assertAlmostEqual(
+            sum(draft_wth_lines.mapped("balance")),
+            posted_wth_balance,
+            places=2,
+            msg="The withholding line must keep its manual amount after reset to draft.",
+        )
+
     def test_force_amount_company_currency_with_withholdings(self):
         """Test that when paying a foreign currency vendor bill with withholdings and a forced
         company currency amount, the journal entry lines are correctly computed.


### PR DESCRIPTION
## Problem (ticket 119846)

When a posted supplier payment with withholdings is **reset to draft**, a withholding line disappears from the journal entry and Odoo inserts an **"Automatic Balancing Line"** in the journal's default account, leaving the entry plugged instead of keeping the real withholding line.

## Root cause

Withholding move lines (carrying `tax_repartition_line_id`) and their base lines are built manually by `account.payment._prepare_move_withholding_lines`, with amounts the standard tax engine **cannot reproduce**: they come from the l10n_ar logic (earnings scales / period accumulation, minimum thresholds) or are typed by the operator.

The witness case is the **VAT withholding**: a `fixed` tax with `amount = 0` whose withheld amount is entered by the operator. `account.tax.compute_all` returns `0` for it.

On a **draft** move the dynamic line sync (`_sync_tax_lines` / `_sync_unbalanced_lines`) takes over and recomputes these lines from the base. The `fixed/0` withholding recomputes to `0`, is dropped by the zero-amount filter in `account.tax._prepare_tax_lines`, and the entry is left unbalanced → balancing line.

Posting is unaffected because both sync managers skip `state == 'posted'`; only the reset-to-draft transition was hit. Preserving amounts via `round_from_tax_lines` is **not** enough — the manual amount is not derivable from the tax computation, so the engine cannot represent it.

## Fix

On the reset-to-draft transition, skip the dynamic recompute (`skip_invoice_sync`) for payment moves that have withholdings, mirroring how posted moves are already skipped. `account.payment._synchronize_to_moves` stays the single owner of these lines and rebuilds them on any later edit of the payment.

## Test

Adds a regression test: payment with a `fixed/0` manual withholding, post and reset to draft; asserts the withholding line survives, the entry balances and no Automatic Balancing Line appears. Full `TestPaymentReceiptbookAndWithholding` class passes (4/4).