### PR TITLE
[ADD] l10n_ar_tax_neuquen: IIBB minimum on invoice untaxed for Neuquen

### DIFF
--- a/l10n_ar_tax_neuquen/README.rst
+++ b/l10n_ar_tax_neuquen/README.rst
@@ -1,0 +1,80 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========================================
+Argentinean Withholding Minimum for Neuquén
+===========================================
+
+Este módulo implementa:
+
+* Para las retenciones de Ingresos Brutos cuya jurisdicción (``Jurisdiction`` /
+  ``l10n_ar_state_id``) es **Neuquén**, el mínimo sujeto a retención cargado en el
+  campo **Minimum Base** (``l10n_ar_base_minimum_threshold``) se evalúa sobre el
+  **neto total de la factura** (base imponible sin impuestos): si no supera ese
+  mínimo, no se practica la retención.
+
+* El gate estándar de ese campo compara contra la base retenida (``base_amount``),
+  que para impuestos de tipo *IIBB Total Amount* es el total con impuestos y en pagos
+  parciales es el neto proporcional al residual pagado. Este módulo, solo para
+  Neuquén, lo compara contra el neto total de la/s factura/s — ni el total con
+  impuestos ni el monto del pago.
+
+* Refleja lo dispuesto por la Res. Gral. 276/DPR/17 (art. 10): el importe mínimo
+  sujeto a retención debe analizarse siempre sobre la base imponible; cuando la
+  factura discrimina IVA, dicho importe se deduce para la comparación contra el mínimo.
+
+* Aplica **solo** cuando la jurisdicción del impuesto es Neuquén. Para el resto de las
+  jurisdicciones el comportamiento no cambia.
+
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Definir en el impuesto de retención de IIBB la jurisdicción **Neuquén**
+   (campo *Jurisdiction*).
+#. Cargar el mínimo en el campo *Minimum Base* (``l10n_ar_base_minimum_threshold``).
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_tax_neuquen/__init__.py
+++ b/l10n_ar_tax_neuquen/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_tax_neuquen/__manifest__.py
+++ b/l10n_ar_tax_neuquen/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Argentinean Withholding Minimum for Neuquén",
+    "version": "18.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Evaluate the IIBB withholding base minimum on the invoice untaxed amount for Neuquén",
+    "depends": ["l10n_ar_tax"],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/l10n_ar_tax_neuquen/models/__init__.py
+++ b/l10n_ar_tax_neuquen/models/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_ar_payment_withholding

--- a/l10n_ar_tax_neuquen/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax_neuquen/models/l10n_ar_payment_withholding.py
@@ -1,0 +1,27 @@
+from odoo import models
+
+
+class L10nArPaymentWithholding(models.Model):
+    _inherit = "l10n_ar.payment.withholding"
+
+    def _tax_compute_all_helper(self):
+        """En Neuquén el mínimo sujeto a retención de IIBB se analiza sobre la base
+        imponible (neto sin impuestos) del comprobante, no sobre el total con
+        impuestos ni sobre el monto del pago (Res. Gral. 276/DPR/17, art. 10).
+
+        El mínimo se carga en el campo "Minimum Base" (``l10n_ar_base_minimum_threshold``).
+        El gate estándar de ese campo compara contra ``base_amount`` (que para
+        ``iibb_total`` es el total con impuestos y en pagos parciales es el neto
+        proporcional). Para Neuquén lo comparamos contra el neto total de la/s
+        factura/s pagada/s: si no supera el mínimo, no corresponde retener.
+        """
+        tax_amount, tax_account_id, tax_repartition_line_id, ref = super()._tax_compute_all_helper()
+        tax = self._get_withholding_tax()
+        neuquen = self.env.ref("base.state_ar_q", raise_if_not_found=False)
+        if tax_amount and neuquen and tax.l10n_ar_state_id == neuquen and tax.l10n_ar_base_minimum_threshold:
+            invoices = self.payment_id.to_pay_move_line_ids.move_id.filtered(lambda m: m.is_invoice())
+            invoice_untaxed = abs(sum(invoices.mapped("amount_untaxed_signed")))
+            # Sin facturas (adelanto puro) invoice_untaxed es 0 y no bloqueamos.
+            if invoices and invoice_untaxed <= tax.l10n_ar_base_minimum_threshold:
+                return 0.0, tax_account_id, tax_repartition_line_id, False
+        return tax_amount, tax_account_id, tax_repartition_line_id, ref

