### PR TITLE
[IMP] l10n_ar_tax: apply the minimum base threshold to AR sale perceptions

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -961,7 +961,7 @@ msgid ""
 "withholding/perception is not applied."
 msgstr ""
 "Si la base calculada para el régimen no supera este valor, no se aplica la "
-"retención."
+"retención/percepción."
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_withholding_certificate_document

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -198,3 +198,95 @@ class AccountTax(models.Model):
                         "The total percentage (%s) should be greater than 0 and less than or equal to 100.", tax.ratio
                     )
                 )
+
+    def _l10n_ar_is_perception_with_base_threshold(self):
+        """Percepción de venta argentina con umbral de base mínima configurado.
+
+        Se identifica la percepción de IVA por el código de tributo ARCA del
+        grupo de impuestos (06 IVA). Para cubrir las percepciones que
+        son provinciales debe tener establecido l10n_ar_state_id.
+
+        Solo se contempla el cálculo por porcentaje (`percent`), que es como se definen
+        las percepciones argentinas. Quedan afuera los impuestos incluidos en el precio
+        (`price_include`) y los que afectan la base de los impuestos siguientes
+        (`include_base_amount`): en ambos casos anular el importe después de que el core
+        calculó el resto dejaría inconsistentes el neto o las bases posteriores.
+        """
+        self.ensure_one()
+        return bool(
+            self.country_code == "AR"
+            and self.type_tax_use == "sale"
+            and self.l10n_ar_base_minimum_threshold
+            and self.amount_type == "percent"
+            and not self.price_include
+            and not self.include_base_amount
+            and (self.l10n_ar_state_id or self.tax_group_id.l10n_ar_tribute_afip_code == "06")
+        )
+
+    @api.model
+    def _add_tax_details_in_base_lines(self, base_lines, company):
+        """Aplicar el umbral de base mínima de las percepciones de venta argentinas.
+
+        Se hace acá (y no en `_get_tax_details`, que trabaja de a una línea por vez) porque
+        el umbral se evalúa **por documento y por impuesto**: se suman las bases de todas
+        las líneas que llevan la percepción y recién ahí se compara contra el umbral.
+        """
+        res = super()._add_tax_details_in_base_lines(base_lines, company)
+        self._l10n_ar_apply_perception_base_threshold(base_lines, company)
+        return res
+
+    @api.model
+    def _l10n_ar_apply_perception_base_threshold(self, base_lines, company):
+        """Poner en 0 las percepciones de venta cuya base agregada no supera el umbral.
+
+        :param base_lines: líneas base de UN documento, ya con `tax_details` calculado.
+        :param company:    compañía dueña de las líneas base.
+        """
+        # `account_fiscal_country_id` es el campo canónico para impuestos; se contempla
+        # `country_id` por si la compañía todavía no tiene país fiscal configurado.
+        if "AR" not in (company.account_fiscal_country_id.code, company.country_id.code):
+            return
+
+        # Base acumulada por impuesto, en moneda de la compañía (`raw_base_amount`).
+        # `is_eligible` cachea la evaluación para no repetirla por cada línea del documento.
+        base_per_tax = {}
+        is_eligible = {}
+        for base_line in base_lines:
+            for tax_data in base_line["tax_details"]["taxes_data"]:
+                tax = tax_data["tax"]
+                if tax not in is_eligible:
+                    is_eligible[tax] = tax._l10n_ar_is_perception_with_base_threshold()
+                if is_eligible[tax]:
+                    base_per_tax[tax] = base_per_tax.get(tax, 0.0) + tax_data["raw_base_amount"]
+
+        # Solo se evalúa el umbral cuando la base agregada es positiva. Una base negativa
+        # significa que estas líneas no son un comprobante sino un fragmento aislado —
+        # típicamente las líneas de un descuento global, que el core calcula por separado
+        # (`_prepare_global_discount_lines`) antes de sumarlas al documento. Anular la
+        # percepción ahí aumentaría el impuesto en vez de reducirlo, y encima quedaría
+        # congelada en `manual_tax_amounts`.
+        excluded_taxes = {
+            tax
+            for tax, base_amount in base_per_tax.items()
+            if company.currency_id.compare_amounts(base_amount, 0.0) > 0
+            and company.currency_id.compare_amounts(base_amount, tax.l10n_ar_base_minimum_threshold) <= 0
+        }
+        if not excluded_taxes:
+            return
+
+        for base_line in base_lines:
+            tax_details = base_line["tax_details"]
+            for tax_data in tax_details["taxes_data"]:
+                if tax_data["tax"] not in excluded_taxes:
+                    continue
+                tax_details["raw_total_included_currency"] -= tax_data["raw_tax_amount_currency"]
+                tax_details["raw_total_included"] -= tax_data["raw_tax_amount"]
+                for key in (
+                    "base_amount",
+                    "tax_amount",
+                    "raw_base_amount",
+                    "raw_base_amount_currency",
+                    "raw_tax_amount",
+                    "raw_tax_amount_currency",
+                ):
+                    tax_data[key] = 0.0

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import test_arba
 from . import test_map_tax_fiscal_position
