### PR TITLE
[IMP] l10n_ar_tax: do not compute fiscal position on journal entries

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -24,6 +24,14 @@ class AccountMove(models.Model):
                 move.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
             )
 
+    @api.depends("partner_id", "partner_shipping_id", "company_id")
+    def _compute_fiscal_position_id(self):
+        """Skip the fiscal position on journal entries (move_type='entry', e.g. payments): it is not
+        used there and, when it carries perceptions, it only adds a misleading warning banner."""
+        entries = self.filtered(lambda move: move.move_type == "entry")
+        entries.fiscal_position_id = False
+        super(AccountMove, self - entries)._compute_fiscal_position_id()
+
     def _get_tax_factor(self):
         self.ensure_one()
         tax_factor = self.amount_total and (self.amount_untaxed / self.amount_total) or 1.0


### PR DESCRIPTION
## What

Journal entries (`move_type='entry'`, e.g. supplier payments with withholdings) auto-detect a fiscal position via the core `account.move._compute_fiscal_position_id`. On these entries the fiscal position is not used, and when it carries perceptions it triggers the `l10n_ar_tax` warning banner, leaving the entry cluttered.

This overrides `_compute_fiscal_position_id` in `l10n_ar_tax` to leave `fiscal_position_id` empty on `entry` moves, delegating the rest to `super()`. Since the banner visibility depends on `perceptions_fiscal_positon` (derived from the fiscal position), clearing the FP also removes the banner — one change covers both.

## Why it's safe

Withholding computation on payments uses the dedicated `account.payment.l10n_ar_fiscal_position_id` field, not the move's `fiscal_position_id`, so clearing it on entries does not affect withholdings. Odoo considers the core auto-detection expected behaviour (not a bug), hence the fix lives in `l10n_ar_tax`.

## Test plan

On an AR company with a fiscal position that has perception taxes, same partner:
- `entry` (payment journal entry) → `fiscal_position_id` empty, warning banner not shown.
- `in_invoice` / `out_invoice` → fiscal position kept (super path), banner unchanged.

Task: 70316