### PR TITLE
[FIX] l10n_ar_tax: read padron zip in memory to avoid stale /tmp aliquots

### DIFF
--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -1,9 +1,6 @@
 import base64
 import io
 import logging
-import os
-import re
-import tempfile
 import zipfile
 
 from odoo import _, api, fields, models
@@ -62,36 +59,6 @@ class ResCompanyJurisdictionPadron(models.Model):
             res += [(padron.id, name)]
         return res
 
-    def descompress_file(self, file_padron):
-        _logger.log(25, "Descompress zip file")
-        ruta_extraccion = "/tmp"
-        try:
-            file = base64.b64decode(file_padron)
-        except:
-            file = base64.decodestring(file_padron)
-        fobj = tempfile.NamedTemporaryFile(delete=False)
-        fname = fobj.name
-        fobj.write(file)
-        fobj.close()
-        f = open(fname, "r+b")
-        f.write(base64.b64decode(file_padron))
-        with zipfile.ZipFile(f, "r") as zip_file:
-            zip_file.extractall(path=ruta_extraccion)
-            zip_file.close()
-
-    def find_aliquot(self, path, cuit):
-        """We try to find aliqut and number for a partner given"""
-        with open(path) as fp:
-            aliq = False
-            nro = False
-            for line in fp.readlines():
-                values = line.split(";")
-                if values[4] == cuit:
-                    aliq = values[8]
-                    nro = values[3]
-                    break
-            return nro, aliq
-
     def _is_santa_fe_jurisdiction(self):
         """Check if jurisdiction is Santa Fe (PARP format)"""
         self.ensure_one()
@@ -124,74 +91,88 @@ class ResCompanyJurisdictionPadron(models.Model):
                 break
         return is_in_padron, aliquot_ret, aliquot_per
 
-    def _find_parp_file(self, rootdir):
+    def _find_parp_member(self, names):
+        """Devuelve el nombre del archivo PARP (.csv/.txt) dentro del ZIP,
+        priorizando el que contenga 'parp'; si no hay, el primer .csv/.txt.
+        """
         fallback_match = False
-        for subdir, dirs, files in os.walk(rootdir):
-            for filename in files:
-                lower_filename = filename.lower()
-                if lower_filename.endswith((".csv", ".txt")):
-                    if "parp" in lower_filename:
-                        return os.path.join(subdir, filename)
-                    if not fallback_match:
-                        fallback_match = os.path.join(subdir, filename)
+        for name in names:
+            lower_name = name.lower()
+            if lower_name.endswith((".csv", ".txt")):
+                if "parp" in lower_name:
+                    return name
+                if not fallback_match:
+                    fallback_match = name
         return fallback_match
 
     def _read_parp_from_binary(self, cuit):
         """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
         or from ZIP if the binary is a ZIP file.
         PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (aliquot_ret, aliquot_per)
+        Returns: (is_in_padron, aliquot_ret, aliquot_per)
         """
         file_content = base64.b64decode(self.file_padron)
-        # is a ZIP file
+        # is a ZIP file: leemos el miembro en memoria, sin extraer a disco
         if self._is_zip_content(file_content):
-            self.descompress_file(self.file_padron)
-            path_file = self._find_parp_file("/tmp/")
-            if not path_file:
-                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
-            with open(path_file, encoding="latin-1") as fp:
-                return self._read_parp_lines(fp.readlines(), cuit)
+            with zipfile.ZipFile(io.BytesIO(file_content)) as zip_file:
+                member = self._find_parp_member(zip_file.namelist())
+                if not member:
+                    raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+                with zip_file.open(member) as parp_file:
+                    lines = io.TextIOWrapper(parp_file, encoding="latin-1").readlines()
+            return self._read_parp_lines(lines, cuit)
 
         # is a CSV file directly
         csv_text = file_content.decode("latin-1")
         return self._read_parp_lines(csv_text.split("\n"), cuit)
 
