### PR TITLE
[IMP] l10n_ar_tax: leer el padrón de AGIP (CABA) subido por el cliente

### DIFF
--- a/l10n_ar_tax/README.md
+++ b/l10n_ar_tax/README.md
@@ -11,7 +11,7 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 - Fiscal position-based tax automation.
 - Withholding certificate generation.
 - Integration with ARCA web services.
-- ARBA and Santa Fe (PARP) padron importers.
+- ARBA, Santa Fe (PARP) and AGIP (CABA) padron readers.
 - Same-period base accumulation for taxes like Ganancias with minimum thresholds.
 - Integration with `account_payment_pro` tri-currency model.
 
@@ -31,7 +31,7 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 2. **Fiscal positions:** Accounting → Configuration → Fiscal Positions — set up automatic tax assignment. In a multi-company setup with branches, a fiscal position of a branch can use the tax groups and taxes of its parent company (same behaviour as standard Odoo account mapping), so the chart of taxes only needs to be configured once on the parent.
 3. **Partner tax ID:** in Contacts, configure CUIT/CUIL/DNI.
 4. **Tax ratios:** set ratios (1–100) on percentage-based taxes to control the taxable base percentage.
-5. **Padron importers:** for Santa Fe (PARP) and ARBA, configure the corresponding fiscal position with the web service setting. See `doc/padron_santa_fe/` for specs and examples.
+5. **Padron files:** for Santa Fe (PARP), ARBA and AGIP (CABA), configure the corresponding fiscal position with the web service setting and upload the padron file in Accounting → Configuration → Padron Alicuotas. The aliquot is read from the uploaded file on demand (AGIP accepts the `.rar` published by AGIP, or a `.zip`; reading `.rar` requires the `unrar` python library). See `doc/padron_santa_fe/` for specs and examples.
 
 ## Usage
 

--- a/l10n_ar_tax/demo/account_fiscal_position_demo.xml
+++ b/l10n_ar_tax/demo/account_fiscal_position_demo.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- Las posiciones fiscales de CABA consultan el padrón, y para eso el impuesto necesita
+         tener la jurisdicción. El chart template la asigna en el post_init_hook, que corre
+         después de la data demo, así que la ponemos acá antes de usar esos impuestos. -->
+    <function model="account.tax" name="write" context="{'active_test': False}">
+        <value eval="[
+            ref('account.%s_%s' % (ref('base.company_ri'), 'ri_tax_percepcion_iibb_caba_aplicada')),
+            ref('account.%s_%s' % (ref('base.company_ri'), 'ex_tax_withholding_iibb_caba_applied')),
+        ]"/>
+        <value eval="{'l10n_ar_state_id': ref('base.state_ar_c')}"/>
+    </function>
+
     <!-- Perc. Córdoba + CABA -->
     <record id="fiscal_position_caba_cordoba_perc" model="account.fiscal.position">
         <field name="name">Percepciones Córdoba + CABA</field>
@@ -16,13 +27,13 @@
         <field name="fiscal_position_id" ref="fiscal_position_caba_cordoba_perc"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ri_tax_percepcion_iibb_caba_aplicada'))"/>
         <field name="tax_type">perception</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">padron</field>
     </record>
     <record id="fiscal_position_caba_cordoba_perc_line_cordoba" model="account.fiscal.position.l10n_ar_tax">
         <field name="fiscal_position_id" ref="fiscal_position_caba_cordoba_perc"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ri_tax_percepcion_iibb_co_aplicada'))"/>
         <field name="tax_type">perception</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">rentas_cordoba</field>
     </record>
 
     <!-- Perc. CABA -->
@@ -40,7 +51,7 @@
         <field name="fiscal_position_id" ref="fiscal_position_caba"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ri_tax_percepcion_iibb_caba_aplicada'))"/>
         <field name="tax_type">perception</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">padron</field>
     </record>
 
     <!-- Córdoba -->
@@ -82,7 +93,7 @@
         <field name="fiscal_position_id" ref="fiscal_position_cordoba_caba_and_proffits"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ex_tax_withholding_iibb_caba_applied'))"/>
         <field name="tax_type">withholding</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">padron</field>
     </record>
     <record id="fiscal_position_cordoba_caba_and_proffits_prof_withholding" model="account.fiscal.position.l10n_ar_tax">
         <field name="fiscal_position_id" ref="fiscal_position_cordoba_caba_and_proffits"/>
