### PR TITLE
[FIX] l10n_ar_ux: IIBB by jurisdiction reports filter and grouping

### DIFF
--- a/l10n_ar_ux/i18n/es.po
+++ b/l10n_ar_ux/i18n/es.po
@@ -74,6 +74,11 @@ msgid "Account"
 msgstr "Cuenta"
 
 #. module: l10n_ar_ux
+#: model_terms:ir.ui.view,arch_db:l10n_ar_ux.view_account_invoice_report_search
+msgid "Accounting Date: Last Month"
+msgstr "Fecha contable: Mes anterior"
+
+#. module: l10n_ar_ux
 #: model:ir.model.fields,field_description:l10n_ar_ux.field_res_company__l10n_ar_report_signed_by
 msgid "Aclaracion"
 msgstr ""

--- a/l10n_ar_ux/reports/account_invoice_report_view.xml
+++ b/l10n_ar_ux/reports/account_invoice_report_view.xml
@@ -12,4 +12,33 @@
         </field>
     </record>
 
+    <!-- Insertamos un separador para que los filtros "with_document" y "filter_accounting_date_this_year"
+    pasen a grupos distintos y se combinen con AND. -->
+    <record id="view_account_invoice_report_search" model="ir.ui.view">
+        <field name="name">account.invoice.report.search.l10n_ar_ux</field>
+        <field name="model">account.invoice.report</field>
+        <field name="inherit_id" ref="l10n_ar.view_account_invoice_report_search_inherit"/>
+        <field name="arch" type="xml">
+            <filter name="filter_accounting_date_this_year" position="before">
+                <separator/>
+            </filter>
+            <!-- Filtro "mes anterior" para el default de IIBB Ventas (se declara el mes calendario
+            cerrado anterior). Queda en el mismo grupo que filter_accounting_date_this_year, separado de
+            with_document, así combina con AND. -->
+            <filter name="filter_accounting_date_this_year" position="after">
+                <filter name="filter_accounting_date_last_month" invisible="1" string="Accounting Date: Last Month" domain="[('date', '&gt;=', (context_today() + relativedelta(months=-1, day=1)).strftime('%Y-%m-%d')), ('date', '&lt;', (context_today() + relativedelta(day=1)).strftime('%Y-%m-%d'))]"/>
+            </filter>
+        </field>
+    </record>
+
+    <!-- Sacamos el agrupamiento por compañía de los reportes de IIBB ya que con branches no aporta valor
+    y suma un nivel de agrupación que afecta a la performance. -->
+    <record id="l10n_ar.action_iibb_sales_by_state_and_account_pivot" model="ir.actions.act_window">
+        <field name="context">{'search_default_current': 1, 'search_default_customer': 1, 'search_default_with_document': 1, 'search_default_groupby_l10n_ar_state_id': 1, 'search_default_groupby_account_id': 2, 'search_default_filter_accounting_date_last_month': 1}</field>
+    </record>
+
+    <record id="l10n_ar.action_iibb_purchases_by_state_and_account_pivot" model="ir.actions.act_window">
+        <field name="context">{'search_default_current': 1, 'search_default_supplier': 1, 'search_default_with_document': 1, 'search_default_groupby_l10n_ar_state_id': 1, 'search_default_groupby_account_id': 2, 'search_default_filter_accounting_date_this_year': 1}</field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
### What

Fixes the *IIBB - Sales/Purchases by jurisdiction* pivot reports (`l10n_ar`), overriding them from `l10n_ar_ux`.

**1. Filters combined with OR instead of AND.** In the `l10n_ar` search view, `with_document` and `filter_accounting_date_this_year` are appended as adjacent filters with no `<separator/>` between them, so they fall in the same group. Both are enabled by default in the IIBB actions, so the facet rendered as *"With Document **or** Accounting Date: This Year"* — returning everything of the year OR everything with a document, instead of the intersection. This bloats the result set and hurts performance. Added a `<separator/>` so they combine with AND.

**2. Removed the `company_id` grouping.** Both IIBB pivot actions set `search_default_company` as the first group-by level. Grouping by company is meaningless with branches and the extra grouping level penalizes performance, so it was dropped (jurisdiction and account remain).

### Files

- `l10n_ar_ux/reports/account_invoice_report_view.xml` — search view inherit (separator) + override of both action contexts.

### Test plan

- Open *Accounting → IIBB - Sales by jurisdiction* and *IIBB - Purchases by jurisdiction*.
- The default facet shows *With Document* and *Accounting Date: This Year* as two separate chips combined with **AND** (no "or").
- The pivot no longer groups by company; rows are grouped by jurisdiction then account for the active companies.

Internal task: #64170