### PR TITLE
[ADD] l10n_ar_tax_payment_method: disable withholdings per outbound payment method

### DIFF
--- a/l10n_ar_tax_payment_method/__init__.py
+++ b/l10n_ar_tax_payment_method/__init__.py
@@ -1,0 +1,12 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models
+
+
+def _l10n_ar_set_apply_withholding(env):
+    """Al instalar el módulo, dejamos activo el cálculo de retenciones en TODOS los
+    métodos de pago salientes existentes (el default del campo ya lo hace para los nuevos)."""
+    lines = env["account.payment.method.line"].search([("payment_type", "=", "outbound")])
+    lines.l10n_ar_apply_withholding = True

--- a/l10n_ar_tax_payment_method/__manifest__.py
+++ b/l10n_ar_tax_payment_method/__manifest__.py
@@ -1,0 +1,38 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Withholdings by Payment Method",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Accounting & Finance",
+    "summary": "Allows disabling automatic withholdings computation at the outbound payment method level",
+    "depends": [
+        "l10n_ar_tax",
+    ],
+    "data": [
+        "views/account_journal_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+    "auto_install": False,
+    "post_init_hook": "_l10n_ar_set_apply_withholding",
+}

--- a/l10n_ar_tax_payment_method/i18n/es.po
+++ b/l10n_ar_tax_payment_method/i18n/es.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ar_tax_payment_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-14 15:38+0000\n"
+"PO-Revision-Date: 2026-07-14 15:38+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_method_line__l10n_ar_apply_withholding
+msgid "Apply Withholdings"
+msgstr "Aplicar retenciones"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment
+msgid "Payments"
+msgstr "Pagos"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment_method_line
+msgid "Payment Methods"
+msgstr "Métodos de pago"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment_register
+msgid "Pay"
+msgstr "Pagar"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,help:l10n_ar_tax_payment_method.field_account_payment_method_line__l10n_ar_apply_withholding
+msgid ""
+"If enabled, payments made with this payment method compute withholdings "
+"automatically. If disabled, the fiscal position is forced to empty so that "
+"no withholdings are computed (e.g. credit card or petty cash payments)."
+msgstr ""
+"Si está activo, los pagos generados con este método de pago calculan "
+"retenciones de forma automática. Si está desactivado, se fuerza la posición "
+"fiscal a vacío para que no se calculen retenciones (ej. pagos con tarjeta de "
+"crédito o de caja chica)."

--- a/l10n_ar_tax_payment_method/i18n/l10n_ar_tax_payment_method.pot
+++ b/l10n_ar_tax_payment_method/i18n/l10n_ar_tax_payment_method.pot
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ar_tax_payment_method
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-14 15:38+0000\n"
+"PO-Revision-Date: 2026-07-14 15:38+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_method_line__l10n_ar_apply_withholding
+msgid "Apply Withholdings"
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment__display_name
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_method_line__display_name
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_register__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment__id
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_method_line__id
+#: model:ir.model.fields,field_description:l10n_ar_tax_payment_method.field_account_payment_register__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model.fields,help:l10n_ar_tax_payment_method.field_account_payment_method_line__l10n_ar_apply_withholding
+msgid ""
+"If enabled, payments made with this payment method compute withholdings "
+"automatically. If disabled, the fiscal position is forced to empty so that "
+"no withholdings are computed (e.g. credit card or petty cash payments)."
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment_register
+msgid "Pay"
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment_method_line
+msgid "Payment Methods"
+msgstr ""
+
+#. module: l10n_ar_tax_payment_method
+#: model:ir.model,name:l10n_ar_tax_payment_method.model_account_payment
+msgid "Payments"
+msgstr ""

--- a/l10n_ar_tax_payment_method/models/__init__.py
+++ b/l10n_ar_tax_payment_method/models/__init__.py
@@ -1,0 +1,7 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import account_payment_method_line
+from . import account_payment
+from . import account_payment_register

