### PR TITLE
[IMP] l10n_ar_tax: forbid jurisdiction on earnings withholding taxes

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -1349,6 +1349,14 @@ msgstr "El código del estado."
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_tax.py:0
+msgid "The earnings withholding tax '%s' cannot have a jurisdiction assigned."
+msgstr ""
+"El impuesto de retención de ganancias '%s' no puede tener una jurisdicción "
+"asignada."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_tax.py:0
 msgid ""
 "The total percentage (%s) should be greater than 0 and less than or equal to "
 "100."

--- a/l10n_ar_tax/i18n/l10n_ar_tax.pot
+++ b/l10n_ar_tax/i18n/l10n_ar_tax.pot
@@ -1307,6 +1307,12 @@ msgstr ""
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_tax.py:0
+msgid "The earnings withholding tax '%s' cannot have a jurisdiction assigned."
+msgstr ""
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_tax.py:0
 msgid ""
 "The total percentage (%s) should be greater than 0 and less than or equal to"
 " 100."

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -198,3 +198,16 @@ class AccountTax(models.Model):
                         "The total percentage (%s) should be greater than 0 and less than or equal to 100.", tax.ratio
                     )
                 )
+
+    @api.constrains("l10n_ar_tax_type", "l10n_ar_state_id")
+    def _check_earnings_no_jurisdiction(self):
+        """Earnings withholdings are not provincial, so they cannot have a
+        jurisdiction assigned (unlike IIBB, which is per-province)."""
+        for tax in self:
+            if tax.l10n_ar_tax_type in ["earnings", "earnings_scale"] and tax.l10n_ar_state_id:
+                raise ValidationError(
+                    self.env._(
+                        "The earnings withholding tax '%s' cannot have a jurisdiction assigned.",
+                        tax.name,
+                    )
+                )


### PR DESCRIPTION
## What

Adds a constraint on `account.tax` that prevents assigning a jurisdiction (`l10n_ar_state_id`) to earnings withholding taxes (`l10n_ar_tax_type in ['earnings', 'earnings_scale']`).

## Why

Earnings withholdings are not provincial (unlike IIBB, which is configured per-province). Having a jurisdiction assigned on an earnings tax is always a configuration error. The constraint blocks it at validation time with a clear message.

## Changes

- `l10n_ar_tax/models/account_tax.py`: new `@api.constrains('l10n_ar_tax_type', 'l10n_ar_state_id')` → `_check_earnings_no_jurisdiction`.
- `l10n_ar_tax/i18n/l10n_ar_tax.pot` and `es.po`: translation entries for the new constraint message.

## Test plan

- Create/edit a tax with `l10n_ar_tax_type = earnings` (or `earnings_scale`) and assign it a jurisdiction → should raise `ValidationError`.
- Create the same tax without a jurisdiction → OK.
- IIBB taxes (`iibb_untaxed`/`iibb_total`) with a jurisdiction → keep working with no restriction.

Task: 69914