### PR TITLE
[IMP] l10n_ar_tax: cache padron aliquot lookup by CUIT + awk column search

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -56,6 +56,7 @@
     ],
     "external_dependencies": {
         "python": ["pyafipws"],
+        "bin": ["awk"],
     },
     "installable": True,
     "auto_install": ["l10n_ar"],

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -129,9 +129,13 @@ class ResCompanyJurisdictionPadron(models.Model):
         return fallback_match
 
     def _get_parp_tmp_dir(self):
-        # Directorio por-padrón: evita mezclar archivos extraídos de distintos registros.
+        # Dir por padron+periodo: no mezcla archivos de otro mes.
         self.ensure_one()
-        return "/tmp/l10n_ar_padron_santafe_%s" % self.id
+        return "/tmp/l10n_ar_padron_%s_%s_%s" % (
+            self.id,
+            self.l10n_ar_padron_from_date,
+            self.l10n_ar_padron_to_date,
+        )
 
     def _ensure_parp_file_extracted(self):
         # Extrae una sola vez y reutiliza (antes se re-decodificaba/re-unzipeaba por CUIT).
@@ -188,16 +192,17 @@ class ResCompanyJurisdictionPadron(models.Model):
             return self._read_parp_from_binary(cuit)
 
         # Original logic for other padron types (ARBA, etc)
+        tmp_dir = self._get_parp_tmp_dir()
         nro = False
         aliquot_ret = 0.0
         aliquot_per = 0.0
         for padron_type in ("Per", "Ret"):
-            path_file = self.find_file("/tmp/", padron_type)
+            path_file = self.find_file(tmp_dir, padron_type)
             if not path_file:
-                self.descompress_file(self.file_padron)
-                path_file = self.find_file("/tmp/", padron_type)
+                self.descompress_file(self.file_padron, dest_dir=tmp_dir)
+                path_file = self.find_file(tmp_dir, padron_type)
             if path_file:
-                nro, aliquot = self.find_aliquot("/tmp/" + path_file, cuit)
+                nro, aliquot = self.find_aliquot(os.path.join(tmp_dir, path_file), cuit)
                 if padron_type == "Per":
                     aliquot_per = aliquot and aliquot.replace(",", ".")
                 else:

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -3,13 +3,15 @@ import io
 import logging
 import os
 import re
-import tempfile
+import subprocess
 import zipfile
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
+
+AWK_TIMEOUT = 30
 
 
 class ResCompanyJurisdictionPadron(models.Model):
@@ -62,35 +64,31 @@ class ResCompanyJurisdictionPadron(models.Model):
             res += [(padron.id, name)]
         return res
 
-    def descompress_file(self, file_padron):
+    def descompress_file(self, file_padron, dest_dir="/tmp"):
         _logger.log(25, "Descompress zip file")
-        ruta_extraccion = "/tmp"
-        try:
-            file = base64.b64decode(file_padron)
-        except:
-            file = base64.decodestring(file_padron)
-        fobj = tempfile.NamedTemporaryFile(delete=False)
-        fname = fobj.name
-        fobj.write(file)
-        fobj.close()
-        f = open(fname, "r+b")
-        f.write(base64.b64decode(file_padron))
-        with zipfile.ZipFile(f, "r") as zip_file:
-            zip_file.extractall(path=ruta_extraccion)
-            zip_file.close()
+        # Decode once and extract in-memory: the previous version decoded the
+        # base64 twice and round-tripped through a temp file.
+        file = base64.b64decode(file_padron)
+        with zipfile.ZipFile(io.BytesIO(file), "r") as zip_file:
+            zip_file.extractall(path=dest_dir)
+
+    def _lookup_aliquot_awk(self, path, cuit, cuit_col, nro_col, aliq_col):
+        # Columna exacta (no substring): evita falsos positivos tipo grep.
+        program = '$%d==c {print $%d";"$%d; exit}' % (cuit_col, nro_col, aliq_col)
+        out = subprocess.run(
+            ["awk", "-F", ";", "-v", "c=" + cuit, program, path],
+            capture_output=True,
+            text=True,
+            timeout=AWK_TIMEOUT,
+        ).stdout.strip()
+        if not out:
+            return False, False
+        nro, aliq = out.split(";", 1)
+        return nro, aliq
 
     def find_aliquot(self, path, cuit):