--- a/l10n_ar_tax_payment_method/models/account_payment.py
+++ b/l10n_ar_tax_payment_method/models/account_payment.py
@@ -1,0 +1,47 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.depends("payment_method_line_id.l10n_ar_apply_withholding")
+    def _compute_fiscal_position_id(self):
+        # Odoo acumula los depends de todos los overrides del método en el MRO, así que este
+        # decorador se suma a los del módulo base sin reemplazarlos.
+        super()._compute_fiscal_position_id()
+        self._l10n_ar_clear_fiscal_position_if_disabled()
+
+    def _l10n_ar_clear_fiscal_position_if_disabled(self):
+        # La restricción a nivel medio de pago prevalece: si el método no aplica retenciones,
+        # forzamos la posición fiscal a vacío para que no se calculen. Filtramos primero y solo
+        # escribimos si hay algo que limpiar: así, cuando esto corre dentro de write(), la re-entrada
+        # encuentra el conjunto vacío y no hay recursión infinita.
+        to_clear = self.filtered(
+            lambda rec: rec.payment_method_line_id
+            and not rec.payment_method_line_id.l10n_ar_apply_withholding
+            and rec.l10n_ar_fiscal_position_id
+        )
+        if to_clear:
+            to_clear.l10n_ar_fiscal_position_id = False
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # El campo es compute store + readonly=False (editable). Un valor pasado directo en create
+        # no dispara el compute, así que reforzamos la restricción del medio de pago acá también.
+        records = super().create(vals_list)
+        records._l10n_ar_clear_fiscal_position_if_disabled()
+        return records
+
+    def write(self, vals):
+        # Un valor explícito a l10n_ar_fiscal_position_id no dispara el compute, así que lo forzamos
+        # también en write para que no se pueda "saltear" el flag del medio de pago. Cambiar el método
+        # de pago sí dispara el compute (depende de payment_method_line_id.l10n_ar_apply_withholding),
+        # por eso ese caso no hace falta contemplarlo acá.
+        res = super().write(vals)
+        if "l10n_ar_fiscal_position_id" in vals:
+            self._l10n_ar_clear_fiscal_position_if_disabled()
+        return res

--- a/l10n_ar_tax_payment_method/models/account_payment_method_line.py
+++ b/l10n_ar_tax_payment_method/models/account_payment_method_line.py
@@ -1,0 +1,17 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class AccountPaymentMethodLine(models.Model):
+    _inherit = "account.payment.method.line"
+
+    l10n_ar_apply_withholding = fields.Boolean(
+        string="Apply Withholdings",
+        default=True,
+        help="If enabled, payments made with this payment method compute withholdings automatically. "
+        "If disabled, the fiscal position is forced to empty so that no withholdings are computed "
+        "(e.g. credit card or petty cash payments).",
+    )

--- a/l10n_ar_tax_payment_method/models/account_payment_register.py
+++ b/l10n_ar_tax_payment_method/models/account_payment_register.py
@@ -1,0 +1,40 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = "account.payment.register"
+
+    @api.depends("payment_method_line_id.l10n_ar_apply_withholding")
+    def _compute_fiscal_position_id(self):
+        super()._compute_fiscal_position_id()
+        self._l10n_ar_clear_fiscal_position_if_disabled()
+
+    def _l10n_ar_clear_fiscal_position_if_disabled(self):
+        # La restricción del medio de pago prevalece en cada recálculo (también en modo manual):
+        # si el método no aplica retenciones, se fuerza la posición fiscal a vacío. Filtramos primero
+        # y solo escribimos si hay algo que limpiar, para no recursar cuando esto corre dentro de write().
+        to_clear = self.filtered(
+            lambda rec: rec.payment_method_line_id
+            and not rec.payment_method_line_id.l10n_ar_apply_withholding
+            and rec.l10n_ar_fiscal_position_id
+        )
+        if to_clear:
+            to_clear.l10n_ar_fiscal_position_id = False
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._l10n_ar_clear_fiscal_position_if_disabled()
+        return records
+
+    def write(self, vals):
+        # Un valor explícito a l10n_ar_fiscal_position_id no dispara el compute; lo forzamos en write
+        # para que el preview de retenciones del wizard respete el flag del medio de pago.
+        res = super().write(vals)
+        if "l10n_ar_fiscal_position_id" in vals:
+            self._l10n_ar_clear_fiscal_position_if_disabled()
+        return res