@@ -105,7 +116,7 @@
         <field name="fiscal_position_id" ref="fiscal_position_caba_and_proffits"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ex_tax_withholding_iibb_caba_applied'))"/>
         <field name="tax_type">withholding</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">padron</field>
     </record>
     <record id="fiscal_position_caba_and_proffits_prof_withholding" model="account.fiscal.position.l10n_ar_tax">
         <field name="fiscal_position_id" ref="fiscal_position_caba_and_proffits"/>

--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -457,6 +457,12 @@ msgid "AGIP (Regimen General)"
 msgstr "AGIP (Régimen General)"
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "AGIP padron aliquot (imported file)"
+msgstr "Alícuota padrón AGIP (archivo importado)"
+
+#. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
 msgid "API"
 msgstr ""
@@ -803,6 +809,12 @@ msgstr "Impuesto por Defecto"
 
 #. module: l10n_ar_tax
 #. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "Default aliquot. Not found in AGIP padron"
+msgstr "Alícuota por defecto. No figura en padrón AGIP"
+
+#. module: l10n_ar_tax
+#. odoo-python
 #: code:addons/l10n_ar_tax/models/res_company.py:0
 msgid "Detail: %s"
 msgstr "Detalle: %s"
@@ -1122,6 +1134,12 @@ msgid "Only compressed ZIP files are allowed for Santa Fe."
 msgstr "Solo se permiten archivos ZIP comprimidos para Santa Fe."
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "Only compressed ZIP or RAR files are allowed for AGIP (CABA)."
+msgstr "Solo se permiten archivos ZIP o RAR comprimidos para AGIP (CABA)."
+
+#. module: l10n_ar_tax
 #: model:ir.actions.act_window,name:l10n_ar_tax.act_company_jurisdiction_padron
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_tree
@@ -1381,6 +1399,30 @@ msgid "Taxes"
 msgstr ""
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid ""
+"The aliquot padron could not be read: looking up CUIT %s took too long. "
+"Please try again in a few minutes or enter the tax rate manually on the "
+"contact."
+msgstr ""
+"No se pudo leer el padrón de alícuotas: la búsqueda del CUIT %s tardó "
+"demasiado. Vuelva a intentar en unos minutos o cargue la alícuota "
+"manualmente en el contacto."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "The compressed file does not contain the padron in CSV or TXT format."
+msgstr "El archivo comprimido no contiene el padrón en formato CSV o TXT."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "The padron for %s is not implemented."
+msgstr "El padrón para %s no está implementado."
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_state_code
 msgid "The state code."
 msgstr "El código del estado."
@@ -1392,6 +1434,22 @@ msgid ""
 "The total percentage (%s) should be greater than 0 and less than or equal to "
 "100."
 msgstr "El porcentaje total (%s) debe ser mayor que 0 y menor o igual que 100."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "There was an error while getting the aliquot from the padron."
+msgstr "Hubo un error al momento de obtener la alícuota del padrón"
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid ""
+"This database cannot read RAR files (the 'unrar' library is not "
+"installed). Please upload the AGIP padron as a ZIP file instead."
+msgstr ""
+"Esta base de datos no puede leer archivos RAR (la librería 'unrar' no está "
+"instalada). Suba el padrón de AGIP como archivo ZIP."
 
 #. module: l10n_ar_tax
 #. odoo-python