-        """We try to find aliqut and number for a partner given"""
-        with open(path) as fp:
-            aliq = False
-            nro = False
-            for line in fp.readlines():
-                values = line.split(";")
-                if values[4] == cuit:
-                    aliq = values[8]
-                    nro = values[3]
-                    break
-            return nro, aliq
+        # ARBA: cuit col 5, nro col 4, alícuota col 9 (1-based).
+        return self._lookup_aliquot_awk(path, cuit, cuit_col=5, nro_col=4, aliq_col=9)
 
     def _is_santa_fe_jurisdiction(self):
         """Check if jurisdiction is Santa Fe (PARP format)"""
@@ -104,25 +102,19 @@ class ResCompanyJurisdictionPadron(models.Model):
         self.ensure_one()
         return bool(self.filename and self.filename.lower().endswith(".zip"))
 
-    def _read_parp_lines(self, lines, cuit):
-        aliquot_ret = False
-        aliquot_per = False
-        is_in_padron = False
-        for line in lines:
-            if not line:
-                continue
-            values = [value.strip() for value in line.split(";")]
-            if len(values) <= 8:
-                continue
-            # CUIT is at index 3, compare as strings
-            if values[3] == cuit:
-                # Percepción at index 7, Retención at index 8
-                # Convert to float, handling comma as decimal separator
-                aliquot_per = float(values[7].replace(",", "."))
-                aliquot_ret = float(values[8].replace(",", "."))
-                is_in_padron = True
-                break
-        return is_in_padron, aliquot_ret, aliquot_per
+    def _lookup_parp_aliquot_awk(self, path, cuit):
+        # PARP: cuit col 4, percepción col 8, retención col 9 (1-based); gsub recorta padding.
+        program = '{f=$4; gsub(/^[ \\t]+|[ \\t]+$/,"",f); if (f==c) {print $4";"$8";"$9; exit}}'
+        out = subprocess.run(
+            ["awk", "-F", ";", "-v", "c=" + cuit, program, path],
+            capture_output=True,
+            text=True,
+            timeout=AWK_TIMEOUT,
+        ).stdout.strip()
+        if not out:
+            return False, False, False
+        _nro, per, ret = (value.strip() for value in out.split(";"))
+        return True, float(ret.replace(",", ".")), float(per.replace(",", "."))
 
     def _find_parp_file(self, rootdir):
         fallback_match = False
@@ -136,25 +128,42 @@ class ResCompanyJurisdictionPadron(models.Model):
                         fallback_match = os.path.join(subdir, filename)
         return fallback_match
 
+    def _get_parp_tmp_dir(self):
+        # Directorio por-padrón: evita mezclar archivos extraídos de distintos registros.
+        self.ensure_one()
+        return "/tmp/l10n_ar_padron_santafe_%s" % self.id
+
+    def _ensure_parp_file_extracted(self):
+        # Extrae una sola vez y reutiliza (antes se re-decodificaba/re-unzipeaba por CUIT).
+        self.ensure_one()
+        tmp_dir = self._get_parp_tmp_dir()
+        path_file = self._find_parp_file(tmp_dir)
+        if path_file:
+            return path_file
+
+        file_content = base64.b64decode(self.file_padron)
+        if self._is_zip_content(file_content):
+            self.descompress_file(self.file_padron, dest_dir=tmp_dir)
+            path_file = self._find_parp_file(tmp_dir)
+            if not path_file:
+                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+            return path_file
+
+        # CSV directo (no ZIP): lo persistimos para no re-decodificar cada vez.
+        os.makedirs(tmp_dir, exist_ok=True)
+        path_file = os.path.join(tmp_dir, "padron.csv")
+        with open(path_file, "w", encoding="latin-1") as fp:
+            fp.write(file_content.decode("latin-1"))
+        return path_file
+
     def _read_parp_from_binary(self, cuit):
         """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
         or from ZIP if the binary is a ZIP file.
         PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (aliquot_ret, aliquot_per)
+        Returns: (is_in_padron, aliquot_ret, aliquot_per)
         """
-        file_content = base64.b64decode(self.file_padron)
-        # is a ZIP file
-        if self._is_zip_content(file_content):
-            self.descompress_file(self.file_padron)
-            path_file = self._find_parp_file("/tmp/")
-            if not path_file:
-                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
-            with open(path_file, encoding="latin-1") as fp:
-                return self._read_parp_lines(fp.readlines(), cuit)
-
-        # is a CSV file directly
-        csv_text = file_content.decode("latin-1")
-        return self._read_parp_lines(csv_text.split("\n"), cuit)
+        path_file = self._ensure_parp_file_extracted()
+        return self._lookup_parp_aliquot_awk(path_file, cuit)
 
     def find_file(self, rootdir, type_code):
         res = False
@@ -168,29 +177,31 @@ class ResCompanyJurisdictionPadron(models.Model):
         return res
 
     def _get_aliquot(self, partner):