--- a/l10n_ar_tax_neuquen/tests/__init__.py
+++ b/l10n_ar_tax_neuquen/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_neuquen_minimum

--- a/l10n_ar_tax_neuquen/tests/test_neuquen_minimum.py
+++ b/l10n_ar_tax_neuquen/tests/test_neuquen_minimum.py
@@ -1,0 +1,119 @@
+from odoo import Command
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
+from odoo.tests import tagged
+
+
+@tagged("-at_install", "post_install")
+class TestNeuquenMinimum(TestArWithholdingArRi):
+    """Tests de aceptación para el mínimo sujeto a retención de IIBB Neuquén.
+
+    En Neuquén el mínimo (campo "Minimum Base" / ``l10n_ar_base_minimum_threshold``) se
+    evalúa sobre el neto total de la factura (base imponible sin IVA), no sobre la base
+    retenida (``base_amount``, que para ``iibb_total`` es el total con impuestos) ni
+    sobre el total del pago (Res. Gral. 276/DPR/17, art. 10).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.neuquen = cls.env.ref("base.state_ar_q")
+        cls.wth_seq_nqn = cls.env["ir.sequence"].create(
+            {"implementation": "standard", "name": "wth neuquen test", "padding": 8, "number_increment": 1}
+        )
+
+        # Retención IIBB 2% con mínimo por base = 300.000, jurisdicción Neuquén
+        cls.tax_iibb_nqn = cls.tax_wth_test_1.copy(
+            default={
+                "name": "IIBB Neuquén 2%",
+                "amount": 2,
+                "l10n_ar_state_id": cls.neuquen.id,
+                "l10n_ar_withholding_sequence_id": cls.wth_seq_nqn.id,
+                "l10n_ar_non_taxable_amount": 0,
+                "l10n_ar_payment_minimum_threshold": 0,
+                "l10n_ar_base_minimum_threshold": 300000,
+                "l10n_ar_minimum_threshold": 0,
+            }
+        )
+
+        # Misma configuración pero SIN jurisdicción Neuquén (control)
+        cls.tax_iibb_no_nqn = cls.tax_wth_test_1.copy(
+            default={
+                "name": "IIBB Otra Jurisdicción 2%",
+                "amount": 2,
+                "l10n_ar_state_id": False,
+                "l10n_ar_withholding_sequence_id": cls.wth_seq_nqn.id,
+                "l10n_ar_non_taxable_amount": 0,
+                "l10n_ar_payment_minimum_threshold": 0,
+                "l10n_ar_base_minimum_threshold": 300000,
+                "l10n_ar_minimum_threshold": 0,
+            }
+        )
+
+    def _make_vendor_invoice(self, price_unit, doc_number):
+        """Factura de proveedor con IVA 21% y neto = price_unit."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "date": "2023-01-01",
+                "invoice_date": "2023-01-01",
+                "partner_id": self.res_partner_adhoc.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product_a.id,
+                            "price_unit": price_unit,
+                            "tax_ids": [Command.set(self.tax_21.ids)],
+                        }
+                    )
+                ],
+                "l10n_latam_document_number": doc_number,
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _make_withholding_line(self, wth_tax, base_amount, invoice):
+        payable_line = invoice.line_ids.filtered(lambda l: l.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": invoice.partner_id.id,
+                "amount": invoice.amount_total,
+                "date": "2023-01-01",
+                "journal_id": self.company_data["default_journal_bank"].id,
+            }
+        )
+        payment.to_pay_move_line_ids = [Command.set(payable_line.ids)]
+        wth_line = self.env["l10n_ar.payment.withholding"].create({"payment_id": payment.id, "tax_id": wth_tax.id})
+        wth_line.base_amount = base_amount
+        wth_line._compute_amount()
+        return payment, wth_line
+
+    # ─── Caso del cliente/video: neto < mínimo → no retiene ────────────────────
+
+    def test_01_neuquen_net_below_minimum_blocks(self):
+        """Factura neto 259.339,04 + IVA = 313.800,24. La base retenida es el total con
+        impuestos (313.800,24 > 300.000, el gate estándar no bloquea), pero el neto de
+        la factura (259.339,04) no supera el mínimo → NO corresponde retener."""
+        invoice = self._make_vendor_invoice(price_unit=259339.04, doc_number="4-1")
+        __, wth = self._make_withholding_line(self.tax_iibb_nqn, base_amount=313800.24, invoice=invoice)
+        self.assertEqual(wth.amount, 0.0, "Neto 259.339,04 <= mínimo 300.000 → sin retención")
+
+    # ─── Neuquén: neto > mínimo → retiene ──────────────────────────────────────
+
+    def test_02_neuquen_net_above_minimum_applies(self):
+        """Factura neto 350.000 > mínimo 300.000 → retiene 2% sobre la base."""
+        invoice = self._make_vendor_invoice(price_unit=350000.0, doc_number="4-2")
+        __, wth = self._make_withholding_line(self.tax_iibb_nqn, base_amount=350000.0, invoice=invoice)
+        self.assertEqual(wth.amount, 7000.0, "Neto 350.000 > mínimo 300.000 → 2% de 350.000 = 7.000")
+
+    # ─── Control: sin Neuquén se usa la base retenida (gate estándar) ──────────
+
+    def test_03_non_neuquen_uses_base_amount(self):
+        """Mismo neto pero jurisdicción distinta de Neuquén: el gate estándar compara
+        contra la base retenida (total 313.800,24 > 300.000) → retiene 2% sobre la base.
+        Confirma que la comparación contra el neto de factura aplica SOLO a Neuquén."""
+        invoice = self._make_vendor_invoice(price_unit=259339.04, doc_number="4-3")
+        __, wth = self._make_withholding_line(self.tax_iibb_no_nqn, base_amount=313800.24, invoice=invoice)
+        self.assertEqual(wth.amount, 6276.0, "Base 313.800,24 > mínimo 300.000 → 2% = 6.276,00")