--- a/l10n_ar_tax_payment_method/tests/__init__.py
+++ b/l10n_ar_tax_payment_method/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_apply_withholding

--- a/l10n_ar_tax_payment_method/tests/test_apply_withholding.py
+++ b/l10n_ar_tax_payment_method/tests/test_apply_withholding.py
@@ -1,0 +1,208 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestApplyWithholdingByPaymentMethod(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.company_ri
+        cls.company.use_payment_pro = True
+
+        # Impuesto de retención + posición fiscal de retención
+        cls.wth_tax = cls.env["account.tax"].create(
+            {
+                "name": "Ret Test PM 3%",
+                "amount": 3.0,
+                "amount_type": "percent",
+                "type_tax_use": "none",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_code": "RET_TEST_PM",
+            }
+        )
+        cls.wth_fp = cls.env["account.fiscal.position"].create(
+            {
+                "name": "FP Retención Test PM",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_ids": [Command.create({"default_tax_id": cls.wth_tax.id, "tax_type": "withholding"})],
+            }
+        )
+        # Mapeamos la FP al partner para que _get_fiscal_position la resuelva automáticamente
+        cls.res_partner_adhoc.property_account_position_id = cls.wth_fp
+
+        # Diario banco con su método de pago saliente (manual, auto-creado)
+        cls.bank_journal = cls.env["account.journal"].create(
+            {
+                "name": "Banco Test PM",
+                "type": "bank",
+                "code": "BPMT",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.out_pml = cls.bank_journal.outbound_payment_method_line_ids[:1]
+        assert cls.out_pml, "El diario banco debe tener un método de pago saliente"
+
+        # Diario de compras sin documentos, para armar facturas de proveedor simples
+        cls.purchase_journal = cls.env["account.journal"].create(
+            {
+                "name": "Compras Test PM",
+                "type": "purchase",
+                "code": "PPMT",
+                "company_id": cls.company.id,
+                "l10n_latam_use_documents": False,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _new_payment(self):
+        return self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.res_partner_adhoc.id,
+                "amount": 1000.0,
+                "journal_id": self.bank_journal.id,
+                "payment_method_line_id": self.out_pml.id,
+            }
+        )
+
+    def _vendor_invoice(self, amount=1000.0):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.res_partner_adhoc.id,
+                "invoice_date": fields.Date.today(),
+                "journal_id": self.purchase_journal.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product_a.id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _register_wizard(self, invoice, mode="automatic"):
+        wizard = (
+            self.env["account.payment.register"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({})
+        )
+        wizard.journal_id = self.bank_journal
+        wizard.payment_method_line_id = self.out_pml
+        wizard.fiscal_position_mode = mode
+        return wizard
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_field_default_true(self):
+        """El campo arranca en True por default en un método de pago nuevo."""
+        self.assertTrue(self.out_pml.l10n_ar_apply_withholding)
+
+    def test_payment_applies_withholding_when_flag_true(self):
+        """account.payment: con el flag activo se resuelve la posición fiscal de retención."""
+        self.out_pml.l10n_ar_apply_withholding = True
+        payment = self._new_payment()
+        self.assertEqual(payment.l10n_ar_fiscal_position_id, self.wth_fp)
+
+    def test_payment_skips_withholding_when_flag_false(self):
+        """account.payment: con el flag desactivado se fuerza la posición fiscal a vacío."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        payment = self._new_payment()
+        self.assertFalse(payment.l10n_ar_fiscal_position_id)
+        self.assertFalse(payment.l10n_ar_withholding_line_ids)
+
+    def test_wizard_applies_withholding_when_flag_true(self):
+        """account.payment.register: con el flag activo se resuelve la posición fiscal de retención."""
+        self.out_pml.l10n_ar_apply_withholding = True
+        wizard = self._register_wizard(self._vendor_invoice())
+        self.assertEqual(wizard.l10n_ar_fiscal_position_id, self.wth_fp)
+
+    def test_wizard_skips_withholding_when_flag_false(self):
+        """account.payment.register: con el flag desactivado se fuerza la posición fiscal a vacío."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        wizard = self._register_wizard(self._vendor_invoice())
+        self.assertFalse(wizard.l10n_ar_fiscal_position_id)
+
+    def test_wizard_flag_false_holds_in_manual_mode(self):
+        """La restricción del medio de pago se sostiene al pasar a modo manual (recompute)."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        wizard = self._register_wizard(self._vendor_invoice())  # automático -> vacío
+        self.assertFalse(wizard.l10n_ar_fiscal_position_id)
+        # Cambiar a modo manual dispara el recompute; la restricción del método sigue vigente
+        wizard.fiscal_position_mode = "manual"
+        self.assertFalse(wizard.l10n_ar_fiscal_position_id)
+
+    # ------------------------------------------------------------------
+    # Bypass: el campo es compute store + readonly=False (editable a mano).
+    # Un write directo no dispara el compute, así que la guarda en create/write
+    # debe sostener la restricción igual.
+    # ------------------------------------------------------------------
+
+    def test_payment_manual_write_cannot_bypass_flag(self):
+        """account.payment: setear la posición fiscal a mano no saltea el flag del método."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        payment = self._new_payment()
+        self.assertFalse(payment.l10n_ar_fiscal_position_id)
+        # Escritura manual directa (no está en los depends del compute)
+        payment.l10n_ar_fiscal_position_id = self.wth_fp
+        self.assertFalse(payment.l10n_ar_fiscal_position_id)
+        self.assertFalse(payment.l10n_ar_withholding_line_ids)
+
+    def test_payment_create_with_fiscal_position_cannot_bypass_flag(self):
+        """account.payment: pasar la posición fiscal directo en create tampoco saltea el flag."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.res_partner_adhoc.id,
+                "amount": 1000.0,
+                "journal_id": self.bank_journal.id,
+                "payment_method_line_id": self.out_pml.id,
+                "l10n_ar_fiscal_position_id": self.wth_fp.id,
+            }
+        )
+        self.assertFalse(payment.l10n_ar_fiscal_position_id)
+
+    def test_payment_manual_write_allowed_when_flag_true(self):
+        """account.payment: con el flag activo, la edición manual de la posición fiscal se respeta."""
+        self.out_pml.l10n_ar_apply_withholding = True
+        payment = self._new_payment()
+        payment.l10n_ar_fiscal_position_id = self.wth_fp
+        self.assertEqual(payment.l10n_ar_fiscal_position_id, self.wth_fp)
+
+    def test_wizard_manual_write_cannot_bypass_flag(self):
+        """account.payment.register: elegir la posición fiscal a mano en modo manual no saltea el flag."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        wizard = self._register_wizard(self._vendor_invoice(), mode="manual")
+        wizard.l10n_ar_fiscal_position_id = self.wth_fp
+        self.assertFalse(wizard.l10n_ar_fiscal_position_id)
+
+    def test_wizard_manual_created_payment_cannot_bypass_flag(self):
+        """El pago creado desde el wizard en modo manual respeta el flag del método
+        (el wizard fuerza la FP sobre el pago con un write directo en _create_payments)."""
+        self.out_pml.l10n_ar_apply_withholding = False
+        wizard = self._register_wizard(self._vendor_invoice(), mode="manual")
+        wizard.l10n_ar_fiscal_position_id = self.wth_fp
+        payments = wizard._create_payments()
+        self.assertFalse(payments.l10n_ar_fiscal_position_id)
+        self.assertFalse(payments.l10n_ar_withholding_line_ids)

--- a/l10n_ar_tax_payment_method/views/account_journal_views.xml
+++ b/l10n_ar_tax_payment_method/views/account_journal_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="name">account.journal.form.l10n.ar.withholding.payment.method</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='outbound_payment_method_line_ids']/list/field[@name='name']" position="after">
+                <field name="l10n_ar_apply_withholding" optional="hide"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a new v19 module that lets users disable the automatic withholdings computation at the outbound payment method level.

- New boolean 'Apply Withholdings' (default True) on account.payment.method.line, shown as an optional column in the journal's outbound payment methods list.
- When disabled, the withholding fiscal position is forced to empty on both account.payment and the account.payment.register wizard, so no withholdings are computed (e.g. credit card or petty cash payments).
- post_init_hook sets the flag True on all existing outbound payment methods.
