### PR TITLE
[IMP] l10n_ar_tax: resolve fiscal position IIBB default tax from group (percent taxes)

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -104,11 +104,12 @@ class AccountFiscalPositionL10nArTax(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        """Resolve default_tax_id from tax_group_id + aliquot before INSERT so that
-        the required=True constraint on default_tax_id is satisfied.
-        Also derives webservice from default_tax_id when not explicitly provided."""
+        """Try to resolve default_tax_id from tax_group_id + aliquot before INSERT
+        (aliquot defaults to 0, i.e. the group's zero-aliquot tax) and derive webservice
+        from it. If no matching tax can be resolved, default_tax_id stays unset and the
+        required=True constraint raises as usual."""
         for vals in vals_list:
-            if not vals.get("default_tax_id") and vals.get("tax_group_id") and "aliquot" in vals:
+            if not vals.get("default_tax_id") and vals.get("tax_group_id"):
                 stub = self.new(vals)
                 stub._sync_default_tax_from_ux_fields()
                 if stub.default_tax_id:
@@ -135,8 +136,9 @@ class AccountFiscalPositionL10nArTax(models.Model):
 
     @api.onchange("tax_group_id")
     def _onchange_tax_group_id(self):
-        """When group changes, sync only if aliquot is already filled."""
-        if self.tax_group_id and self.aliquot:
+        """Resolve default_tax_id from the group (and aliquot); selecting the group alone
+        defaults to its zero-aliquot tax, so the line can be saved with just the group."""
+        if self.tax_group_id:
             self._sync_default_tax_from_ux_fields()
 
     @api.onchange("aliquot")
@@ -188,7 +190,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
     def _get_tax_domain(self, filter_tax_group=True):
         self.ensure_one()
         domain = self.env["account.tax"]._check_company_domain(self.fiscal_position_id.company_id)
-        domain += [("amount_type", "in", ["percent", "division"])]
+        domain += [("amount_type", "in", ["percent"])]
         if filter_tax_group:
             tax_group = self.tax_group_id or self.default_tax_id.tax_group_id
             if tax_group:


### PR DESCRIPTION
## Qué cambia

En posiciones fiscales de compañías argentinas, en la solapa **Perceptions and Withholdings** (`l10n_ar_tax_ids`), al elegir un grupo de impuestos IIBB en `tax_group_id` ahora se resuelve `default_tax_id` **eligiendo únicamente el grupo**, sin necesidad de cargar la alícuota: se toma el impuesto de **alícuota cero** del grupo, de modo que la línea puede guardarse solo con el grupo.

Además, la búsqueda del impuesto se **acota a impuestos `percent`** (ya no matchea `division`).

## Notas técnicas

- `_onchange_tax_group_id` sincroniza al setear el grupo aunque la alícuota sea 0 (antes requería alícuota no nula).
- `create()` resuelve `default_tax_id` cuando viene solo `tax_group_id` (antes exigía además que `aliquot` estuviera en `vals`). Si no se puede resolver ningún impuesto, `default_tax_id` queda sin setear y el constraint `required=True` da error como siempre.
- `_get_tax_domain` acota `amount_type` a `['percent']` (antes `['percent', 'division']`), para no seleccionar impuestos `division`.
- La resolución sigue centralizada en `_sync_default_tax_from_ux_fields` → `_ensure_tax`, sin cambios de comportamiento (activa un impuesto archivado o copia el template del grupo para la alícuota cuando hace falta).

## Test plan

- En una FP de una compañía AR, agregar una línea en "Perceptions and Withholdings" y elegir el grupo "WTH IIBB Santa Fe" (sin tocar la alícuota): `default_tax_id` debe completarse con la retención IIBB Santa Fe de alícuota 0 y la línea debe poder guardarse.
- Ingresar una alícuota de ese grupo para la que no existe impuesto: `default_tax_id` debe resolverse a un impuesto `percent` (copiando el template del grupo si hacía falta), nunca a un `division`.

Task: https://www.adhoc.inc/odoo/project/902/tasks/69895