+        self.ensure_one()
+        return self._get_aliquot_cached(partner.vat)
+
+    @tools.ormcache("self.id", "self.write_date", "cuit")
+    def _get_aliquot_cached(self, cuit):
+        # Caché por-CUIT; write_date invalida sola al recargar el padrón.
+        if self._is_santa_fe_jurisdiction():
+            # Read PARP directly from binary field
+            return self._read_parp_from_binary(cuit)
+
+        # Original logic for other padron types (ARBA, etc)
         nro = False
         aliquot_ret = 0.0
         aliquot_per = 0.0
-
-        # Check if this is Santa Fe PARP format
-        if self._is_santa_fe_jurisdiction():
-            # Read PARP directly from binary field
-            is_in_padron, aliquot_ret, aliquot_per = self._read_parp_from_binary(partner.vat)
-            return is_in_padron, aliquot_ret, aliquot_per
-        else:
-            # Original logic for other padron types (ARBA, etc)
-            padron_types = ["Per", "Ret"]
-            for padron_type in padron_types:
+        for padron_type in ("Per", "Ret"):
+            path_file = self.find_file("/tmp/", padron_type)
+            if not path_file:
+                self.descompress_file(self.file_padron)
                 path_file = self.find_file("/tmp/", padron_type)
-                if not path_file:
-                    self.descompress_file(self.file_padron)
-                    path_file = self.find_file("/tmp/", padron_type)
-                if path_file:
-                    nro, aliquot = self.find_aliquot("/tmp/" + path_file, partner.vat)
-                    if padron_type == "Per":
-                        aliquot_per = aliquot and aliquot.replace(",", ".")
-                    else:
-                        aliquot_ret = aliquot and aliquot.replace(",", ".")
+            if path_file:
+                nro, aliquot = self.find_aliquot("/tmp/" + path_file, cuit)
+                if padron_type == "Per":
+                    aliquot_per = aliquot and aliquot.replace(",", ".")
+                else:
+                    aliquot_ret = aliquot and aliquot.replace(",", ".")
         return nro, aliquot_ret, aliquot_per
 
     @api.model

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_arba
+from . import test_padron_aliquot
 from . import test_padron_cleanup_cron
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_kept_on_post

--- a/l10n_ar_tax/tests/test_padron_aliquot.py
+++ b/l10n_ar_tax/tests/test_padron_aliquot.py
@@ -1,6 +1,5 @@
 import base64
 import io
-import os
 import shutil
 import zipfile
 from datetime import timedelta
@@ -31,7 +30,7 @@ class TestPadronAliquot(common.TransactionCase):
             }
         )
 
-    def _create_arba_padron(self, per_lines, ret_lines):
+    def _create_arba_padron(self, per_lines, ret_lines, from_date=None, to_date=None):
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
             zip_file.writestr("Per.TXT", "\n".join(per_lines) + "\n")
@@ -42,12 +41,11 @@ class TestPadronAliquot(common.TransactionCase):
                 "state_id": self.state_arba.id,
                 "file_padron": base64.b64encode(buffer.getvalue()).decode(),
                 "filename": "padron_arba.zip",
-                "l10n_ar_padron_from_date": self.today + relativedelta(days=-1),
-                "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
+                "l10n_ar_padron_from_date": from_date or self.today + relativedelta(days=-1),
+                "l10n_ar_padron_to_date": to_date or self.today + relativedelta(days=30),
             }
         )
-        for name in ("/tmp/Per.TXT", "/tmp/Ret.TXT"):
-            self.addCleanup(lambda p=name: os.path.exists(p) and os.remove(p))
+        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
         return padron
 
     def _create_santa_fe_padron(self, parp_lines):
@@ -82,6 +80,26 @@ class TestPadronAliquot(common.TransactionCase):
         self.assertEqual(nro, "NRO789")
         self.assertEqual(aliquot_per, "12.50")
         self.assertEqual(aliquot_ret, "7.00")
