### PR TITLE
[FIX] l10n_ar_ux: sanitize VAT to avoid traceback with hidden characters

### DIFF
--- a/l10n_ar_ux/__manifest__.py
+++ b/l10n_ar_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Accounting UX",
-    "version": "18.0.1.11.0",
+    "version": "18.0.1.12.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_ux/models/res_partner.py
+++ b/l10n_ar_ux/models/res_partner.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -117,17 +118,36 @@ class ResPartner(models.Model):
                     values.pop(r_field, False)
         return values
 
+    def _get_id_number_sanitize(self):
+        """Devuelve los dígitos del número de identificación (0 si no hay VAT).
+
+        Usamos una regex en lugar de ``stdnum.ar.cuit.compact`` (que usaba
+        ``l10n_ar`` para CUIT/CUIL) porque ``compact`` no limpia caracteres
+        ocultos (p. ej. pegados desde Excel) y hacía fallar el ``int()``.
+        Mantenemos el comportamiento del base: con VAT sin dígitos devuelve un
+        string vacío (los callers ya lo tratan como falsy).
+        """
+        self.ensure_one()
+        if not self.vat:
+            return 0
+        id_number = re.sub("[^0-9]", "", self.vat)
+        return id_number and int(id_number)
+
     @api.onchange("vat", "country_id", "l10n_latam_identification_type_id")
     def _onchange_ar_identification_fields(self):
         """
-        Agregamos este onchange para que cuando el usuario modifique el VAT o el tipo de documento
-        se formatee el VAT automaticamente si es un CUIT o un DNI.
-        En v19 esto ya está hecho en este commit https://github.com/odoo/odoo/commit/ac95d2d6d80a368dfb190d0ac21da2af479a8488.
-        Traemos sólo lo necesario acá para tenerlo disponible en esta versión.
+        Formatea automáticamente el VAT cuando el usuario modifica el VAT o el tipo de
+        documento, dejando sólo los dígitos si es un documento numérico argentino
+        (CUIT, CUIL o DNI).
+
+        Nuestro comportamiento diverge a propósito del de Odoo:
+        En v19 la sanitización se aplica a todos los tipos de documento; acá la limitamos
+        a los documentos numéricos argentinos vía ``_get_validation_module`` (devuelve un
+        módulo sólo para CUIT/CUIL/DNI —AFIP 80/86/96— y None para el resto: VAT,
+        pasaporte, documento extranjero, etc., que pueden contener letras y no deben
+        sanitizarse).
         """
-        l10n_ar_partners = self.filtered(
-            lambda p: p.vat and (p.l10n_latam_identification_type_id.l10n_ar_afip_code or p.country_code == "AR")
-        )
+        l10n_ar_partners = self.filtered(lambda p: p.vat and p._get_validation_module())
         for partner in l10n_ar_partners:
             if id_number := partner._get_id_number_sanitize():
                 partner.vat = str(id_number)

--- a/l10n_ar_ux/tests/__init__.py
+++ b/l10n_ar_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_partner

