### PR TITLE
[FIX] l10n_ar_tax: set batch payment sequence in payment register test

### DIFF
--- a/l10n_ar_tax/tests/test_payment_register_pro_wizard.py
+++ b/l10n_ar_tax/tests/test_payment_register_pro_wizard.py
@@ -14,6 +14,24 @@ class TestPaymentRegisterProWizard(common.TransactionCase):
         cls.today = fields.Date.today()
         cls.company = cls.env.company
         cls.company.use_payment_pro = True
+        # Pre-existing companies lack batch_payment_sequence_id (the field default
+        # only fires on company create), so multi-partner batch communication
+        # crashes on next_by_id() over an empty sequence. Ensure it here.
+        if not cls.company.batch_payment_sequence_id:
+            cls.company.batch_payment_sequence_id = (
+                cls.env["ir.sequence"]
+                .sudo()
+                .create(
+                    {
+                        "name": "Group Payments Number Sequence",
+                        "implementation": "no_gap",
+                        "padding": 5,
+                        "use_date_range": True,
+                        "company_id": cls.company.id,
+                        "prefix": "GROUP/%(year)s/",
+                    }
+                )
+            )
         cls.company_journal = cls.env["account.journal"].search(
             [("company_id", "=", cls.company.id), ("type", "=", "sale")], limit=1
         )


### PR DESCRIPTION
## Problem

`TestPaymentRegisterProWizard.test_create_payments_and_grouping` fails on a fresh install with:

```
psycopg2.errors.UndefinedFunction: operator does not exist: integer = boolean
SELECT number_next FROM ir_sequence WHERE id=false FOR UPDATE NOWAIT
```

## Cause

Odoo core `_get_communication` computes the communication for a multi-partner inbound batch via `company.get_next_batch_payment_communication()`, which calls `batch_payment_sequence_id.next_by_id()`. The `batch_payment_sequence_id` field default only fires when a company is created *after* `account` is installed; the base company (`env.company`) predates it and there is no post-init backfill on a fresh install, so the field is empty. Calling `next_by_id()` over the empty recordset produces `WHERE id=false`.

The wizard's `_init_payments` override runs `self.env.flush_all()`, which forces the `communication` recompute during payment creation and hits the crash. Upgraded databases are unaffected (a migration backfills the sequence), so this only surfaces on fresh installs / CI.

## Fix

Ensure `batch_payment_sequence_id` on the test company in `setUpClass` (mirroring the field default), so the communication compute has a valid sequence. Test-only change; no runtime behaviour is modified.

## Test plan

- `l10n_ar_tax` test suite green on a fresh build (the failing test now passes).