### PR TITLE
[FIX] l10n_ar_tax: skip _synchronize_to_moves for non-structural withholding changes

### DIFF
--- a/l10n_ar_tax/__init__.py
+++ b/l10n_ar_tax/__init__.py
@@ -12,12 +12,38 @@ _logger = logging.getLogger(__name__)
 
 def monkey_patch_synchronize_to_moves():
     def _synchronize_to_moves(self, changed_fields):
-        # dynamic_unlink=True allows deletion of withholding move lines with display_type='tax'
-        # that are classified as write-off lines by _seek_for_lines. Without it,
-        # _prevent_automatic_line_deletion raises a ValidationError even in draft state.
-        # This is safe: _synchronize_to_moves only runs on draft moves (posted are skipped),
-        # and this is a programmatic sync, not a user UI deletion.
-        return super(AccountPayment, self.with_context(dynamic_unlink=True))._synchronize_to_moves(changed_fields)
+        # When l10n_ar_withholding_line_ids triggers the sync, distinguish structural
+        # changes (withholding taxes added or removed) from non-structural ones (e.g.
+        # sequence name assignment in action_post via Command.update).
+        #
+        # Non-structural (tax sets on payment and move already match) → skip the sync
+        # entirely; the core would try to delete withholding lines that already have
+        # display_type='tax' (set by _recompute_tax_lines), causing
+        # _prevent_automatic_line_deletion to raise even without dynamic_unlink.
+        #
+        # Structural (tax sets differ: line added or deleted) → apply dynamic_unlink=True
+        # so withholding move lines with display_type='tax' can be safely replaced.
+        ctx_self = self
+        if "l10n_ar_withholding_line_ids" in changed_fields:
+            needs_structural_sync = False
+            for payment in self:
+                active_wth_tax_ids = set(
+                    t.id
+                    for t in payment.l10n_ar_withholding_line_ids.mapped("tax_id")
+                    if t.l10n_ar_withholding_sequence_id
+                )
+                existing_wth_move_tax_ids = set(
+                    l.tax_line_id.id
+                    for l in payment.move_id.line_ids
+                    if l.tax_line_id and l.tax_line_id.l10n_ar_withholding_sequence_id
+                )
+                if active_wth_tax_ids != existing_wth_move_tax_ids:
+                    needs_structural_sync = True
+                    break
+            if not needs_structural_sync:
+                return
+            ctx_self = self.with_context(dynamic_unlink=True)
+        return super(AccountPayment, ctx_self)._synchronize_to_moves(changed_fields)
 
     AccountPayment._synchronize_to_moves = _synchronize_to_moves
 

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -315,8 +315,8 @@ class AccountPayment(models.Model):
                             _("Please enter withholding number for tax %s or configure a sequence on that tax")
                             % line.tax_id.name
                         )
-                if commands:
-                    rec.l10n_ar_withholding_line_ids = commands
+            if commands:
+                rec.l10n_ar_withholding_line_ids = commands
 
         return super().action_post()
 

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -416,13 +416,6 @@ class AccountPayment(models.Model):
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_line_ids = withholdings
 
-    def _synchronize_to_moves(self, changed_fields):
-        # _recompute_tax_lines runs after _synchronize_to_moves rebuilds the payment lines
-        # and explicitly sets display_type='tax' on withholding lines (they have
-        # tax_repartition_line_id).
-        self = self.with_context(dynamic_unlink=True)
-        return super()._synchronize_to_moves(changed_fields)
-
     def compute_to_pay_amount_for_check(self):
         checks_payments = self.filtered(
             lambda x: x.payment_method_code in ["in_third_party_checks", "out_third_party_checks"]


### PR DESCRIPTION
## Problem

The monkey-patch on `_synchronize_to_moves` (added to allow deletion of withholding lines on reset-to-draft) was unconditionally injecting `dynamic_unlink=True` into the context.

This caused a regression during `action_post`: the sequence-name assignment (`Command.update` on `l10n_ar_withholding_line_ids`) triggers `account.payment.write()` → `_synchronize_to_moves`. With `dynamic_unlink=True` always active, the move was fully rebuilt prematurely, leaving an inconsistent draft that could not be posted (*"Solo puede conciliar los asientos publicados"*).

A previous attempt fixed this by applying `dynamic_unlink=True` only when an orphaned withholding move line existed. This was **still insufficient**: when no orphan exists (action_post name assignment), the sync fell through to the core, which classifies withholding lines as `writeoff_lines` and tries to delete them via `(2, id)`. Because `_recompute_tax_lines` had already set `display_type='tax'` on those lines (they carry `tax_repartition_line_id`), `_prevent_automatic_line_deletion` raised a `ValidationError`.

## Fix

Compare the **set of withholding taxes** on the payment (`l10n_ar_withholding_line_ids.tax_id`) against those already on the move (`tax_line_id` with `l10n_ar_withholding_sequence_id`):

- **Equal sets** → non-structural change (e.g. name assignment in `action_post`) → **skip the sync entirely**; the move is left intact and posted normally by `super().action_post()`.
- **Differing sets** → structural change (line added or deleted) → `dynamic_unlink=True` applied so withholding move lines with `display_type='tax'` can be replaced safely.

The original use-case — reset-to-draft + delete an ARBA withholding line — continues to work: after deletion the tax disappears from `l10n_ar_withholding_line_ids` but its move line remains → sets differ → `dynamic_unlink=True` → orphaned line deleted cleanly.

Related: #1457

Replaces: #1461