### PR TITLE
[IMP] l10n_ar_tax: limitar auto-detección de posición fiscal AR a NC con reversión

### DIFF
--- a/l10n_ar_tax/README.md
+++ b/l10n_ar_tax/README.md
@@ -9,6 +9,7 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 - Multi-currency withholdings: payments in USD, EUR, or any foreign currency produce correct ARS-denominated withholdings.
 - Configurable tax ratios for specific jurisdictions (e.g. Córdoba).
 - Fiscal position-based tax automation.
+- Argentine fiscal positions can be flagged to only auto-detect on credit notes created as a full-refund reversal, avoiding their application on manual credit notes.
 - Withholding certificate generation.
 - Integration with ARCA web services.
 - ARBA and Santa Fe (PARP) padron importers.

--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -928,6 +928,17 @@ msgid "ID"
 msgstr "ID (identificación)"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid ""
+"If enabled, the perception taxes of this fiscal position only apply to "
+"credit notes when the amount is exactly equal to the related invoice and "
+"both are in the same month."
+msgstr ""
+"Si está habilitado, las percepciones de esta posición fiscal solo se aplican "
+"a las notas de crédito cuando el importe es exactamente igual al de la "
+"factura relacionada y ambas están en el mismo mes."
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,help:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid ""
@@ -1114,6 +1125,11 @@ msgstr "Número"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "Observations:"
 msgstr "Observaciones:"
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid "Only applies to NC with total refund (AR)"
+msgstr "Solo aplica en NC con devolución total (AR)"
 
 #. module: l10n_ar_tax
 #. odoo-python

--- a/l10n_ar_tax/i18n/l10n_ar_tax.pot
+++ b/l10n_ar_tax/i18n/l10n_ar_tax.pot
@@ -890,6 +890,14 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,help:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid ""
+"If enabled, the perception taxes of this fiscal position only apply to "
+"credit notes when the amount is exactly equal to the related invoice and "
+"both are in the same month."
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,help:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid ""
@@ -1061,6 +1069,11 @@ msgstr ""
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.report_payment_receipt_document
 msgid "Observations:"
+msgstr ""
+
+#. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position__l10n_ar_require_related_invoice
+msgid "Only applies to NC with total refund (AR)"
 msgstr ""
 
 #. module: l10n_ar_tax

--- a/l10n_ar_tax/models/account_fiscal_position.py
+++ b/l10n_ar_tax/models/account_fiscal_position.py
@@ -6,6 +6,14 @@ class AccountFiscalPosition(models.Model):
     _inherit = "account.fiscal.position"
 
     l10n_ar_tax_ids = fields.One2many("account.fiscal.position.l10n_ar_tax", "fiscal_position_id")
