### PR TITLE
[FIX] l10n_ar_tax: fail fast when ARBA padrón webservice is down

### DIFF
--- a/l10n_ar_tax/models/res_company.py
+++ b/l10n_ar_tax/models/res_company.py
@@ -63,6 +63,10 @@ class ResCompany(models.Model):
             ws.Usuario = cuit
             ws.Password = self.arba_cit
             ws.Conectar(url=arba_url)
+            # pyafipws arma el cliente httplib2 con un timeout de 30s hardcodeado; cuando el WS de ARBA
+            # se cae eso bloquea el worker ~30-50s por consulta. Fijamos un timeout corto para fallar rápido.
+            if getattr(ws, "client", None) is not None:
+                ws.client.http.timeout = 15
             _logger.info('Connection getted to ARBA with url "%s" and CUIT %s' % (arba_url, cuit))
         except ConnectionRefusedError:
             raise UserError(


### PR DESCRIPTION
### Problem

The ARBA padrón webservice is queried **synchronously** from the supplier payment onchange (`_get_arba_data`). `pyafipws` builds its `httplib2` client with a **hardcoded 30s timeout**, so when ARBA is unreachable every interaction blocked the worker ~30-50s, and repeated onchanges saturated the workers until the instance became unresponsive.

### Change

`Conectar` only builds the `WebClient`; the actual HTTP (and the 30s wait) happens inside `ConsultarContribuyentes`. We set a short **15s** timeout on the already-created `httplib2` client (`ws.client.http.timeout`) right after connecting, so the call fails fast instead of waiting the 30s default. Localized to the ws instance (thread-safe), unlike `socket.setdefaulttimeout` which is process-global.

4-line change in `res_company.arba_connect`.

### Test plan

- Existing `l10n_ar_tax` suite stays green.
- Manual: with ARBA unreachable, the payment onchange now errors after ~15s instead of ~30-50s.