--- a/l10n_ar_tax/migrations/19.0.1.28.0/pre-migration.py
+++ b/l10n_ar_tax/migrations/19.0.1.28.0/pre-migration.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Sacamos la opción 'agip' del campo webservice: CABA pasa a resolverse por 'padron',
+    que lee el padrón subido en la base y, si no está, consulta el que Adhoc baja y procesa
+    en la suya."""
+    cr.execute("UPDATE account_fiscal_position_l10n_ar_tax SET webservice = 'padron' WHERE webservice = 'agip'")
+    logger.info("Posiciones fiscales que pasaron de webservice 'agip' a 'padron': %s", cr.rowcount)

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -20,7 +20,6 @@ class AccountFiscalPositionL10nArTax(models.Model):
     # pero que no esta seleccionado
     webservice = fields.Selection(
         [
-            ("agip", "AGIP (Regimen General)"),
             ("arba", "ARBA"),
             ("rentas_cordoba", "Rentas Cordoba"),
             ("padron", "Archivo de padrón"),
@@ -80,7 +79,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
                     raise ValidationError(
                         "Impuesto %s sin provincia establecida, no puede consultar padrón" % record.default_tax_id.name
                     )
-                if record.default_tax_id.l10n_ar_state_id.jurisdiction_code not in ["902", "921"]:
+                if record.default_tax_id.l10n_ar_state_id.jurisdiction_code not in ["901", "902", "921"]:
                     raise ValidationError(
                         "Padrón no implementado para la provincia de %s." % record.default_tax_id.l10n_ar_state_id.name
                     )
@@ -151,7 +150,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
         """Returns the webservice selection value for a given state (res.country.state).
         Override in downstream modules to add support for additional jurisdictions."""
         mapping = {
-            "901": "agip",  # CABA
+            "901": "padron",  # CABA
             "902": "arba",  # Buenos Aires provincia
             "904": "rentas_cordoba",  # Córdoba
             "921": "padron",  # Santa Fe
@@ -325,10 +324,31 @@ class AccountFiscalPositionL10nArTax(models.Model):
         return res
 
     def _get_agip_data(self, partner, date, to_date):
+        """Metodo que obtiene la alicuota de AGIP (CABA) del padron que Adhoc baja y procesa
+        en su propia base
+
+        :return: (float, string) alícuota y referencia
+
+        Se llama solo cuando el cliente no cargó el padron de AGIP en su base (ver
+        _get_padron_data). En las bases SaaS de Adhoc, saas_client_l10n_ar extiende este
+        método para consultar ese padron; sin esa integración no tenemos de dónde sacar la
+        alícuota y pedimos que carguen el padron.
+        """
+        self.ensure_one()
+
         # si es base en data demo devolvemos una alicuota demo para que no falle la demo data
         if self.env.ref("base.user_demo", raise_if_not_found=False):
             return (2.5 if self.tax_type == "withholding" else 3.0, "VALOR DUMMY | dummy")
-        raise UserError(_("Missing ADHOC credential configuration for AGIP tax rate queries"))
+
+        raise self._no_padron_uploaded_error(date, to_date)
+
+    def _no_padron_uploaded_error(self, date, to_date):
+        return UserError(
+            _(
+                "No padron uploaded for the indicated date %s to %s. You must upload it in 'Accounting / Configuration / AFIP / Tax Rate Padron by Company' or manually enter the tax rate on the contact for the current period."
+            )
+            % (date, to_date)
+        )
 
     def _get_arba_data(self, partner, date, to_date):
         """Metodo que obtiene la alicuota de ARBA de un partner y fecha dado
@@ -458,8 +478,8 @@ class AccountFiscalPositionL10nArTax(models.Model):
         return aliquot, ref
 
     def _get_padron_data(self, partner, date, to_date):
-        """Método implementado para obtener alícuota de padrón ARBA y Santa Fe:
-        jurisdiction_code de Santa Fe = 921, de ARBA = 902
+        """Método implementado para obtener alícuota de padrón ARBA, Santa Fe y AGIP:
+        jurisdiction_code de Santa Fe = 921, de ARBA = 902, de AGIP (CABA) = 901
         1) Santa Fe:
          * si no existe padrón para el período correspondiente entonces devuelve UserError para que lo cargue.
          * si existe padrón para el período correspondiente, busca el CUIT en el padrón y:
@@ -470,25 +490,45 @@ class AccountFiscalPositionL10nArTax(models.Model):
          * si existe padrón para el período correspondiente, busca el CUIT en el padrón y:
             a) si lo encuentra devuelve la tasa y "Alícuota padrón ARBA (archivo importado)",
             b) si no lo encuentra devuelve None, "Alícuota no inscripto ARBA (archivo importado)"
