### PR TITLE
[FIX] l10n_ar_tax: restrict AR fiscal position default tax to percent

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -188,7 +188,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
     def _get_tax_domain(self, filter_tax_group=True):
         self.ensure_one()
         domain = self.env["account.tax"]._check_company_domain(self.fiscal_position_id.company_id)
-        domain += [("amount_type", "in", ["percent", "division"])]
+        domain += [("amount_type", "=", "percent")]
         if filter_tax_group:
             tax_group = self.tax_group_id or self.default_tax_id.tax_group_id
             if tax_group:


### PR DESCRIPTION
## Qué

En las posiciones fiscales argentinas (sección "Percepciones y Retenciones"), solo se puede usar como impuesto por defecto un impuesto cuyo "Cálculo de impuestos" (`amount_type`) sea **Porcentaje** (`percent`).

## Por qué

El cálculo de percepciones/retenciones asume una alícuota porcentual aplicada sobre la base imponible (`amount = base * tax.amount / 100`). De esa premisa dependen el campo `aliquot`, la duplicación del impuesto plantilla en `_ensure_tax`, y las alícuotas que devuelven los padrones/webservices (ARBA, AGIP, Rentas Córdoba).

Hasta ahora el dominio también permitía `division` ("Porcentaje de impuesto incluido"). Con ese cálculo Odoo deduce la base a partir de un precio con impuesto incluido, por lo que la percepción/retención se calcula sobre una base equivocada y el monto queda mal (ej.: `3035,36 * 5%` debería dar `151,77` y devolvía `159,76`). Además se propaga: los impuestos se duplican y reutilizan por alícuota + jurisdicción, así que una vez generado uno mal contamina a todos los contactos con esa alícuota hasta borrarlo a mano.

## Cómo

Se restringe `_get_tax_domain` a `amount_type = 'percent'`. Esto filtra tanto el dropdown del impuesto por defecto como la búsqueda/creación de impuestos en `_ensure_tax` (flujo IIBB + webservices).

## Test plan

- En una posición fiscal AR de percepciones/retenciones, el combo "Impuesto por defecto" ya no ofrece impuestos con cálculo distinto a "Porcentaje" (ej. "Porcentaje de impuesto incluido").
- Con un impuesto base configurado como "Porcentaje", al generar la percepción IIBB vía webservice (ARBA) el impuesto duplicado queda en "Porcentaje" y el monto se calcula sobre la base imponible.