### PR DESCRIPTION
## Qué

Nuevo módulo `l10n_ar_tax_neuquen`. Para las retenciones de IIBB cuya jurisdicción (`l10n_ar_state_id`) es Neuquén, el mínimo cargado en el campo *Minimum Base* (`l10n_ar_base_minimum_threshold`) se evalúa sobre el **neto total de la factura** (base imponible sin impuestos). Si el neto no supera el mínimo, no se practica la retención.

## Por qué

El gate estándar de `l10n_ar_base_minimum_threshold` compara contra la base retenida (`base_amount`), que para impuestos `iibb_total` es el total con impuestos y en pagos parciales es el neto proporcional al residual pagado. Para Neuquén el mínimo sujeto a retención debe analizarse siempre sobre la base imponible neta de la factura (Res. Gral. 276/DPR/17, art. 10) — no sobre el total con impuestos ni sobre el monto del pago. En 16.0 funcionaba así; en 18.0 tomaba el total.

## Cómo

- Override de `_tax_compute_all_helper` (vía `super()`) en `l10n_ar.payment.withholding`, solo para impuestos con jurisdicción Neuquén. Anula el importe retenido si el neto total de la/s factura/s no supera el mínimo.
- No modifica el módulo base `l10n_ar_tax`. Solo cambia la evaluación del mínimo; el importe retenido se calcula igual que antes.
- Adelantos puros (sin factura) mantienen el comportamiento estándar.

## Tests

- `test_01`: base retenida = total 313.800,24 (> mínimo, el gate estándar no bloquea) pero neto de factura 259.339,04 < 300.000 → no retiene.
- `test_02`: neto 350.000 > 300.000 → retiene 2%.
- `test_03`: control sin jurisdicción Neuquén → usa la base retenida (gate estándar).

Task 70313