### PR TITLE
[FIX] l10n_ar_tax: keep AR withholding lines as product type instead of tax

### DIFF
--- a/l10n_ar_tax/__init__.py
+++ b/l10n_ar_tax/__init__.py
@@ -12,12 +12,11 @@ _logger = logging.getLogger(__name__)
 
 def monkey_patch_synchronize_to_moves():
     def _synchronize_to_moves(self, changed_fields):
-        # dynamic_unlink=True allows deletion of withholding move lines with display_type='tax'
-        # that are classified as write-off lines by _seek_for_lines. Without it,
-        # _prevent_automatic_line_deletion raises a ValidationError even in draft state.
-        # This is safe: _synchronize_to_moves only runs on draft moves (posted are skipped),
-        # and this is a programmatic sync, not a user UI deletion.
-        return super(AccountPayment, self.with_context(dynamic_unlink=True))._synchronize_to_moves(changed_fields)
+        # Neutralize l10n_ar_withholding's _synchronize_to_moves override, which manually unlinks
+        # the withholding lines on every sync ("synchronization mechanism is not implemented yet").
+        # Since l10n_ar_tax now keeps withholding lines as display_type='product', the standard
+        # sync handles them correctly, so we skip that manual-unlink override and call super directly.
+        return super(AccountPayment, self)._synchronize_to_moves(changed_fields)
 
     AccountPayment._synchronize_to_moves = _synchronize_to_moves
 

--- a/l10n_ar_tax/models/account_move_line.py
+++ b/l10n_ar_tax/models/account_move_line.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+from collections import defaultdict
+
+from odoo import api, fields, models
 
 
 class AccountMoveLine(models.Model):
@@ -25,3 +27,19 @@ class AccountMoveLine(models.Model):
                 self.partner_id, self.company_id, date, "perception"
             )
         return taxes
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # Force display_type='product' for Argentine withholdings to keep them editable
+        rep_id_to_vals = defaultdict(list)
+        for vals in vals_list:
+            if vals.get("display_type") == "tax" and (rep_id := vals.get("tax_repartition_line_id")):
+                rep_id_to_vals[rep_id].append(vals)
+
+        if rep_id_to_vals:
+            rep_lines = self.env["account.tax.repartition.line"].browse(rep_id_to_vals.keys())
+            for rep_line in rep_lines.filtered(lambda r: r.tax_id.l10n_ar_withholding_payment_type):
+                for vals in rep_id_to_vals[rep_line.id]:
+                    vals["display_type"] = "product"
+
+        return super().create(vals_list)

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -416,13 +416,6 @@ class AccountPayment(models.Model):
                 withholdings += [Command.create({"tax_id": x.id}) for x in taxes]
             rec.l10n_ar_withholding_line_ids = withholdings
 
-    def _synchronize_to_moves(self, changed_fields):
-        # _recompute_tax_lines runs after _synchronize_to_moves rebuilds the payment lines
-        # and explicitly sets display_type='tax' on withholding lines (they have
-        # tax_repartition_line_id).
-        self = self.with_context(dynamic_unlink=True)
-        return super()._synchronize_to_moves(changed_fields)
-
     def compute_to_pay_amount_for_check(self):
         checks_payments = self.filtered(
             lambda x: x.payment_method_code in ["in_third_party_checks", "out_third_party_checks"]

--- a/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
+++ b/l10n_ar_tax/tests/test_payment_receiptbook_and_withholding.py
@@ -142,6 +142,122 @@ class TestPaymentReceiptbookAndWithholding(TestArWithholdingArRi):
             msg="The withholding line must keep its manual amount after reset to draft.",
         )
 