+
+    def test_arba_different_months_do_not_share_extracted_files(self):
+        """Dos padrones de distinto mes no deben devolver la alícuota del otro."""
+        cuit = "30112223351"
+        padron_1 = self._create_arba_padron(
+            ["f0;f1;f2;NRO-1;%s;f5;f6;f7;11,00" % cuit],
+            ["f0;f1;f2;NRO-1;%s;f5;f6;f7;1,00" % cuit],
+            from_date=self.today,
+            to_date=self.today + relativedelta(days=30),
+        )
+        padron_2 = self._create_arba_padron(
+            ["f0;f1;f2;NRO-2;%s;f5;f6;f7;22,00" % cuit],
+            ["f0;f1;f2;NRO-2;%s;f5;f6;f7;2,00" % cuit],
+            from_date=self.today + relativedelta(months=1),
+            to_date=self.today + relativedelta(months=1, days=30),
+        )
+        partner = self._create_partner(cuit)
+
+        self.assertEqual(padron_1._get_aliquot(partner), ("NRO-1", "1.00", "11.00"))
+        self.assertEqual(padron_2._get_aliquot(partner), ("NRO-2", "2.00", "22.00"))
 
     def test_get_aliquot_caches_by_cuit_and_invalidates_on_write_date(self):
         """Cache hit en la 2da consulta; write_date nuevo invalida la caché."""

