### PR TITLE
[FIX] l10n_ar_account_withholding: attach withholding certificate as .pdf

### DIFF
--- a/l10n_ar_account_withholding/models/mail_compose_message.py
+++ b/l10n_ar_account_withholding/models/mail_compose_message.py
@@ -22,11 +22,12 @@ class MailComposeMessage(models.TransientModel):
                 result, format = self.env['ir.actions.report']._render(report.report_name, payment.ids)
                 file = base64.b64encode(result)
                 data_attach = {
-                    'name': report_name,
+                    'name': "%s.%s" % (report_name, format),
                     'datas': file,
                     'res_model': 'mail.compose.message',
                     'res_id': 0,
                     'type': 'binary',
+                    'mimetype': 'application/pdf',
                 }
                 attachment_ids.append(self.env['ir.attachment'].create(data_attach).id)
             if values.get('value', False) and values['value'].get('attachment_ids', []) or attachment_ids:


### PR DESCRIPTION
## Problema

Al enviar el mail de pago a proveedor (plantilla "Pago de cliente/proveedor - Enviar por correo"), el certificado de retención adjunto llegaba con formato incorrecto y el destinatario no lo podía abrir/descargar. En el chatter del pago se visualizaba bien.

## Causa

En `l10n_ar_account_withholding/models/mail_compose_message.py`, el `ir.attachment` del certificado se creaba con `name = print_report_name`, y el `print_report_name` del reporte es `'Certificado de Retención Slip - %s'` — **sin extensión `.pdf`**.

- En el chatter se ve bien porque `ir.attachment._compute_mimetype` infiere `application/pdf` desde el contenido y Odoo lo sirve con ese Content-Type.
- Por mail, el nombre del adjunto MIME queda sin `.pdf`, así que el cliente de correo del destinatario no lo reconoce como PDF.

## Solución

Cambio mínimo en `_onchange_template_id`: el nombre del adjunto ahora lleva la extensión del formato del reporte (`.pdf`). Se agrega además `mimetype = 'application/pdf'` de forma defensiva (aunque ya se infería del contenido).

## Test plan

- Registrar un pago a proveedor con retención, enviar con la plantilla "Pago de cliente/proveedor - Enviar por correo" y verificar que el certificado adjunto se genera con nombre `...pdf` y `mimetype application/pdf`.
- Verificado en base de test con el PR aplicado replicando el flujo (`_onchange_template_id`) e inspeccionando el `ir.attachment` resultante. No requiere envío real (bloqueado en test): el fix es puramente sobre la extensión del adjunto.

Ref: ticket 121366.