+    l10n_ar_require_related_invoice = fields.Boolean(
+        string="Only applies to NC with total refund (AR)",
+        help=(
+            "If enabled, the perception taxes of this fiscal position only apply "
+            "to credit notes when the amount is exactly equal to the related invoice "
+            "and both are in the same month."
+        ),
+    )
     l10n_ar_tax_type = fields.Selection(
         selection=[
             ("perception", "Perception"),

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -44,11 +44,17 @@ class AccountMove(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
+        # Disparamos el recompute en write y no en create: al momento del create todavía no se
+        # computaron todos los campos del account.move (líneas, importes, etc.), por lo que
+        # _l10n_ar_recompute_fiscal_position_taxes no se ejecutaría correctamente en el create.
         # Si el invoice_date cambia, recomputamos las percepciones.
         # En Odoo 18+, cuando el guardado viene de un formulario (UI), los 'tax_ids' de las líneas
         # suelen estar presentes en los 'vals' (dentro de 'invoice_line_ids').
         # Si el usuario editó las líneas, no queremos re-ejecutar nuestra lógica de refresco automático.
-        if "invoice_date" in vals and "invoice_line_ids" not in vals:
+        if ("invoice_date" in vals and "invoice_line_ids" not in vals) or (
+            "fiscal_position_id" in vals
+            and self.env["account.fiscal.position"].browse(vals["fiscal_position_id"]).l10n_ar_require_related_invoice
+        ):
             self._l10n_ar_recompute_fiscal_position_taxes()
         return res
 
@@ -58,7 +64,12 @@ class AccountMove(models.Model):
         IMPORTANTE: este metodo solo esta pensado para cambiar alicuota de MISMA fiscal position (por cambio en fecha o partner) pero no para cambiar los impuestos.
         Para ello nos basamos en los impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
         reemplazamos por los nuevos impuestos.
-        NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes
+        Por regla general NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes.
+        EXCEPCION: write() sí invoca este recompute cuando se cambia a una fiscal_position_id con l10n_ar_require_related_invoice=True, para reevaluar las percepciones según las reglas de NC con reversión que se describen abajo.
+
+        Para posiciones fiscales con l10n_ar_require_related_invoice=True:
+        - En NC: solo aplica si es devolución total (mismo monto) en el mismo mes que la factura relacionada.
+        - Si no cumple → elimina los impuestos de percepción de las líneas.
         """
         for move in self.filtered(
             lambda x: x.is_sale_document(include_receipts=True)
@@ -69,14 +80,65 @@ class AccountMove(models.Model):
             fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"
             ).mapped("default_tax_id.tax_group_id")
-            new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
-                move.partner_id, move.company_id, move.date, "perception"
+
+            if move.move_type == "out_refund" and move.fiscal_position_id.l10n_ar_require_related_invoice:
+                related = move._found_related_invoice()
+                if (
+                    related
+                    and move.invoice_date
+                    and related.invoice_date
+                    and move.invoice_date.year == related.invoice_date.year
+                    and move.invoice_date.month == related.invoice_date.month
+                    and move.currency_id.is_zero(abs(related.amount_untaxed) - abs(move.amount_untaxed))
+                ):
+                    new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                        move.partner_id, move.company_id, related.date, "perception"
+                    )
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink._origin != new_taxes:
+                            line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+                elif move._l10n_ar_so_invoice_same_untaxed():
+                    # Existe una factura vinculada en la orden de venta con el mismo importe sin
+                    # impuestos: calculamos las percepciones normalmente (como si la posición fiscal
+                    # no tuviera l10n_ar_require_related_invoice).
+                    new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                        move.partner_id, move.company_id, move.date, "perception"
+                    )
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink._origin != new_taxes:
+                            line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+                else:
+                    for line in move.invoice_line_ids:
+                        to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                        if to_unlink:
+                            line.tax_ids = line.tax_ids - to_unlink
+            else:
+                new_taxes = move.fiscal_position_id._l10n_ar_add_taxes(
+                    move.partner_id, move.company_id, move.date, "perception"
+                )
+                # Solo queremos que se recomputen los impuestos en facturas de cliente/proveedor
+                for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
+                    to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
+                    if to_unlink._origin != new_taxes:
+                        line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+
+    def _l10n_ar_so_invoice_same_untaxed(self):
+        """Factura(s) de cliente posteada(s) vinculada(s) a la(s) misma(s) orden(es) de venta de esta
+        NC, con el mismo importe sin impuestos. Se usa para decidir si, pese a no cumplirse la
+        condición de devolución total contra la factura original (reversed_entry_id), igual
+        corresponde calcular las percepciones. Vacío si el módulo sale no está instalado.
+        """
+        self.ensure_one()
+        if "sale_line_ids" not in self.env["account.move.line"]._fields:
+            return self.env["account.move"]
+        orders = self.invoice_line_ids.sale_line_ids.order_id
+        return orders.invoice_ids.filtered(
+            lambda m: (
+                m.move_type == "out_invoice" and m.state == "posted" and m.amount_untaxed == abs(self.amount_untaxed)
             )
-            # Solo queremos que se recomputen los impuestos en facturas de cliente/proveedor
-            for line in move.filtered(lambda x: not x.reversed_entry_id).invoice_line_ids:
-                to_unlink = line.tax_ids.filtered(lambda x: x.tax_group_id in fp_tax_groups)
-                if to_unlink._origin != new_taxes:
-                    line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+        )[:1]
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una factura porque puede ser que la factura venga de otro periodo

--- a/l10n_ar_tax/views/account_fiscal_position_view.xml
+++ b/l10n_ar_tax/views/account_fiscal_position_view.xml
@@ -6,6 +6,9 @@
         <field name="model">account.fiscal.position</field>
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='auto_apply']" position="after">
+                <field name="l10n_ar_require_related_invoice" invisible="'AR' not in fiscal_country_codes or not auto_apply"/>
+            </xpath>
             <xpath expr="//field[@name='company_id'][@groups='base.group_multi_company']" position="before">
                 <field
                     name="l10n_ar_tax_type"


### PR DESCRIPTION
Forward-port a 19.0 de #1384 (18.0).

## Qué hace

Agrega el campo `l10n_ar_require_related_invoice` ("Solo aplica en NC con devolución total (AR)") en `account.fiscal.position`. Cuando está activo, las percepciones de esa posición fiscal en notas de crédito solo se aplican si es una devolución total (mismo importe sin impuestos) en el mismo mes que la factura relacionada. Evita aplicar percepciones en NC manuales que no corresponden a una reversión.

## Cambios

- `account_fiscal_position.py`: nuevo campo booleano `l10n_ar_require_related_invoice`.
- `account_move.py`:
  - `write`: para moves AR con posición fiscal `l10n_ar_require_related_invoice` (o cambio de `invoice_date`), dispara el recompute de percepciones. Se hace en `write` y no en `create` porque al momento del `create` todavía no se computaron todos los campos del `account.move` (líneas, importes, etc.), por lo que `_l10n_ar_recompute_fiscal_position_taxes` no se ejecutaría correctamente.
  - `_l10n_ar_recompute_fiscal_position_taxes`: en `out_refund` con `l10n_ar_require_related_invoice`, aplica percepciones solo si la NC es devolución total (mismo mes + mismo importe sin impuestos) contra la factura relacionada (`_found_related_invoice`); si existe factura vinculada por la orden de venta con igual importe sin impuestos, también las calcula; si no cumple, elimina las percepciones de las líneas.
  - `_l10n_ar_so_invoice_same_untaxed`: helper que busca facturas posteadas vinculadas a la misma orden de venta con igual importe sin impuestos.
- `account_fiscal_position_view.xml`: expone el campo (visible solo para AR con `auto_apply`).
- `README.md`: documenta la funcionalidad.
- `i18n/es.po` + `i18n/l10n_ar_tax.pot`: traducción al español del nuevo campo y su ayuda, y actualización del POT del módulo.

## Test plan

- Posición fiscal AR con percepciones y `l10n_ar_require_related_invoice = True`.
- NC creada como reversión total de una factura del mismo mes → mantiene percepciones.
- NC manual sin factura relacionada / importe distinto → no aplica percepciones.
- Factura de cliente normal → percepciones se calculan como siempre.

Tarea Adhoc: 57361