### PR TITLE
[FIX] l10n_ar_ux: evitar marca roja de salto de secuencia en facturas con documentos

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "19.0.1.10.0",
+    "version": "19.0.1.10.1",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -111,6 +111,22 @@ class AccountMove(models.Model):
     def _get_l10n_ar_codes_used_for_inv_and_ref(self):
         return super()._get_l10n_ar_codes_used_for_inv_and_ref() + ["33", "331"]
 
+    def _update_sequence_made_gap(self, invalidate_current=False):
+        """Las facturas que usan documentos (p. ej. facturas de proveedor argentinas) toman su
+        numeración del documento del proveedor, no de una secuencia administrada por el diario,
+        por lo que los "saltos de secuencia" son normales y no deben marcar el comprobante en rojo.
+
+        En v18 el flag lo computaba `_compute_made_sequence_gap` y `l10n_latam_invoice_document`
+        ya excluía estos comprobantes. En v19 el cálculo se movió a `_update_sequence_made_gap`,
+        pero el override de upstream quedó sobre los métodos deprecados (`_compute_made_sequence_gap`
+        y `_set_next_made_sequence_gap`), que ya no se ejecutan, dejando el guard sin efecto.
+        Reaplicamos acá la exclusión hasta que Odoo lo corrija upstream.
+        """
+        use_documents_moves = self.filtered(lambda m: m.l10n_latam_use_documents)
+        use_documents_moves.made_sequence_gap = False
+        if other_moves := self - use_documents_moves:
+            super(AccountMove, other_moves)._update_sequence_made_gap(invalidate_current=invalidate_current)
+
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()
         domain = super()._get_l10n_latam_documents_domain()


### PR DESCRIPTION
## Problema

En v19 las facturas de proveedor argentinas aparecen marcadas en rojo en la lista de comprobantes, como si rompieran la secuencia del diario. En facturas de proveedor AR esto no debería pasar: su numeración proviene del documento del proveedor, no de una secuencia administrada por el diario, por lo que los "saltos" entre números son normales.

## Causa

El flag `made_sequence_gap` (que dispara el `decoration-danger` rojo en la vista) en v18 lo computaba `_compute_made_sequence_gap`, y `l10n_latam_invoice_document` ya excluía de ese cálculo a los comprobantes con `l10n_latam_use_documents`.

En v19 el cálculo se movió a `_update_sequence_made_gap`, pero el override de upstream quedó solamente sobre los métodos ahora deprecados (`_compute_made_sequence_gap` y `_set_next_made_sequence_gap`), que ya no se ejecutan. El guard quedó sin efecto y los comprobantes con documentos vuelven a marcarse en rojo.

Esto es un bug de Odoo upstream (la localización LatAm no se actualizó al refactor de v19) y debería reportarse. Mientras tanto reaplicamos la exclusión del lado de Adhoc.

## Solución

Override de `_update_sequence_made_gap` en `l10n_ar_ux` que excluye los moves con `l10n_latam_use_documents` (les fija `made_sequence_gap = False`) y delega al `super` solo para el resto, replicando la intención del guard original de `l10n_latam_invoice_document`.

## Test plan

- En una base AR, cargar varias facturas de proveedor con números de documento no consecutivos y confirmarlas.
- Verificar en la lista de facturas de proveedor que el número (`name`) ya no aparece en rojo.
- Verificar que en diarios sin documentos (que sí usan secuencia administrada) la detección de saltos de secuencia sigue funcionando.

Tarea: https://www.adhoc.inc/odoo/project.task/69756