+from . import test_perception_base_minimum_threshold
 from . import test_vat_fiscal_position_eligibility
 from . import test_withholding_thresholds
 from . import test_payment_withholding_multimoneda

--- a/l10n_ar_tax/tests/test_perception_base_minimum_threshold.py
+++ b/l10n_ar_tax/tests/test_perception_base_minimum_threshold.py
@@ -1,0 +1,139 @@
+"""
+Tests del monto mínimo de base en percepciones de venta AR
+(`l10n_ar_base_minimum_threshold`, ver l10n_ar_tax/models/account_tax.py).
+
+La base se evalúa por documento y por impuesto, en moneda de la compañía: se suman
+las bases de las líneas que llevan la percepción (las que no la llevan no suman); si
+la suma no supera el umbral, la percepción es 0; si lo supera, se calcula sobre la
+base completa.
+
+Casos (alícuota 3%, umbral 300000):
+    1. Base 301000 (> umbral) → percepción 9030.
+    2. Base 299000 (< umbral) → percepción 0.
+    3. Sin umbral configurado (0) → percepción normal aunque la base sea baja.
+    4. Dos líneas de 200000 con la percepción + dos líneas sin ella → percepción
+       sobre 400000.
+    5. Factura en USD con nominal < umbral pero convertido > umbral → percibe.
+    6. Factura en USD cuyo valor convertido no llega al umbral → no percibe.
+    7. Dos líneas con percepción de 180000 con 5% de descuento y dos líneas sin
+       percepción con 10% de descuento → percepción sobre 342000.
+"""
+
+from odoo import Command
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("-at_install", "post_install")
+class TestPerceptionBaseMinimumThreshold(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Percepción de venta con alícuota fija 3%. Usamos un impuesto propio y no la
+        # percepción CABA "aplicada" de demo (que tiene amount=0 y resuelve su alícuota
+        # vía padrón) para fijar la alícuota y aislar el gate por base mínima.
+        perception_group = cls.env.ref(
+            "account.%i_ri_tax_percepcion_iibb_caba_aplicada" % cls.env.company.id
+        ).tax_group_id
+        cls.perception_tax = cls.env["account.tax"].create(
+            {
+                "name": "Test Percepción IIBB 3%",
+                "amount": 3.0,
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "country_id": cls.env.ref("base.ar").id,
+                "company_id": cls.company_ri.id,
+                "l10n_ar_state_id": cls.env.ref("base.state_ar_c").id,
+                "tax_group_id": perception_group.id,
+            }
+        )
+
+        # 1 USD = 1000 ARS desde el 01/01/2025 (las facturas de los tests son del 15/01).
+        cls.usd = cls.setup_other_currency("USD", rates=[("2025-01-01", 0.001)])
+
+    def _perception_amount(self, lines, currency=None):
+        """Crea y confirma una factura de cliente y devuelve la percepción.
+
+        :param lines: lista de tuplas (price_unit, lleva_percepcion[, descuento_%]). La
+                      línea siempre lleva IVA 21%; la base de la percepción es el neto.
+        :param currency: moneda de la factura (default: la de la compañía).
+        :return: monto de percepción, en la moneda de la factura.
+        """
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.res_partner_adhoc.id,
+                "company_id": self.company_ri.id,
+                "currency_id": (currency or self.company_ri.currency_id).id,
+                "invoice_date": "2025-01-15",
+                "date": "2025-01-15",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.service_iva_21.id,
+                            "quantity": 1,
+                            "price_unit": price_unit,
+                            "discount": discount[0] if discount else 0.0,
+                            "tax_ids": [
+                                Command.set(
+                                    (
+                                        self.tax_21
+                                        + (self.perception_tax if with_perception else self.env["account.tax"])
+                                    ).ids
+                                )
+                            ],
+                        }
+                    )
+                    for price_unit, with_perception, *discount in lines
+                ],
+            }
+        )
+        invoice.action_post()
+        perception_lines = invoice.line_ids.filtered(lambda line: line.tax_line_id == self.perception_tax)
+        return abs(sum(perception_lines.mapped("amount_currency")))
+
+    def test_01_base_above_threshold(self):
+        """Base 301000 > umbral 300000 → percepción sobre la base completa: 9030."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        self.assertAlmostEqual(self._perception_amount([(301000.0, True)]), 9030.0, places=2)
+
+    def test_02_base_below_threshold(self):
+        """Base 299000 < umbral 300000 → percepción 0."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        self.assertAlmostEqual(self._perception_amount([(299000.0, True)]), 0.0, places=2)
+
+    def test_03_no_threshold_perceives_normally(self):
+        """Sin umbral configurado (0), una base baja igual percibe: 1000 * 3% = 30."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 0
+        self.assertAlmostEqual(self._perception_amount([(1000.0, True)]), 30.0, places=2)
+
+    def test_04_base_is_aggregated_only_over_lines_with_the_tax(self):
+        """Dos líneas de 200000 con la percepción (ninguna supera el umbral por sí sola,
+        la suma sí) y dos líneas sin la percepción → percepción sobre 400000 = 12000."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        amount = self._perception_amount([(200000.0, True), (200000.0, True), (500000.0, False), (500000.0, False)])
+        self.assertAlmostEqual(amount, 12000.0, places=2)
+
+    def test_05_foreign_currency_converted_base_above_threshold(self):
+        """500 USD = 500000 ARS: el nominal no llega al umbral pero el convertido sí
+        (el umbral está en moneda de la compañía) → percibe 500 * 3% = 15 USD."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        self.assertAlmostEqual(self._perception_amount([(500.0, True)], currency=self.usd), 15.0, places=2)
+
+    def test_06_foreign_currency_converted_base_below_threshold(self):
+        """200 USD = 200000 ARS < umbral 300000 ARS → percepción 0."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        self.assertAlmostEqual(self._perception_amount([(200.0, True)], currency=self.usd), 0.0, places=2)
+
+    def test_07_base_with_discounts(self):
+        """Dos líneas con percepción de 180000 con 5% de descuento (171000 cada una) y
+        dos líneas sin percepción con 10% de descuento.
+
+        La base del régimen es la neta de descuentos y solo de las líneas que llevan el
+        impuesto: 342000 > umbral 300000 → percepción 342000 * 3% = 10260."""
+        self.perception_tax.l10n_ar_base_minimum_threshold = 300000
+        amount = self._perception_amount(
+            [(180000.0, True, 5.0), (180000.0, True, 5.0), (100000.0, False, 10.0), (100000.0, False, 10.0)]
+        )
+        self.assertAlmostEqual(amount, 10260.0, places=2)