-    def find_file(self, rootdir, type_code):
-        res = False
-        date = str(self.l10n_ar_padron_from_date.month) + str(self.l10n_ar_padron_from_date.year)
-        pattern = r"%s.{1}|.TXT\Z" % type_code + date
-        for subdir, dirs, files in os.walk(rootdir):
-            for f in files:
-                if re.search(pattern, f):
-                    res = f
-                    break
-        return res
+    def _find_aliquot_in_lines(self, lines, cuit):
+        """Busca el CUIT en las líneas del padrón ARBA (separador ';') y devuelve
+        (nro_comprobante, alícuota) o (False, False) si no figura.
+        Formato ARBA: CUIT en índice 4, nro en índice 3, alícuota en índice 8.
+        """
+        for line in lines:
+            values = line.split(";")
+            if len(values) > 8 and values[4] == cuit:
+                return values[3], values[8]
+        return False, False
+
+    def _get_arba_aliquot_from_zip(self, cuit):
+        """Obtiene (nro, aliquot_ret, aliquot_per) del padrón ARBA leyendo el ZIP
+        ``file_padron`` en memoria.
+
+        Antes se extraía el ZIP a ``/tmp`` y se buscaba el archivo por nombre. Como
+        ``/tmp`` es compartido y persiste entre consultas, podía quedar el padrón
+        de otro período y leerse la alícuota equivocada (p. ej. traer la del mes
+        anterior). Leyendo el ZIP de este registro en memoria eso no puede pasar.
+        """
+        self.ensure_one()
+        nro = False
+        aliquot_ret = False
+        aliquot_per = False
+        file_content = base64.b64decode(self.file_padron)
+        with zipfile.ZipFile(io.BytesIO(file_content)) as zip_file:
+            names = zip_file.namelist()
+            for padron_type in ("Per", "Ret"):
+                member = next((name for name in names if padron_type.lower() in name.lower()), False)
+                if not member:
+                    continue
+                with zip_file.open(member) as member_file:
+                    lines = io.TextIOWrapper(member_file, encoding="latin-1").readlines()
+                member_nro, aliquot = self._find_aliquot_in_lines(lines, cuit)
+                if padron_type == "Per":
+                    aliquot_per = aliquot and aliquot.replace(",", ".")
+                else:
+                    aliquot_ret = aliquot and aliquot.replace(",", ".")
+                if member_nro:
+                    nro = member_nro
+        return nro, aliquot_ret, aliquot_per
 
     def _get_aliquot(self, partner):
-        nro = False
-        aliquot_ret = 0.0
-        aliquot_per = 0.0
-
-        # Check if this is Santa Fe PARP format
+        # Santa Fe usa formato PARP; el resto (ARBA) usa un ZIP con archivos Per/Ret.
         if self._is_santa_fe_jurisdiction():
-            # Read PARP directly from binary field
-            is_in_padron, aliquot_ret, aliquot_per = self._read_parp_from_binary(partner.vat)
-            return is_in_padron, aliquot_ret, aliquot_per
-        else:
-            # Original logic for other padron types (ARBA, etc)
-            padron_types = ["Per", "Ret"]
-            for padron_type in padron_types:
-                path_file = self.find_file("/tmp/", padron_type)
-                if not path_file:
-                    self.descompress_file(self.file_padron)
-                    path_file = self.find_file("/tmp/", padron_type)
-                if path_file:
-                    nro, aliquot = self.find_aliquot("/tmp/" + path_file, partner.vat)
-                    if padron_type == "Per":
-                        aliquot_per = aliquot and aliquot.replace(",", ".")
-                    else:
-                        aliquot_ret = aliquot and aliquot.replace(",", ".")
-        return nro, aliquot_ret, aliquot_per
+            return self._read_parp_from_binary(partner.vat)
+        return self._get_arba_aliquot_from_zip(partner.vat)
 
     @api.model
     def _cron_clean_old_padron_files(self):

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -117,7 +117,7 @@ class ResCompanyJurisdictionPadron(models.Model):
             with zipfile.ZipFile(io.BytesIO(file_content)) as zip_file:
                 member = self._find_parp_member(zip_file.namelist())
                 if not member:
-                    raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+                    raise ValidationError(_("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT."))
                 with zip_file.open(member) as parp_file:
                     lines = io.TextIOWrapper(parp_file, encoding="latin-1").readlines()
             return self._read_parp_lines(lines, cuit)

--- a/l10n_ar_tax/tests/test_arba.py
+++ b/l10n_ar_tax/tests/test_arba.py
@@ -1,4 +1,8 @@
-from odoo.exceptions import UserError
+import base64
+import io
+import zipfile
+
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import common
 
 
@@ -20,3 +24,93 @@ class TestARBA(common.TransactionCase):
         company.vat = ""
         with self.assertRaisesRegex(UserError, "No VAT configured"):
             self.env.company.arba_connect()
