### PR TITLE
[I18N] l10n_ar_tax: translate reversal moves receipt setting (es)

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -1287,12 +1287,12 @@ msgstr "Deuda Seleccionada No Gravada"
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_config_settings__show_reversal_moves_in_receipts
 msgid "Show Reversal Moves In Receipts"
-msgstr ""
+msgstr "Mostrar movimientos de reversión en los recibos"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.res_config_settings_view_form
 msgid "Show reversal moves in receipts"
-msgstr ""
+msgstr "Mostrar movimientos de reversión en los recibos"
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.res_config_settings_view_form


### PR DESCRIPTION
## Summary

Spanish translation for the "show reversal moves in payment receipts" setting added in #1318 (task 61868). These msgids existed in `l10n_ar_tax/i18n/es.po` with an empty `msgstr`:

| msgid | msgstr (es) |
|---|---|
| Show Reversal Moves In Receipts | Mostrar movimientos de reversión en los recibos |
| Show reversal moves in receipts | Mostrar movimientos de reversión en los recibos |

Consistent with the already-translated help text ("Muestra las ND y NC en los recibos de pago, como movimientos a parte.").

Task: 69662
