### PR TITLE
[FIX] l10n_ar_purchase: show expected arrival date per line on purchase order report

### DIFF
--- a/l10n_ar_purchase/__manifest__.py
+++ b/l10n_ar_purchase/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinean Purchase",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_purchase/i18n/es.po
+++ b/l10n_ar_purchase/i18n/es.po
@@ -44,6 +44,11 @@ msgstr "% IVA"
 
 #. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
+msgid "<strong>Expected Arrival</strong>"
+msgstr "<strong>Entrega esperada</strong>"
+
+#. module: l10n_ar_purchase
+#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchasequotation_document
 msgid "<strong>Purchase Representative:</strong>"
 msgstr "<strong>Comprador:</strong>"

--- a/l10n_ar_purchase/i18n/l10n_ar_purchase.pot
+++ b/l10n_ar_purchase/i18n/l10n_ar_purchase.pot
@@ -39,6 +39,11 @@ msgstr ""
 
 #. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
+msgid "<strong>Expected Arrival</strong>"
+msgstr ""
+
+#. module: l10n_ar_purchase
+#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchasequotation_document
 msgid "<strong>Purchase Representative:</strong>"
 msgstr ""

--- a/l10n_ar_purchase/views/purchase_report_templates.xml
+++ b/l10n_ar_purchase/views/purchase_report_templates.xml
@@ -203,6 +203,22 @@
             </div>
         </div>
 
+        <!-- Re-add the expected arrival date per order line.
+             In v16 the AR purchase order report showed the expected arrival
+             ("Llegada prevista") per product line. In v18 the confirmed purchase
+             order report (both native and AR) dropped it, and the data
+             (purchase.order.line.date_planned) is only printed on the RFQ /
+             quotation report. We re-add it as a column on the AR purchase order
+             report so suppliers receive the expected delivery date per product. -->
+        <xpath expr="//th[@name='th_description']" position="after">
+            <th name="th_date_planned" class="text-center"><strong>Expected Arrival</strong></th>
+        </xpath>
+        <xpath expr="//td[@id='product']" position="after">
+            <td class="text-center">
+                <span t-field="line.date_planned" t-options="{'date_only': 'true'}"/>
+            </td>
+        </xpath>
+
     </template>
 
 </odoo>


### PR DESCRIPTION
## What

The Argentinean purchase order PDF (`l10n_ar_purchase.report_purchaseorder_document`) no longer prints the **expected arrival date** of each order line on confirmed purchase orders.

## Why

For AR companies, `l10n_ar_purchase` fully replaces the native purchase report sections (via `_get_name_purchase_report`). When the AR template rebuilds the `informations` block it drops the native header "Expected Arrival" field, and the **confirmed Purchase Order** report in v18 has no per-line date at all. The per-line `order_line.date_planned` only survives on the native **RFQ / quotation** report — which is why the date is visible while the order is a draft but disappears once it is confirmed and printed as a Purchase Order.

In 16.0 the AR purchase order report did show the expected arrival per line; it was lost in the v18 report rewrite.

## What changed

`l10n_ar_purchase.report_purchaseorder_document`:
- Add an **Expected Arrival** column (header + per-line cell) rendering `line.date_planned` (date only) right after the description column, mirroring the pre-v18 layout and the native RFQ report.
- Add the `es` translation ("Entrega esperada") to `i18n/es.po` and the term to the `.pot`.
- Bump module version to `18.0.1.2.0` — a data/view change needs the bump to reload on deployed databases. Use `nobump` at merge.

## Test plan
- On an AR company, open a purchase order with several lines having different *Expected Arrival* (`date_planned`) values.
- Confirm the order and print the **Purchase Order** PDF → an **Entrega esperada** column shows each line's date.
- Print the **RFQ** (draft) → per-line date still shown (unchanged).

Related (translation fix on the same report, already merged): #1482
Adhoc helpdesk ticket: 121188
