### PR TITLE
[FIX] l10n_ar_tax: recompute perceptions_fiscal_positon on fiscal position change

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -10,6 +10,11 @@ class AccountMove(models.Model):
         compute="_compute_perceptions_fiscal_position",
     )
 
+    @api.depends(
+        "fiscal_position_id",
+        "fiscal_position_id.l10n_ar_tax_ids",
+        "fiscal_position_id.l10n_ar_tax_ids.tax_type",
+    )
     def _compute_perceptions_fiscal_position(self):
         """
         Compute if the fiscal position has perceptions.
@@ -48,7 +53,10 @@ class AccountMove(models.Model):
         NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes
         """
         for move in self.filtered(
-            lambda x: x.is_sale_document(include_receipts=True) and x.perceptions_fiscal_positon and x.state == "draft"
+            lambda x: x.is_sale_document(include_receipts=True)
+            and x.fiscal_position_id
+            and x.perceptions_fiscal_positon
+            and x.state == "draft"
         ):
             fp_tax_groups = move.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"


### PR DESCRIPTION
perceptions_fiscal_positon was a computed field without @api.depends, so it kept a stale cached True after fiscal_position_id was recomputed to empty (e.g. changing the customer to one without a fiscal position). 

The onchange _l10n_ar_recompute_fiscal_position_taxes then called _l10n_ar_add_taxes on an empty fiscal position, raising 'Expected singleton: account.fiscal.position()'.

Add the missing @api.depends so the field is invalidated when the fiscal position or its perception taxes change, and guard the onchange filter with fiscal_position_id as an extra safety net