+
+    # -- Helpers para tests de lectura de padrón --------------------------------
+
+    def _zip_b64(self, files):
+        """Devuelve un zip (base64) con {nombre: contenido} en memoria."""
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zip_file:
+            for name, content in files.items():
+                zip_file.writestr(name, content)
+        return base64.b64encode(buffer.getvalue())
+
+    def _padron(self, file_b64):
+        """Registro de padrón en memoria (sin persistir) con file_padron seteado."""
+        return self.env["res.company.jurisdiction.padron"].new({"file_padron": file_b64})
+
+    def _arba_line(self, cuit, aliquot, nro="NRO"):
+        # Formato ARBA: nro en índice 3, cuit en índice 4, alícuota en índice 8
+        # (con columnas después, tal como el archivo real; así el índice 8 no
+        # arrastra el salto de línea).
+        return "0;0;0;%s;%s;0;0;0;%s;GRP;RAZON SOCIAL\n" % (nro, cuit, aliquot)
+
+    # -- Tests del fix de lectura de padrón -------------------------------------
+
+    def test_arba_reads_own_zip(self):
+        cuit = "30709328839"
+        padron = self._padron(
+            self._zip_b64(
+                {
+                    "PadronRGSPer072026.txt": self._arba_line(cuit, "0,70"),
+                    "PadronRGSRet072026.txt": self._arba_line(cuit, "0,90"),
+                }
+            )
+        )
+        nro, aliquot_ret, aliquot_per = padron._get_arba_aliquot_from_zip(cuit)
+        self.assertTrue(nro)
+        self.assertEqual(aliquot_ret, "0.90")
+        self.assertEqual(aliquot_per, "0.70")
+
+    def test_arba_no_cross_period_contamination(self):
+        """Leer el padrón de un período no debe devolver la alícuota de otro:
+        la lectura en memoria usa el file_padron del propio registro."""
+        cuit = "30709328839"
+        june = self._padron(
+            self._zip_b64(
+                {
+                    "PadronRGSPer062026.txt": self._arba_line(cuit, "2,50"),
+                    "PadronRGSRet062026.txt": self._arba_line(cuit, "2,50"),
+                }
+            )
+        )
+        july = self._padron(
+            self._zip_b64(
+                {
+                    "PadronRGSPer072026.txt": self._arba_line(cuit, "0,70"),
+                    "PadronRGSRet072026.txt": self._arba_line(cuit, "0,90"),
+                }
+            )
+        )
+        # Consultar junio primero y luego julio: cada uno devuelve lo suyo.
+        june._get_arba_aliquot_from_zip(cuit)
+        nro, aliquot_ret, aliquot_per = july._get_arba_aliquot_from_zip(cuit)
+        self.assertEqual(aliquot_ret, "0.90")
+        self.assertEqual(aliquot_per, "0.70")
+
+    def test_arba_cuit_not_in_padron(self):
+        padron = self._padron(
+            self._zip_b64(
+                {
+                    "PadronRGSPer072026.txt": self._arba_line("20111111112", "0,70"),
+                    "PadronRGSRet072026.txt": self._arba_line("20111111112", "0,90"),
+                }
+            )
+        )
+        nro, aliquot_ret, aliquot_per = padron._get_arba_aliquot_from_zip("30709328839")
+        self.assertFalse(nro)
+
+    def test_santa_fe_reads_zip_in_memory(self):
+        cuit = "30709328839"
+        # Formato PARP: cuit en índice 3, percepción en índice 7, retención en índice 8.
+        line = "0;0;0;%s;0;0;0;1,50;2,00\n" % cuit
+        padron = self._padron(self._zip_b64({"parp_012026.csv": line}))
+        is_in_padron, aliquot_ret, aliquot_per = padron._read_parp_from_binary(cuit)
+        self.assertTrue(is_in_padron)
+        self.assertEqual(aliquot_per, 1.5)
+        self.assertEqual(aliquot_ret, 2.0)
+
+    def test_santa_fe_zip_without_parp_raises(self):
+        padron = self._padron(self._zip_b64({"readme.md": "sin datos"}))
+        with self.assertRaises(ValidationError):
+            padron._read_parp_from_binary("30709328839")


### PR DESCRIPTION
## Problem

The ARBA aliquot lookup (`res.company.jurisdiction.padron`) extracted the padron zip to a shared, hardcoded `/tmp` directory and located the `Per`/`Ret` file with `find_file`. Two defects combined:

- **`find_file` regex was broken:** `r"%s.{1}|.TXT\Z" % type_code + date` appends the month/year (`date`) *after* `\Z`, so the period filter is unreachable dead code. The pattern effectively matched any `Per?`/`Ret?` file regardless of period.
- **`/tmp` is shared and persistent, and the zip was only decompressed when no file was found.** A file left in `/tmp` from a previous period's consultation was matched and read again, and the current record's zip was never extracted.

Result: the aliquot of a previous period could be returned for the current one (e.g. the first payments of the month reading the prior month's rate).

## Fix

Read the record's own `file_padron` zip **in memory** (`io.BytesIO` + `zipfile`), the same approach already used for Santa Fe PARP. A given padron record can now only ever return its own period's aliquot — no shared `/tmp`, no cross-period contamination. Santa Fe reading is also moved fully in-memory.

Removed the now-unused `/tmp` helpers: `find_file`, `find_aliquot`, `descompress_file`, `_find_parp_file` (and the unused `os`, `re`, `tempfile` imports).

## Test plan

- ARBA: a padron record returns the `Per`/`Ret` aliquot of the CUIT present in its own zip; a CUIT not present returns no aliquot (not-inscripto path).
- Regression: two padron records for consecutive periods with different rates for the same CUIT each return their own rate (previously the second read could return the first's rate via `/tmp`).
- Santa Fe (PARP): zip and plain-CSV inputs still resolve the aliquot.
- `pre-commit` (ruff, ruff-format, pylint_odoo) green.