+        3) AGIP (CABA): el padrón de Regímenes Generales viene en un único archivo, con
+           las mismas columnas que el PARP de Santa Fe, por eso se lee igual (nro viene
+           True/False y las alícuotas como float):
+         * si no existe padrón para el período, la alícuota sale del padrón que Adhoc baja
+           y procesa en su propia base (_get_agip_data). El error para que carguen el
+           padrón queda para cuando allá tampoco esté.
+         * si existe padrón para el período correspondiente, busca el CUIT en el padrón y:
+            a) si lo encuentra devuelve la tasa y "Alícuota padrón AGIP (archivo importado)",
+            b) si no lo encuentra devuelve None, "Alícuota por defecto. No figura en padrón AGIP"
 
         return: alicuot, ref
         """
         self.ensure_one()
         if self.env.ref("base.user_demo", raise_if_not_found=False):
-            return (2.5 / 3.0, "VALOR DUMMY | dummy")
+            return (2.5 if self.tax_type == "withholding" else 3.0, "VALOR DUMMY | dummy")
         state = self.default_tax_id.l10n_ar_state_id
         padron_file = self._search_padron_file(state, date)
         if not padron_file:
-            # si la consulta de padron viene por "contingencia" (por ej. se usa ws de arba o agip) y no hay padron, no queremos raise
+            if state.jurisdiction_code == "901":
+                # AGIP: si el cliente no cargó el padron en su base, la alícuota sale del
+                # padron que Adhoc baja y procesa en la suya (lo resuelve saas_client_l10n_ar
+                # extendiendo _get_agip_data).
+                # Validamos el cuit acá para que un partner sin cuit de su propio error y no
+                # el de "cargá el padron".
+                partner.ensure_vat()
+                try:
+                    return self._get_agip_data(partner, date, to_date)
+                except UserError as error:
+                    # Error de negocio: el padron no está cargado en la base de Adhoc (o
+                    # Adhoc no lo pudo devolver). Pedimos que lo carguen y dejamos el
+                    # detalle en el log.
+                    _logger.info("No pudimos obtener el padron de AGIP desde Adhoc: %s", error)
+                    raise self._no_padron_uploaded_error(date, to_date) from error
+                except Exception as error:
+                    raise UserError(_("There was an error while getting the aliquot from the padron.")) from error
             if self.webservice != "padron":
                 return None, None
             # Si se está consultando alícuota con tipo "padron" y no hay, entonces damos error.
-            raise UserError(
-                _(
-                    "No padron uploaded for the indicated date %s to %s. You must upload it in 'Accounting / Configuration / AFIP / Tax Rate Padron by Company' or manually enter the tax rate on the contact for the current period."
-                )
-                % (date, to_date)
-            )
+            raise self._no_padron_uploaded_error(date, to_date)
         nro, alicuot_ret, alicuot_per = padron_file._get_aliquot(partner)
         if state.jurisdiction_code == "921":
             if nro:
@@ -499,6 +539,16 @@ class AccountFiscalPositionL10nArTax(models.Model):
                 )
             else:
                 return None, _("Penalty aliquot. Not found in Santa Fe padron")
+        if state.jurisdiction_code == "901":
+            if nro:
+                # el padrón de AGIP tiene el mismo layout que el de Santa Fe: no hay nro,
+                # viene True/False (según si lo encontramos) y las alícuotas ya son float
+                return (
+                    alicuot_ret if self.tax_type == "withholding" else alicuot_per,
+                    _("AGIP padron aliquot (imported file)"),
+                )
+            else:
+                return None, _("Default aliquot. Not found in AGIP padron")
         if state.jurisdiction_code == "902":
             if nro:
                 return (

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -1,18 +1,20 @@
 import base64
-import io
 import logging
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import zipfile
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
 GREP_TIMEOUT = 30
+# Magic bytes de un ZIP: archivo con contenido, vacio y multi-volumen.
+ZIP_MAGIC_BYTES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 
 
 class ResCompanyJurisdictionPadron(models.Model):
@@ -43,8 +45,8 @@ class ResCompanyJurisdictionPadron(models.Model):
     @api.constrains("state_id")
     def check_state_id(self):
         for rec in self:
-            if rec.state_id.jurisdiction_code not in ["902", "921"]:
-                raise ValidationError("El padron para (%s) no está implementado." % rec.state_id.name)
+            if rec.state_id.jurisdiction_code not in ["901", "902", "921"]:
+                raise ValidationError(_("The padron for %s is not implemented.") % rec.state_id.name)
 
     @api.constrains("state_id", "file_padron")
     def _check_santa_fe_file_padron_format(self):
@@ -57,6 +59,27 @@ class ResCompanyJurisdictionPadron(models.Model):
             if not rec._has_zip_filename() or not rec._is_zip_content(file_content):
                 raise ValidationError(_("Only compressed ZIP files are allowed for Santa Fe."))
 
+    @api.constrains("state_id", "file_padron")
+    def _check_agip_file_padron_format(self):
+        """Validar que para AGIP (CABA) solo se permiten archivos comprimidos: RAR
+        tal como lo publica AGIP, o ZIP si se re-comprime."""
+        for rec in self:
+            if not rec._is_agip_jurisdiction() or not rec.file_padron:
+                continue
+
+            file_content = base64.b64decode(rec.file_padron)
+            if not rec._has_compressed_filename() or not rec._is_compressed_content(file_content):
+                raise ValidationError(_("Only compressed ZIP or RAR files are allowed for AGIP (CABA)."))
+            # Validamos acá y no al liquidar: si falta la lib de rar queremos que se
+            # entere quien sube el archivo, no quien emite el comprobante.
+            if rec._is_rar_content(file_content) and not rec._rar_support_available():
+                raise ValidationError(
+                    _(
+                        "This database cannot read RAR files (the 'unrar' library is not installed). "
+                        "Please upload the AGIP padron as a ZIP file instead."
+                    )
+                )
+
     @api.depends("company_id", "state_id")
     def name_get(self):
         res = []
@@ -66,20 +89,26 @@ class ResCompanyJurisdictionPadron(models.Model):
         return res
 
     def descompress_file(self, file_padron, dest_dir="/tmp"):
-        _logger.log(25, "Descompress zip file")
-        try:
-            file = base64.b64decode(file_padron)
-        except:
-            file = base64.decodestring(file_padron)
+        """Extrae el padrón comprimido en dest_dir. Soporta ZIP (ARBA, Santa Fe) y
+        RAR (AGIP publica el padrón de Regímenes Generales en .rar)."""
+        file = base64.b64decode(file_padron)
         fobj = tempfile.NamedTemporaryFile(delete=False)
         fname = fobj.name
         fobj.write(file)
         fobj.close()
-        f = open(fname, "r+b")
-        f.write(base64.b64decode(file_padron))
-        with zipfile.ZipFile(f, "r") as zip_file:
-            zip_file.extractall(path=dest_dir)
-            zip_file.close()
+        os.makedirs(dest_dir, exist_ok=True)
+        if self._is_rar_content(file):
+            _logger.log(25, "Descompress rar file")
+            # Import lazy: no declaramos unrar en external_dependencies para no
+            # romper instalaciones que no usan el padrón de AGIP. Que la lib esté
+            # disponible se valida al subir el archivo (_check_agip_file_padron_format).
+            from unrar import rarfile
+
+            rarfile.RarFile(fname).extractall(path=dest_dir)
+        else:
+            _logger.log(25, "Descompress zip file")
+            with zipfile.ZipFile(fname, "r") as zip_file:
+                zip_file.extractall(path=dest_dir)
 
     def find_aliquot(self, path, cuit):
         """We try to find aliqut and number for a partner given"""
@@ -102,21 +131,63 @@ class ResCompanyJurisdictionPadron(models.Model):
         self.ensure_one()
         return self.state_id and self.state_id.jurisdiction_code == "921"
 
+    def _is_agip_jurisdiction(self):
+        """Check if jurisdiction is CABA / AGIP (Regímenes Generales padron)"""
+        self.ensure_one()
+        return self.state_id and self.state_id.jurisdiction_code == "901"
+
+    def _is_single_file_padron(self):
+        """Jurisdicciones cuyo padrón viene en un único archivo con las dos alícuotas por
+        CUIT y las mismas columnas, así que se leen igual (ver _read_padron_lines): Santa Fe
+        (921, padrón PARP de API) y AGIP / CABA (901, Regímenes Generales). ARBA (902) no
+        entra acá: publica percepciones y retenciones en archivos separados."""
+        self.ensure_one()
+        return self._is_santa_fe_jurisdiction() or self._is_agip_jurisdiction()
+
     def _is_zip_content(self, file_content):
-        return zipfile.is_zipfile(io.BytesIO(file_content))
+        # Miramos los magic bytes en lugar de zipfile.is_zipfile(io.BytesIO(...)): el
+        # BytesIO duplica en memoria todo el contenido, y el padron de AGIP pesa >100 MB.
+        # Como efecto, alcanza con pasar los primeros bytes del archivo.
+        return file_content[:4] in ZIP_MAGIC_BYTES
+
+    def _is_rar_content(self, file_content):
+        # Magic bytes de RAR: "Rar!\x1a\x07" (común a v4 y v5).
+        return file_content.startswith(b"Rar!\x1a\x07")
+
+    def _rar_support_available(self):
+        """La lib unrar no está en external_dependencies (no queremos condicionar la
+        instalación del módulo a un padrón puntual), así que chequeamos en runtime."""
+        try:
+            from unrar import rarfile  # noqa: F401
+
+            return True
+        except Exception:
+            return False
+
+    def _is_compressed_content(self, file_content):
+        return self._is_zip_content(file_content) or self._is_rar_content(file_content)
 
     def _has_zip_filename(self):
         self.ensure_one()
         return bool(self.filename and self.filename.lower().endswith(".zip"))
 
-    def _read_parp_lines(self, lines, cuit):
+    def _has_compressed_filename(self):
+        self.ensure_one()
+        return bool(self.filename and self.filename.lower().endswith((".zip", ".rar")))
+
+    def _read_padron_lines(self, lines, cuit):
+        """Layout del padrón de archivo único, compartido por Santa Fe (PARP) y AGIP:
+        F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
+        Returns: (is_in_padron, aliquot_ret, aliquot_per)
+        """
         aliquot_ret = False
         aliquot_per = False
         is_in_padron = False
         for line in lines:
             if not line:
                 continue
-            values = [value.strip() for value in line.split(";")]
+            # Algunos padrones (AGIP) traen bytes nulos y BOM en la primera columna.
+            values = [value.replace("\0", "").strip() for value in line.split(";")]
             if len(values) <= 8:
                 continue
             # CUIT is at index 3, compare as strings
@@ -129,8 +200,38 @@ class ResCompanyJurisdictionPadron(models.Model):
                 break
         return is_in_padron, aliquot_ret, aliquot_per
 
-    def _find_parp_file(self, rootdir):
+    def _find_padron_aliquot(self, path, cuit):
+        """Busca el CUIT en un padrón de archivo único (ver _is_single_file_padron) y
+        devuelve (is_in_padron, aliquot_ret, aliquot_per).
+
+        Filtra los candidatos con grep -F (en C) porque el padrón de AGIP tiene del
+        orden de 1.5M de líneas; la comparación exacta por columna la hace
+        _read_padron_lines para descartar falsos positivos (CUIT como substring de otro
+        campo). Si grep timeoutea damos error en lugar de devolver una alícuota de castigo
+        por no haber podido leer el padrón.
+        """
+        try:
+            result = subprocess.run(
+                # -a: los padrones pueden traer bytes nulos y grep los trataría como binarios
+                ["grep", "-a", "-F", cuit, path],
+                capture_output=True,
+                encoding="latin-1",
+                timeout=GREP_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            _logger.warning("Padrón: la búsqueda del cuit %s en %s superó el timeout.", cuit, path)
+            raise UserError(
+                _(
+                    "The aliquot padron could not be read: looking up CUIT %s took too long. Please try "
+                    "again in a few minutes or enter the tax rate manually on the contact."
+                )
+                % cuit
+            )
+        return self._read_padron_lines(result.stdout.splitlines(), cuit)
+
+    def _find_padron_file(self, rootdir):
         fallback_match = False
+        any_file_match = False
         for subdir, dirs, files in os.walk(rootdir):
             for filename in files:
                 lower_filename = filename.lower()
@@ -139,9 +240,12 @@ class ResCompanyJurisdictionPadron(models.Model):
                         return os.path.join(subdir, filename)
                     if not fallback_match:
                         fallback_match = os.path.join(subdir, filename)
-        return fallback_match
+                elif not any_file_match:
+                    # El padrón de AGIP viene con nombre y extensión variables dentro del .rar
+                    any_file_match = os.path.join(subdir, filename)
+        return fallback_match or any_file_match
 
-    def _get_parp_tmp_dir(self):
+    def _get_padron_tmp_dir(self):
         # Dir por padron+periodo: no mezcla archivos de otro mes.
         self.ensure_one()
         return "/tmp/l10n_ar_padron_%s_%s_%s" % (
@@ -150,38 +254,47 @@ class ResCompanyJurisdictionPadron(models.Model):
             self.l10n_ar_padron_to_date,
         )
 
-    def _ensure_parp_file_extracted(self):
-        # Extrae/persiste una sola vez y reutiliza (antes se re-decodificaba/re-unzipeaba por CUIT).
+    def _ensure_padron_file_extracted(self):
+        """Descomprime el padrón una sola vez y lo deja en el directorio temporal del
+        período: de ahí en más todas las búsquedas usan ese archivo, hasta que se reinicie
+        el pod (igual que el padrón de Santa Fe).
+
+        La descompresión va a un directorio staging que ninguna búsqueda mira y recién al
+        terminar se publica moviéndolo con os.rename, que es atómico. Por eso ningún worker
+        puede encontrar el archivo antes de que esté completamente descomprimido: o el
+        directorio del período no existe, o tiene la extracción completa.
+        """
         self.ensure_one()
-        tmp_dir = self._get_parp_tmp_dir()
-        path_file = self._find_parp_file(tmp_dir)
+        tmp_dir = self._get_padron_tmp_dir()
+        path_file = self._find_padron_file(tmp_dir)
         if path_file:
             return path_file
 
-        file_content = base64.b64decode(self.file_padron)
-        if self._is_zip_content(file_content):
-            self.descompress_file(self.file_padron, dest_dir=tmp_dir)
-            path_file = self._find_parp_file(tmp_dir)
+        # Sniff de los primeros bytes: alcanza para saber si viene comprimido y evita
+        # decodificar 100 MB de base64 (padron de AGIP) solo para chequear el formato.
+        if self._is_compressed_content(base64.b64decode(self.file_padron[:8])):
+            staging_dir = tempfile.mkdtemp(prefix="l10n_ar_padron.staging-", dir=os.path.dirname(tmp_dir))
+            try:
+                self.descompress_file(self.file_padron, dest_dir=staging_dir)
+                # rename no reemplaza un directorio con contenido, y acá sabemos que lo que
+                # haya en tmp_dir no sirve (no encontramos el padrón).
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                os.rename(staging_dir, tmp_dir)
+            except Exception:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                raise
+            path_file = self._find_padron_file(tmp_dir)
             if not path_file:
-                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+                raise ValidationError(_("The compressed file does not contain the padron in CSV or TXT format."))
             return path_file
 
-        # CSV directo (no ZIP): lo persistimos para no re-decodificar cada vez.
+        # CSV directo (no comprimido): lo persistimos para no re-decodificar cada vez.
+        file_content = base64.b64decode(self.file_padron)
         os.makedirs(tmp_dir, exist_ok=True)
         path_file = os.path.join(tmp_dir, "padron.csv")
         with open(path_file, "w", encoding="latin-1") as fp:
             fp.write(file_content.decode("latin-1"))
         return path_file
-
-    def _read_parp_from_binary(self, cuit):
-        """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
-        or from ZIP if the binary is a ZIP file.
-        PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (aliquot_ret, aliquot_per)
-        """
-        path_file = self._ensure_parp_file_extracted()
-        with open(path_file, encoding="latin-1") as fp:
-            return self._read_parp_lines(fp.readlines(), cuit)
 
     def find_file(self, rootdir, type_code):
         res = False
@@ -199,14 +312,12 @@ class ResCompanyJurisdictionPadron(models.Model):
         aliquot_ret = 0.0
         aliquot_per = 0.0
 
-        # Check if this is Santa Fe PARP format
-        if self._is_santa_fe_jurisdiction():
-            # Read PARP directly from binary field
-            is_in_padron, aliquot_ret, aliquot_per = self._read_parp_from_binary(partner.vat)
-            return is_in_padron, aliquot_ret, aliquot_per
+        # Check if the whole padron comes in a single file (Santa Fe, AGIP)
+        if self._is_single_file_padron():
+            return self._find_padron_aliquot(self._ensure_padron_file_extracted(), partner.vat)
         else:
             # Original logic for other padron types (ARBA, etc)
-            tmp_dir = self._get_parp_tmp_dir()
+            tmp_dir = self._get_padron_tmp_dir()
             padron_types = ["Per", "Ret"]
             for padron_type in padron_types:
                 path_file = self.find_file(tmp_dir, padron_type)

--- a/l10n_ar_tax/tests/test_padron_tmp_dir.py
+++ b/l10n_ar_tax/tests/test_padron_tmp_dir.py
@@ -47,7 +47,7 @@ class TestPadronTmpDir(common.TransactionCase):
                 "l10n_ar_padron_to_date": to_date,
             }
         )
-        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
         return padron
 
     def _create_santa_fe_padron(self, lines):
@@ -64,7 +64,7 @@ class TestPadronTmpDir(common.TransactionCase):
                 "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
             }
         )
-        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
         return padron
 
     def test_arba_different_months_do_not_share_extracted_files(self):

--- a/l10n_ar_tax/tests/test_payment_withholding_validation.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_validation.py
@@ -87,7 +87,7 @@ class TestPaymentWithholdingValidation(TestArWithholdingArRi):
                 "fiscal_position_id": fiscal_position_caba.id,
                 "default_tax_id": self.caba_tax_perception.id,
                 "tax_type": "perception",
-                "webservice": "agip",
+                "webservice": "padron",
             }
         )
 

--- a/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
+++ b/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
@@ -42,6 +42,8 @@
                             </li>
                             <li>Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API y que tiene nombre de forma "PARP_999999.zip"
                             </li>
+                            <li>AGIP (CABA): debe subir el archivo comprimido (rar o zip) del padrón de Regímenes Generales que descarga de la web de AGIP. La alícuota se lee del archivo cuando se necesita, no hace falta procesarlo.
+                            </li>
                         </ul>
                     </p>
                 </sheet>


### PR DESCRIPTION
## Qué hace

Habilita usar el **padrón de AGIP (CABA) subido por el cliente** como fuente de alícuotas de IIBB, para que una base cliente pueda liquidar aunque falle la conexión con la base de Adhoc.

El padrón de AGIP tiene las mismas columnas que el PARP de Santa Fe, así que CABA reusa ese lector en lugar de importar sus ~1.5M de líneas a una tabla: el archivo comprimido (`.rar` como lo publica AGIP, o `.zip`) se descomprime una vez al directorio temporal del período y el CUIT se busca ahí con `grep -F` cada vez que se necesita una alícuota.

## Orden de resolución

1. Padrón subido en la base del cliente → se usa ese archivo.
2. Sin padrón cargado → se consulta el padrón de la base de Adhoc (`saas_client_l10n_ar` extiende `_get_agip_data`).
3. En ninguna de las dos → se pide que lo carguen.

## Cambios

- **`res_company_jurisdiction_padron.py`**: CABA (901) entra por el mismo lector que Santa Fe; `descompress_file` soporta `.rar`; la descompresión va a un staging y se publica con `os.rename` (atómico), así nadie lee un padrón a medio descomprimir; constraint que exige archivo comprimido para AGIP y que la lib `unrar` esté disponible.
- **`account_fiscal_position_l10n_ar_tax.py`**: se saca la opción `agip` del campo Webservice (CABA usa "Archivo de padrón"); branch 901 en `_get_padron_data` con el fallback a Adhoc; `_get_agip_data` queda como el hook del padrón de Adhoc.
- **`migrations/19.0.1.28.0/pre-migration.py`**: pasa las líneas existentes de `agip` a `padron`.
- Demo, ayuda de la vista, README y traducciones al español.

## Notas de merge

- Trae migration script → mergear con **`bump`** (lleva la versión a `19.0.1.28.0`, que es el directorio del script).
- Leer `.rar` necesita la lib `unrar`, que no se declara en `external_dependencies`: si no está, el error salta al subir el archivo y el padrón se puede subir como `.zip`.
- Chequear que los impuestos de IIBB de CABA tengan la jurisdicción cargada: el constraint la exige para `padron` y `ex_tax_withholding_iibb_caba_applied` no la recibe del chart template.

## Test plan

- Cargar el padrón comprimido del período en "Contabilidad / Configuración / Padron Alicuotas" para CABA y verificar que un partner presente toma la alícuota del archivo y uno ausente la del impuesto por defecto.
- Verificar que se descomprime una sola vez (la segunda consulta no vuelve a descomprimir).
- Borrar el padrón y verificar que se consulta el de la base de Adhoc.
- Actualizar el módulo en una base con `agip` y verificar que las posiciones fiscales quedan en "Archivo de padrón".

Task: https://www.adhoc.inc/odoo/project.task/38027
