### PR TITLE
[FIX] l10n_ar_tax: user-friendly error on ARBA webservice timeout

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -678,6 +678,33 @@ msgstr "No se pudo conectar a ARBA: %s"
 
 #. module: l10n_ar_tax
 #. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company.py:0
+msgid ""
+"Could not get the tax rate from the ARBA webservice, probably due to a "
+"service outage or intermittency.\n"
+"\n"
+"To keep operating you can:\n"
+"1) Check the taxpayer's tax rate manually (for example at "
+"https://padron.devos.com.ar/ or on the ARBA website).\n"
+"2) Manually set the tax rate on the contact's 'Accounting' tab, to "
+"exceptionally register the payment/document.\n"
+"\n"
+"If the problem persists, please contact our Support team.\n"
+msgstr ""
+"No se pudo obtener la alícuota desde el webservice de ARBA, probablemente "
+"por una intermitencia o caída del servicio.\n"
+"\n"
+"Para poder seguir operando podés:\n"
+"1) Consultar la alícuota del contribuyente manualmente (por ejemplo en "
+"https://padron.devos.com.ar/ o en la página de ARBA).\n"
+"2) Cargar la alícuota a mano en la solapa 'Contabilidad' del contacto, para "
+"registrar el pago/comprobante de forma excepcional.\n"
+"\n"
+"Si el problema persiste, comuníquese con nuestro equipo de Servicio de "
+"Asistencia.\n"
+
+#. module: l10n_ar_tax
+#. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
 msgid ""
 "Could not get the tax rate from the rentascordoba webservice.\n"
@@ -773,6 +800,18 @@ msgstr "Alícuota por defecto (%)"
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position_l10n_ar_tax__default_tax_id
 msgid "Default Tax"
 msgstr "Impuesto por Defecto"
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company.py:0
+msgid "Detail: %s"
+msgstr "Detalle: %s"
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company.py:0
+msgid "Detail: read operation timed out."
+msgstr "Detalle: se agotó el tiempo de espera de lectura."
 
 #. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_account_payment_register_form

--- a/l10n_ar_tax/models/res_company.py
+++ b/l10n_ar_tax/models/res_company.py
@@ -98,10 +98,27 @@ class ResCompany(models.Model):
             "user": self.partner_id.ensure_vat(),
             "password": self.arba_cit,
         }
-        res = requests.post(login_url, data=request_data, files={"file": file}, timeout=arba_alicout_timeout)
+        arba_error_msg = _(
+            "Could not get the tax rate from the ARBA webservice, "
+            "probably due to a service outage or intermittency.\n\n"
+            "To keep operating you can:\n"
+            "1) Check the taxpayer's tax rate manually "
+            "(for example at https://padron.devos.com.ar/ or on the ARBA website).\n"
+            "2) Manually set the tax rate on the contact's 'Accounting' tab, "
+            "to exceptionally register the payment/document.\n\n"
+            "If the problem persists, please contact our Support team.\n"
+        )
+        try:
+            res = requests.post(login_url, data=request_data, files={"file": file}, timeout=arba_alicout_timeout)
+        except requests.exceptions.Timeout as exp:
+            _logger.warning("ARBA webservice timeout: %s", exp)
+            raise UserError(arba_error_msg + _("Detail: read operation timed out."))
+        except requests.exceptions.RequestException as exp:
+            _logger.warning("ARBA webservice connection error: %s", exp)
+            raise UserError(arba_error_msg + _("Detail: %s") % str(exp))
         if res.ok:
             response_xml = self._arba_cit_parse_response(res.content)
         else:
-            _logger.error("Error parsing ARBA response: %s\n %s", str(res.text))
+            _logger.error("Error parsing ARBA response: %s", str(res.text))
             raise UserError(self.env._("Error parsing ARBA response: %s") % str(res.text))
         return response_xml

--- a/l10n_ar_tax/tests/test_arba.py
+++ b/l10n_ar_tax/tests/test_arba.py
@@ -1,31 +1,55 @@
+from unittest import mock
+
+import requests
 from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import common
+from odoo.tools import mute_logger
 
 
 class TestARBA(common.TransactionCase):