--- a/l10n_ar_tax/views/account_tax_view.xml
+++ b/l10n_ar_tax/views/account_tax_view.xml
@@ -58,13 +58,16 @@
             <field name="l10n_ar_minimum_threshold" position="attributes">
                 <attribute name="invisible">country_code != 'AR' or l10n_ar_type_tax_use != 'supplier' or l10n_ar_tax_type not in ['earnings', 'earnings_scale', 'iibb_untaxed', 'iibb_total']</attribute>
             </field>
-            <!-- Nuevos campos: solo IIBB retención proveedor -->
+            <!-- Nuevos campos: IIBB retención proveedor y, para la base mínima, percepción de ventas (IIBB, IVA) -->
             <field name="l10n_ar_minimum_threshold" position="after">
                 <field name="company_currency_id" invisible="1"/>
+                <field name="l10n_ar_tribute_afip_code" invisible="1"/>
                 <field name="l10n_ar_payment_minimum_threshold"
                     invisible="country_code != 'AR' or l10n_ar_type_tax_use != 'supplier' or l10n_ar_tax_type not in ['iibb_untaxed', 'iibb_total']"/>
+                <!-- Se muestra donde el campo tiene efecto: retención de IIBB a proveedor y las percepciones
+                     de venta que evalúa account.tax._l10n_ar_is_perception_with_base_threshold. -->
                 <field name="l10n_ar_base_minimum_threshold"
-                    invisible="country_code != 'AR' or l10n_ar_type_tax_use != 'supplier' or l10n_ar_tax_type not in ['iibb_untaxed', 'iibb_total']"/>
+                    invisible="country_code != 'AR' or not ((l10n_ar_type_tax_use == 'supplier' and l10n_ar_tax_type in ['iibb_untaxed', 'iibb_total']) or (l10n_ar_type_tax_use == 'sale' and amount_type == 'percent' and not price_include and not include_base_amount and (l10n_ar_state_id or l10n_ar_tribute_afip_code == '06')))"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Aplica el monto mínimo de base del impuesto (`l10n_ar_base_minimum_threshold`, hasta ahora solo usado por las retenciones de IIBB a proveedor) a las **percepciones de venta argentinas**.

El mínimo se evalúa **por documento y por impuesto**: se suman las bases de todas las líneas que llevan esa percepción y la suma se compara, **en moneda de la compañía**, contra el mínimo del impuesto. Si no lo supera, la percepción queda en 0 en todas las líneas; si lo supera, se percibe sobre la base completa (no se resta el mínimo).

Ejemplo con alícuota 2.5% y mínimo de base 650000:

- base 651000 (supera el mínimo) → se percibe 16275 (651000 * 2.5%)
- base 649999 (no supera el mínimo) → se percibe 0, independientemente de la alícuota

Se agregan casos de test. Casos (alícuota 3%, umbral 300000):
    1. Base 301000 (> umbral) → percepción 9030.
    2. Base 299000 (< umbral) → percepción 0.
    3. Sin umbral configurado (0) → percepción normal aunque la base sea baja.
    4. Dos líneas de 200000 con la percepción + dos líneas sin ella → percepción
       sobre 400000.
    5. Factura en USD con nominal < umbral pero convertido > umbral → percibe.
    6. Factura en USD cuyo valor convertido no llega al umbral → no percibe.
    7. Dos líneas con percepción de 180000 con 5% de descuento y dos líneas sin
       percepción con 10% de descuento → percepción sobre 342000.

Tarea: 64477
