### PR TITLE
[IMP] l10n_ar_tax: cache supplier payment receipt PDF (attachment_use)

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -321,6 +321,26 @@ class AccountPayment(models.Model):
 
         return super().action_post()
 
+    def action_draft(self):
+        # The supplier payment receipt PDF is cached (attachment_use on
+        # account.report_payment_receipt). Resetting to draft means the payment
+        # may be edited (amounts, withholdings, reconciliation) and reposted
+        # under the same name, which would otherwise serve the stale cached PDF.
+        # Drop the cached receipt so it is regenerated on the next render.
+        self._unlink_cached_payment_receipt()
+        return super().action_draft()
+
+    def _unlink_cached_payment_receipt(self):
+        report = self.env.ref("account.action_report_payment_receipt", raise_if_not_found=False)
+        if not report:
+            return
+        for payment in self:
+            # retrieve_attachment evalúa la misma expresión `attachment` del
+            # reporte (devuelve None si no corresponde cachear, p.ej. clientes).
+            attachment = report.retrieve_attachment(payment)
+            if attachment:
+                attachment.unlink()
+
     @api.model
     def _get_trigger_fields_to_synchronize(self):
         res = super()._get_trigger_fields_to_synchronize()

--- a/l10n_ar_tax/views/report_payment_receipt_templates.xml
+++ b/l10n_ar_tax/views/report_payment_receipt_templates.xml
@@ -315,4 +315,16 @@
         <field name="binding_type">report</field>
         <field name="binding_view_types">list</field>
     </record>
+
+    <!-- Cache the rendered receipt PDF (attachment_use) only for supplier
+         payments, whose receipt is immutable once the payment is processed.
+         Customer receipts embed a "pending vouchers as of today()" table
+         (report_payment_receipt_document > open_table, gated by
+         l10n_ar_ux.group_include_pending_receivable_documents), so caching
+         them would freeze that section: the attachment expression returns
+         False for customers, disabling the cache for them. -->
+    <record id="account.action_report_payment_receipt" model="ir.actions.report">
+        <field name="attachment_use" eval="True"/>
+        <field name="attachment">(object.partner_type == 'supplier' and object.state in ('in_process', 'paid')) and ((object.name or 'recibo').replace('/', '_') + '.pdf') or False</field>
+    </record>
 </odoo>


### PR DESCRIPTION
## Qué hace (resumen para PO / funcional)

Al enviar o imprimir el **recibo de pago**, el sistema rearmaba el PDF
desde cero **cada vez** (es un reporte pesado en AR: bundle, retenciones,
cheques, comprobantes imputados). Cuando varios usuarios de tesorería
emiten pagos en simultáneo, eso satura los procesos y enlentece todo.

Este cambio hace que el recibo de **pagos a proveedor** se **guarde una
vez y se reutilice** (el recibo de una OP ya procesada no cambia). Los
recibos de **clientes NO se cachean a propósito**, porque incluyen la
tabla *"Comprobantes pendientes al \<fecha de hoy\>"*, que tiene que
seguir mostrando datos actuales en cada emisión.

**Y si la OP se corrige después:** al reusar el PDF guardado, si se
editara el pago el recibo quedaría desactualizado. Por eso, cuando la OP
se **pasa a borrador** (paso obligado para editar importes/retenciones),
se **borra el PDF cacheado** → al reconfirmar y re-emitir, se regenera
con los datos nuevos.

**Qué verificar (PO):**
- Recibo de **proveedor**: que el PDF salga igual que antes.
- **Corrección de una OP**: pasar a borrador, cambiar importes,
  reconfirmar y re-emitir → el recibo debe mostrar los **datos nuevos**
  (no el PDF viejo).
- Recibo de **cliente**: que la tabla de "Comprobantes pendientes" siga
  mostrando la fecha/datos actuales en cada emisión (no congelada).

## Detalle técnico (devs)

El reporte `account.report_payment_receipt` tenía `attachment_use=False`,
así que se re-renderizaba siempre. Se habilita `attachment_use=True` y se
define una expresión de `attachment` que devuelve un nombre de archivo
**solo** para pagos de proveedor en estado `in_process`/`paid`; para
clientes devuelve `False`, deshabilitando el cache (por el `today()` del
`open_table`, gateado por
`l10n_ar_ux.group_include_pending_receivable_documents`).

Como `attachment_use` cachea por **nombre** (no compara contenido),
`action_draft` borra el adjunto cacheado del recibo (mismo criterio de la
expresión) para evitar servir un PDF viejo tras editar y reconfirmar la OP.

Tanto el preview del composer como el envío pasan por `_render_qweb_pdf`
(attachment-aware), así que la OP se renderiza **una vez por envío en
lugar de dos**, y los re-envíos / re-impresiones reutilizan el PDF guardado.

## Cómo se validó

Renderizando el recibo dos veces sobre el mismo pago y contando queries SQL:

| recibo | render 1 | render 2 (re-render) |
|---|---|---|
| proveedor | 130 queries | **7 queries** (reutiliza el PDF cacheado; además saltea wkhtmltopdf) |
| cliente | 66 queries | 64 queries (re-renderiza — cache deshabilitado, correcto) |

Emparejado con ingadhoc/account-payment#1122 (N+1 en
`_compute_matched_move_line_ids`); mismo nombre de branch para un único
build de runbot.