-    def test_0_arbaconnect(self):
-        partner = self.env["res.partner"].create(
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        partner = cls.env["res.partner"].create(
             {
                 "name": "test_company",
-                "l10n_latam_identification_type_id": self.env.ref("l10n_ar.it_cuit").id,
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
                 "vat": "30697130841",
             }
         )
-        company = self.env["res.company"].create(
+        company = cls.env["res.company"].create(
             {"name": "test_company", "partner_id": partner.id, "vat": "30697130841"}
         )
-        company = company.with_company(company)
+        cls.company = company.with_company(company)
+
+    def _arba_consultar(self):
+        return self.company.arba_consultar_contribuyente(
+            "30697130841",
+            fields.Date.start_of(fields.Date.today(), "month"),
+            fields.Date.end_of(fields.Date.today(), "month"),
+        )
+
+    def test_0_arbaconnect(self):
         with self.assertRaisesRegex(UserError, "You must configure CIT"):
-            company.arba_consultar_contribuyente(
-                "30697130841",
-                fields.Date.start_of(fields.Date.today(), "month"),
-                fields.Date.end_of(fields.Date.today(), "month"),
-            )
-        company.vat = ""
+            self._arba_consultar()
+        self.company.vat = ""
         with self.assertRaisesRegex(UserError, "No VAT configured"):
-            company.arba_consultar_contribuyente(
-                "30697130841",
-                fields.Date.start_of(fields.Date.today(), "month"),
-                fields.Date.end_of(fields.Date.today(), "month"),
-            )
+            self._arba_consultar()
+
+    @mute_logger("odoo.addons.l10n_ar_tax.models.res_company")
+    def test_1_arba_ws_timeout_raises_user_error(self):
+        """Si el webservice de ARBA no responde (timeout), la excepcion de red no
+        debe propagarse cruda: se traduce a un UserError amigable."""
+        self.company.arba_cit = "dummy_cit"
+        with mock.patch.object(requests, "post", side_effect=requests.exceptions.Timeout("read timed out")):
+            with self.assertRaisesRegex(UserError, "ARBA webservice"):
+                self._arba_consultar()
+
+    @mute_logger("odoo.addons.l10n_ar_tax.models.res_company")
+    def test_2_arba_ws_connection_error_raises_user_error(self):
+        """Idem para cualquier otro error de conexion (RequestException)."""
+        self.company.arba_cit = "dummy_cit"
+        with mock.patch.object(requests, "post", side_effect=requests.exceptions.ConnectionError("connection refused")):
+            with self.assertRaisesRegex(UserError, "ARBA webservice"):
+                self._arba_consultar()


### PR DESCRIPTION
## What

When ARBA's alicuot webservice is unavailable (a frequent outage), loading a
supplier payment recomputes the IIBB withholding lines, which queries the ARBA
padrón through `res.company.arba_consultar_contribuyente`. The underlying
`requests.post` had no exception handling, so a `ReadTimeout` / connection error
propagated raw to the client as an `RPC_ERROR` traceback.

## Change

- Wrap the ARBA request in `try/except`, catching `requests.exceptions.Timeout`
  and `requests.exceptions.RequestException`, and raise a `UserError` that
  explains the outage and the manual alternatives (check the rate manually and
  load the aliquot by hand on the contact). This mirrors the pattern already
  used for Córdoba in `_get_rentas_cordoba_data`.
- Fix a broken `_logger.error` call in the non-OK response branch (two `%s`
  placeholders, one argument) that would raise a `TypeError` instead of logging
  the real error.

Only network exceptions are caught around the request; `UserError`s raised by
`_arba_cit_parse_response` (e.g. padrón error codes) keep propagating unchanged.

## Test plan

- Mock `requests.post` to raise `requests.exceptions.Timeout` and assert
  `arba_consultar_contribuyente` re-raises `UserError` (not `Timeout`).
- Manually: with an invalid/unreachable ARBA endpoint, load a supplier payment
  with BsAs IIBB withholding and confirm a clean dialog appears instead of the
  RPC traceback.

Task 70832.