--- a/l10n_ar_ux/tests/test_res_partner.py
+++ b/l10n_ar_ux/tests/test_res_partner.py
@@ -1,0 +1,71 @@
+from odoo.tests import Form, common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestResPartnerSanitize(common.TransactionCase):
+    """Sanitización del VAT con caracteres ocultos (tarea #66709).
+
+    El error sólo se dispara en Adhoc por el onchange ``_onchange_ar_identification_fields``
+    de ``l10n_ar_ux`` (que llama a ``_get_id_number_sanitize``). Por eso la lógica
+    vive acá: la sanitización usa regex en vez de ``stdnum.ar.cuit.compact``, que
+    no limpia caracteres ocultos y hacía fallar el ``int()``.
+    """
+
+    # Word joiner (U+2060): el carácter oculto del traceback original.
+    HIDDEN_CHAR = chr(0x2060)
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Reutilizamos el partner CUIT que ya provee l10n_ar (data, siempre cargado).
+        cls.partner = cls.env.ref("l10n_ar.partner_afip")
+        cls.ar = cls.env.ref("base.ar")
+        cls.it_dni = cls.env.ref("l10n_ar.it_dni")  # AFIP 96
+        cls.it_passport = cls.env.ref("l10n_latam_base.it_pass")  # AFIP 94
+
+    def test_sanitize_cuit_with_hidden_char_no_traceback(self):
+        """Un CUIT con carácter oculto no debe romper, debe devolver sólo dígitos."""
+        cuit = self.partner.vat
+        partner = self.partner.new({"vat": self.HIDDEN_CHAR + cuit}, origin=self.partner)
+        self.assertEqual(partner._get_id_number_sanitize(), int(cuit))
+
+    def test_sanitize_cuit_with_separators(self):
+        """El CUIT con guiones se compacta a sólo dígitos."""
+        cuit = self.partner.vat
+        formatted = "%s-%s-%s" % (cuit[:2], cuit[2:10], cuit[10:])
+        partner = self.partner.new({"vat": formatted}, origin=self.partner)
+        self.assertEqual(partner._get_id_number_sanitize(), int(cuit))
+
+    def test_sanitize_no_vat_returns_zero(self):
+        partner = self.partner.new({"vat": False}, origin=self.partner)
+        self.assertEqual(partner._get_id_number_sanitize(), 0)
+
+    def test_onchange_formats_cuit_with_hidden_char(self):
+        """El onchange limpia el VAT del CUIT dejando sólo el número y permite guardar."""
+        cuit = self.partner.vat
+        with Form(self.partner) as form:
+            form.vat = self.HIDDEN_CHAR + cuit
+        self.assertEqual(self.partner.vat, cuit)
+
+    def test_onchange_formats_dni(self):
+        """El DNI también es un documento numérico argentino: se formatea.
+
+        No guardamos el Form: el onchange dispara al setear el VAT, y evitar el
+        ``save`` desacopla el test de campos requeridos que agregan otros módulos
+        (p. ej. ``sire_born_country_id`` de ``l10n_ar_txt_sire``).
+        """
+        form = Form(self.env["res.partner"])
+        form.name = "Test DNI"
+        form.country_id = self.ar
+        form.l10n_latam_identification_type_id = self.it_dni
+        form.vat = "30.717.808"
+        self.assertEqual(form.vat, "30717808")
+
+    def test_onchange_keeps_non_numeric_doc_untouched(self):
+        """Un documento no numérico (pasaporte) puede tener letras: no se toca."""
+        form = Form(self.env["res.partner"])
+        form.name = "Test passport"
+        form.country_id = self.ar
+        form.l10n_latam_identification_type_id = self.it_passport
+        form.vat = "AB123456"
+        self.assertEqual(form.vat, "AB123456")


### PR DESCRIPTION
### Issue

When a contact's VAT (CUIT/CUIL) is pasted from an external source such as Excel or a PDF, it may carry hidden/special characters (e.g. a word joiner or a zero-width space). Saving such a contact raised a traceback and the contact could not be created:

```
File ".../l10n_ar/models/res_partner.py", in _get_id_number_sanitize
    res = int(stdnum.ar.cuit.compact(self.vat))
ValueError: invalid literal for int() with base 10: '...'
```

The error surfaces in this module specifically because `l10n_ar_ux` backported the `_onchange_ar_identification_fields` onchange, which calls `_get_id_number_sanitize()` to auto-format the VAT. The standard `l10n_ar` implementation uses `stdnum.ar.cuit.compact()` for AFIP codes 80/86, and that helper does not strip non-numeric characters.

### Fix

- Override `res.partner._get_id_number_sanitize()` in `l10n_ar_ux` to keep only digits via regex. This avoids the `ValueError` and yields the same result for valid numbers.
- The `_onchange_ar_identification_fields` onchange now auto-formats the VAT only for Argentine numeric documents (CUIT, CUIL and DNI), detected via `_get_validation_module()` (the same predicate `l10n_ar` uses to know which documents it validates as numbers). Non-numeric documents (VAT, passport, foreign id) are left untouched, since they may contain letters.

A first approach proposed the fix upstream (odoo/odoo#260164), but the traceback is not reproducible in standard Odoo (no such onchange), so the logic is kept here instead.

### Test plan

`tests/test_res_partner.py` (`TestResPartnerSanitize`) reuses the CUIT partner shipped by `l10n_ar` (`l10n_ar.partner_afip`) and covers:

- `_get_id_number_sanitize()` returns only the numeric part for a CUIT with a hidden character (no traceback) and for a CUIT with separators; returns `0` when there is no VAT.
- The onchange formats a CUIT with a hidden character and a DNI with separators, and the cleaned VAT validates and saves.
- The onchange leaves a non-numeric document (passport with letters) untouched.

```
test_onchange_formats_cuit_with_hidden_char ... ok
test_onchange_formats_dni ... ok
test_onchange_keeps_non_numeric_doc_untouched ... ok
test_sanitize_cuit_with_hidden_char_no_traceback ... ok
test_sanitize_cuit_with_separators ... ok
test_sanitize_no_vat_returns_zero ... ok
0 failed, 0 error(s) of 6 tests
```