+    def test_reset_to_draft_change_withholding_amount_and_repost(self):
+        """Regression for ticket #118586 (PR #1464): a payment with automatic withholdings must
+        allow reset to draft, editing the withholding amount, and re-confirming.
+
+        Reproduces feg's video step-by-step: register a supplier payment that auto-computes a
+        withholding, override its amount with our own value, post it, then reset to draft, change
+        the withholding amount, and post again.
+
+        The bug: withholding move lines carried ``tax_repartition_line_id`` and were classified as
+        ``display_type='tax'``, so on the next ``_synchronize_to_moves`` rebuild (triggered by
+        reset to draft) ``_prevent_automatic_line_deletion`` raised a ``ValidationError`` and the
+        cycle blew up. We assert the functional outcome instead of internal flags: the whole
+        post → draft → edit amount → post cycle succeeds and the journal entry reflects the edited
+        amount while staying balanced.
+        """
+        first_amount = 30000.0
+        second_amount = 45000.0
+
+        # 1. Vendor bill for a CABA partner and post.
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.env.ref("l10n_ar_tax.res_partner_adhoc_caba").id,
+                "move_type": "in_invoice",
+                "company_id": self.company_ri.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.env.ref("product.product_product_16").id,
+                            "quantity": 1,
+                            "price_unit": 500000,
+                        }
+                    ),
+                ],
+                "invoice_date": self.today,
+                "l10n_latam_document_number": "1-1464",
+            }
+        )
+        invoice.action_post()
+
+        # 2. Fiscal position with the CABA withholding for this partner (auto-applied).
+        fiscal_pos = self.env["account.fiscal.position"].create(
+            {
+                "name": "IIBB CABA 1464",
+                "l10n_ar_afip_responsibility_type_ids": [(6, 0, [self.env.ref("l10n_ar.res_IVARI").id])],
+                "sequence": 10,
+                "auto_apply": True,
+                "country_id": self.env.ref("base.ar").id,
+                "company_id": self.company_ri.id,
+                "state_ids": [(6, 0, [self.env.ref("base.state_ar_c").id])],
+            }
+        )
+        self.env["account.fiscal.position.l10n_ar_tax"].create(
+            {
+                "fiscal_position_id": fiscal_pos.id,
+                "default_tax_id": self.tax_wth_test_1.id,
+                "tax_type": "withholding",
+            }
+        )
+
+        # 3. Register the payment: the withholding is computed automatically from the tax.
+        action_context = invoice.action_register_payment()["context"]
+        payment = (
+            self.env["account.payment"]
+            .with_context(**action_context)
+            .create(
+                {
+                    "journal_id": self.company_bank_journal.id,
+                    "amount": invoice.amount_total,
+                    "date": self.today,
+                }
+            )
+        )
+        wth_line = payment.l10n_ar_withholding_line_ids.filtered(lambda l: l.tax_id == self.tax_wth_test_1)
+        self.assertTrue(wth_line, "The automatic withholding line should have been created")
+
+        def posted_withholding_balance():
+            move_lines = payment.move_id.line_ids.filtered(lambda l: l.tax_repartition_line_id)
+            return abs(sum(move_lines.mapped("balance")))
+
+        def assert_balanced():
+            self.assertTrue(
+                payment.company_currency_id.is_zero(sum(payment.move_id.line_ids.mapped("balance"))),
+                "The journal entry must balance to zero",
+            )
+
+        # 4. Override the withholding amount with our own value and post. We write through the
+        # parent One2many (like the form does) so the change marks the payment dirty and
+        # _synchronize_to_moves rebuilds the journal entry from the edited amount.
+        payment.l10n_ar_withholding_line_ids = [Command.update(wth_line.id, {"amount": first_amount})]
+        payment.action_post()
+        self.assertEqual(payment.move_id.state, "posted")
+        assert_balanced()
+        self.assertAlmostEqual(
+            posted_withholding_balance(),
+            first_amount,
+            places=2,
+            msg="The posted withholding line must reflect the amount we entered",
+        )
+
+        # 5. Reset to draft: this rebuilds the payment lines via _synchronize_to_moves. Before the
+        # fix it raised a ValidationError trying to delete the 'tax' withholding lines.
+        payment.action_draft()
+        self.assertEqual(payment.move_id.state, "draft")
+
+        # 6. Change the withholding amount and confirm again.
+        payment.l10n_ar_withholding_line_ids = [Command.update(wth_line.id, {"amount": second_amount})]
+        payment.action_post()
+        self.assertEqual(payment.move_id.state, "posted")
+        assert_balanced()
+        self.assertAlmostEqual(
+            posted_withholding_balance(),
+            second_amount,
+            places=2,
+            msg="After reset to draft and editing, the journal entry must reflect the new " "withholding amount",
+        )
+
     def test_force_amount_company_currency_with_withholdings(self):
         """Test that when paying a foreign currency vendor bill with withholdings and a forced
         company currency amount, the journal entry lines are correctly computed.


### PR DESCRIPTION
Both the deletion fix from #118586 and the issue in #119788 stem from the same root cause: AR withholding move lines carry tax_repartition_line_id, so _recompute_tax_lines forces display_type='tax' on them. As 'tax' lines they become non-editable and _prevent_automatic_line_deletion blocks them from being removed on the next _synchronize_to_moves rebuild.

The previous approach worked around the symptom by passing dynamic_unlink=True into _synchronize_to_moves (in two places: the post_load monkeypatch in __init__.py and the AccountPayment override in account_payment.py) just to authorise deleting those 'tax' lines.

This commit drops both workarounds and fixes the cause instead: override account.move.line create to force display_type='product' for AR withholding lines (repartition lines whose tax has l10n_ar_withholding_payment_type set). The lines are never classified as tax lines, so they stay editable and can be deleted on sync without bypassing _prevent_automatic_line_deletion.

- Remove dynamic_unlink=True from _synchronize_to_moves monkeypatch (__init__.py)
- Remove the AccountPayment._synchronize_to_moves override (account_payment.py)
- Force display_type='product' for AR withholdings in account.move.line.create