### PR TITLE
[FIX] l10n_ar_tax: reset amount on payment 'Remove All'

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -119,6 +119,13 @@ class AccountPayment(models.Model):
             if rec.partner_id != rec._origin.partner_id:
                 rec._onchange_withholdings()
 
+    def remove_all(self):
+        # server method: form onchanges don't run, so re-sync `amount` with the
+        # (now empty) debt, otherwise it stays stuck at its last value.
+        res = super().remove_all()
+        self._onchange_withholdings()
+        return res
+
     # # ver mensaje en commit
     # @api.onchange('to_pay_amount', 'withholdable_advanced_amount', 'partner_id')
     # def _onchange_to_pay_amount(self):

--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -126,6 +126,13 @@ class AccountPayment(models.Model):
         self._onchange_withholdings()
         return res
 
+    def action_add_all(self):
+        # same as remove_all: re-sync `amount` after re-adding the debt, otherwise
+        # it stays stuck (e.g. at 0 after a previous Remove All).
+        res = super().action_add_all()
+        self._onchange_withholdings()
+        return res
+
     # # ver mensaje en commit
     # @api.onchange('to_pay_amount', 'withholdable_advanced_amount', 'partner_id')
     # def _onchange_to_pay_amount(self):


### PR DESCRIPTION
Ticket 123054.

## Problema
En una orden de pago a proveedores, al usar el botón **"Eliminar todo"** para vaciar las líneas de deuda de una sola vez, los campos **importe** y **total pago** quedaban clavados con el último valor en lugar de volver a cero. Eliminando las líneas de a una, el recálculo funcionaba bien; y **retenciones** sí volvía a cero en ambos casos.

## Causa
`remove_all` es un método de servidor (botón `type="object"`), así que los onchange del formulario no corren. El único lugar que sincroniza `amount` con la deuda seleccionada es el onchange `_onchange_withholdings`, que nunca se ejecutaba en este flujo. `to_pay_amount`/`selected_debt`/`withholdings_amount` sí se resetean por ser campos computados; `amount` es un campo plano y quedaba con su último valor.

## Solución
Override de `remove_all` que re-dispara `_onchange_withholdings()` tras el super, siguiendo el mismo patrón que ya usa `_onchange_partner_id`.

## Prueba
Reproducido y validado en base local: tras "Eliminar todo", `amount` pasa de quedar clavado en el último importe a volver a `0`, junto con el resto de los campos.