--- a/l10n_ar_tax/tests/test_padron_aliquot.py
+++ b/l10n_ar_tax/tests/test_padron_aliquot.py
@@ -1,0 +1,144 @@
+import base64
+import io
+import os
+import shutil
+import zipfile
+from datetime import timedelta
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+from odoo.tests import common
+
+
+class TestPadronAliquot(common.TransactionCase):
+    """Track 1: lookup awk columna exacta + caché por-CUIT + fix re-decode Santa Fe."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.padron_model = cls.env["res.company.jurisdiction.padron"]
+        cls.state_arba = cls.env.ref("base.state_ar_b")
+        cls.state_santa_fe = cls.env.ref("base.state_ar_s")
+        cls.cuit_type = cls.env.ref("l10n_ar.it_cuit")
+        cls.today = cls.env["res.partner"].create({"name": "dummy"}).create_date.date()
+
+    def _create_partner(self, vat):
+        return self.env["res.partner"].create(
+            {
+                "name": "partner_%s" % vat,
+                "l10n_latam_identification_type_id": self.cuit_type.id,
+                "vat": vat,
+            }
+        )
+
+    def _create_arba_padron(self, per_lines, ret_lines):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("Per.TXT", "\n".join(per_lines) + "\n")
+            zip_file.writestr("Ret.TXT", "\n".join(ret_lines) + "\n")
+        padron = self.padron_model.create(
+            {
+                "company_id": self.env.company.id,
+                "state_id": self.state_arba.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "padron_arba.zip",
+                "l10n_ar_padron_from_date": self.today + relativedelta(days=-1),
+                "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
+            }
+        )
+        for name in ("/tmp/Per.TXT", "/tmp/Ret.TXT"):
+            self.addCleanup(lambda p=name: os.path.exists(p) and os.remove(p))
+        return padron
+
+    def _create_santa_fe_padron(self, parp_lines):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("PARP072026.TXT", "\n".join(parp_lines) + "\n")
+        padron = self.padron_model.create(
+            {
+                "company_id": self.env.company.id,
+                "state_id": self.state_santa_fe.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "padron_santafe.zip",
+                "l10n_ar_padron_from_date": self.today + relativedelta(days=-1),
+                "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
+            }
+        )
+        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        return padron
+
+    def test_arba_lookup_matches_exact_column_not_substring(self):
+        """El CUIT decoy es substring de otro campo; awk no debe matchearlo."""
+        cuit = "30112223335"
+        decoy_per = "d0;d1;d2;DECOY;RAZON%sSA;d5;d6;d7;99,99" % cuit
+        real_per = "f0;f1;f2;NRO456;%s;f5;f6;f7;12,50" % cuit
+        decoy_ret = "d0;d1;d2;DECOY;RAZON%sSA;d5;d6;d7;88,88" % cuit
+        real_ret = "f0;f1;f2;NRO789;%s;f5;f6;f7;7,00" % cuit
+        padron = self._create_arba_padron([decoy_per, real_per], [decoy_ret, real_ret])
+        partner = self._create_partner(cuit)
+
+        nro, aliquot_ret, aliquot_per = padron._get_aliquot(partner)
+
+        self.assertEqual(nro, "NRO789")
+        self.assertEqual(aliquot_per, "12.50")
+        self.assertEqual(aliquot_ret, "7.00")
+
+    def test_get_aliquot_caches_by_cuit_and_invalidates_on_write_date(self):
+        """Cache hit en la 2da consulta; write_date nuevo invalida la caché."""
+        cuit = "30112223343"
+        per_line = "f0;f1;f2;NRO456;%s;f5;f6;f7;12,50" % cuit
+        ret_line = "f0;f1;f2;NRO789;%s;f5;f6;f7;7,00" % cuit
+        padron = self._create_arba_padron([per_line], [ret_line])
+        partner = self._create_partner(cuit)
+
+        original_find_aliquot = type(padron).find_aliquot
+        calls = []
+
+        def counting_find_aliquot(self, path, cuit):
+            calls.append(1)
+            return original_find_aliquot(self, path, cuit)
+
+        with patch.object(type(padron), "find_aliquot", counting_find_aliquot):
+            padron._get_aliquot(partner)
+            padron._get_aliquot(partner)
+            self.assertEqual(
+                len(calls), 2, "Segunda consulta del mismo CUIT debe ser cache hit (Per+Ret solo la 1ra vez)"
+            )
+
+            # write() no sirve acá: Odoo memoiza now() por cursor, mismo write_date en la
+            # misma transacción. Simulamos un reload real pisando write_date por SQL.
+            new_write_date = padron.write_date + timedelta(seconds=1)
+            self.env.cr.execute(
+                "UPDATE res_company_jurisdiction_padron SET write_date = %s WHERE id = %s",
+                (new_write_date, padron.id),
+            )
+            padron.invalidate_recordset(["write_date"])
+            padron._get_aliquot(partner)
+            self.assertEqual(len(calls), 4, "write_date nuevo debe invalidar la caché y volver a ejecutar el lookup")
+
+    def test_santa_fe_does_not_redecode_binary_on_second_cuit(self):
+        """El binario se extrae una sola vez, no por cada CUIT consultado."""
+        cuit_a = "20222333440"
+        cuit_b = "20222333459"
+        line_a = "01012026;01012026;31122026; %s ;RI;A;S;5,00;3,00;G1;G2;RAZON A" % cuit_a
+        line_b = "01012026;01012026;31122026; %s ;RI;A;S;7,50;4,25;G1;G2;RAZON B" % cuit_b
+        padron = self._create_santa_fe_padron([line_a, line_b])
+        partner_a = self._create_partner(cuit_a)
+        partner_b = self._create_partner(cuit_b)
+
+        original_descompress = type(padron).descompress_file
+        calls = []
+
+        def counting_descompress(self, file_padron, dest_dir="/tmp"):
+            calls.append(1)
+            return original_descompress(self, file_padron, dest_dir=dest_dir)
+
+        with patch.object(type(padron), "descompress_file", counting_descompress):
+            is_in_padron_a, aliquot_ret_a, aliquot_per_a = padron._get_aliquot(partner_a)
+            is_in_padron_b, aliquot_ret_b, aliquot_per_b = padron._get_aliquot(partner_b)
+
+        self.assertEqual(len(calls), 1, "El binario no debe re-decodificarse/re-unzipearse en la 2da consulta")
+        self.assertTrue(is_in_padron_a)
+        self.assertEqual((aliquot_ret_a, aliquot_per_a), (3.0, 5.0))
+        self.assertTrue(is_in_padron_b)
+        self.assertEqual((aliquot_ret_b, aliquot_per_b), (4.25, 7.5))


### PR DESCRIPTION
## Summary

Mass payments against a partner journal recompute IIBB withholdings/perceptions
per partner. For each partner without a cached `l10n_ar.partner.tax` for the
period, `find_aliquot` (ARBA) and the Santa Fe PARP lookup used to scan the
padron file line by line in Python, once per partner (`O(partners x file
lines)`).

This PR:

- Replaces the Python line scan with an `awk` subprocess lookup, matching the
  CUIT column exactly (`args` as a list, no `shell=True`, `timeout=30`) to
  avoid substring false positives.
- Caches the per-CUIT result with `@tools.ormcache("self.id", "self.write_date",
  "cuit")`. Keying on `write_date` gives natural invalidation: reloading the
  padron file changes it, so the old cache entries stop resolving.
- Fixes Santa Fe re-decoding/re-unzipping the whole binary on every CUIT
  lookup — now it extracts once per padron record and reuses the file.

Functional behavior (aliquot, ref, "not registered" handling) is unchanged;
only the lookup path is faster and cached.

Builds on top of #1499 (stream + single decode quick-wins), same task.

## Test plan

- [x] New tests in `l10n_ar_tax/tests/test_padron_aliquot.py`:
  - ARBA lookup matches the exact column, ignoring a decoy value that
    contains the CUIT as a substring in another field.
  - Same CUIT queried twice is a cache hit; a new `write_date` (simulated via
    direct SQL, since Odoo memoizes `now()` per cursor within one transaction)
    invalidates it and re-runs the lookup.
  - Santa Fe: the binary is decoded/extracted once, not once per CUIT.
- [x] `pre-commit` clean on the changed files.

Task: https://www.adhoc.inc/odoo/project.task/70296