### PR TITLE
[IMP] l10n_ar_tax: extract each padron ARBA period into its own tmp dir

### DIFF
--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -3,6 +3,7 @@ import io
 import logging
 import os
 import re
+import subprocess
 import tempfile
 import zipfile
 
@@ -10,6 +11,8 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
+
+GREP_TIMEOUT = 30
 
 
 class ResCompanyJurisdictionPadron(models.Model):
@@ -80,16 +83,19 @@ class ResCompanyJurisdictionPadron(models.Model):
 
     def find_aliquot(self, path, cuit):
         """We try to find aliqut and number for a partner given"""
-        with open(path) as fp:
-            aliq = False
-            nro = False
-            for line in fp.readlines():
-                values = line.split(";")
-                if values[4] == cuit:
-                    aliq = values[8]
-                    nro = values[3]
-                    break
-            return nro, aliq
+        # grep -F filtra candidatos en C; el split+comparación exacta abajo
+        # descarta falsos positivos (CUIT como substring de otro campo).
+        result = subprocess.run(
+            ["grep", "-F", cuit, path],
+            capture_output=True,
+            text=True,
+            timeout=GREP_TIMEOUT,
+        )
+        for line in result.stdout.splitlines():
+            values = line.split(";")
+            if len(values) > 8 and values[4] == cuit:
+                return values[3], values[8]
+        return False, False
 
     def _is_santa_fe_jurisdiction(self):
         """Check if jurisdiction is Santa Fe (PARP format)"""
@@ -144,25 +150,38 @@ class ResCompanyJurisdictionPadron(models.Model):
             self.l10n_ar_padron_to_date,
         )
 
+    def _ensure_parp_file_extracted(self):
+        # Extrae/persiste una sola vez y reutiliza (antes se re-decodificaba/re-unzipeaba por CUIT).
+        self.ensure_one()
+        tmp_dir = self._get_parp_tmp_dir()
+        path_file = self._find_parp_file(tmp_dir)
+        if path_file:
+            return path_file
+
+        file_content = base64.b64decode(self.file_padron)
+        if self._is_zip_content(file_content):
+            self.descompress_file(self.file_padron, dest_dir=tmp_dir)
+            path_file = self._find_parp_file(tmp_dir)
+            if not path_file:
+                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+            return path_file
+
+        # CSV directo (no ZIP): lo persistimos para no re-decodificar cada vez.
+        os.makedirs(tmp_dir, exist_ok=True)
+        path_file = os.path.join(tmp_dir, "padron.csv")
+        with open(path_file, "w", encoding="latin-1") as fp:
+            fp.write(file_content.decode("latin-1"))
+        return path_file
+
     def _read_parp_from_binary(self, cuit):
         """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
         or from ZIP if the binary is a ZIP file.
         PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
         Returns: (aliquot_ret, aliquot_per)
         """
-        file_content = base64.b64decode(self.file_padron)
-        # is a ZIP file
-        if self._is_zip_content(file_content):
-            self.descompress_file(self.file_padron)
-            path_file = self._find_parp_file("/tmp/")
-            if not path_file:
-                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
-            with open(path_file, encoding="latin-1") as fp:
-                return self._read_parp_lines(fp.readlines(), cuit)
-
-        # is a CSV file directly
-        csv_text = file_content.decode("latin-1")
-        return self._read_parp_lines(csv_text.split("\n"), cuit)
+        path_file = self._ensure_parp_file_extracted()
+        with open(path_file, encoding="latin-1") as fp:
+            return self._read_parp_lines(fp.readlines(), cuit)
 
     def find_file(self, rootdir, type_code):
         res = False

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -62,9 +62,8 @@ class ResCompanyJurisdictionPadron(models.Model):
             res += [(padron.id, name)]
         return res
 
-    def descompress_file(self, file_padron):
+    def descompress_file(self, file_padron, dest_dir="/tmp"):
         _logger.log(25, "Descompress zip file")
-        ruta_extraccion = "/tmp"
         try:
             file = base64.b64decode(file_padron)
         except:
@@ -76,7 +75,7 @@ class ResCompanyJurisdictionPadron(models.Model):
         f = open(fname, "r+b")
         f.write(base64.b64decode(file_padron))
         with zipfile.ZipFile(f, "r") as zip_file:
-            zip_file.extractall(path=ruta_extraccion)
+            zip_file.extractall(path=dest_dir)
             zip_file.close()
 
     def find_aliquot(self, path, cuit):
@@ -136,6 +135,15 @@ class ResCompanyJurisdictionPadron(models.Model):
                         fallback_match = os.path.join(subdir, filename)
         return fallback_match
 
+    def _get_parp_tmp_dir(self):
+        # Dir por padron+periodo: no mezcla archivos de otro mes.
+        self.ensure_one()
+        return "/tmp/l10n_ar_padron_%s_%s_%s" % (
+            self.id,
+            self.l10n_ar_padron_from_date,
+            self.l10n_ar_padron_to_date,
+        )
+
     def _read_parp_from_binary(self, cuit):
         """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
         or from ZIP if the binary is a ZIP file.
@@ -179,14 +187,15 @@ class ResCompanyJurisdictionPadron(models.Model):
             return is_in_padron, aliquot_ret, aliquot_per
         else:
             # Original logic for other padron types (ARBA, etc)
+            tmp_dir = self._get_parp_tmp_dir()
             padron_types = ["Per", "Ret"]
             for padron_type in padron_types:
-                path_file = self.find_file("/tmp/", padron_type)
+                path_file = self.find_file(tmp_dir, padron_type)
                 if not path_file:
-                    self.descompress_file(self.file_padron)
-                    path_file = self.find_file("/tmp/", padron_type)
+                    self.descompress_file(self.file_padron, dest_dir=tmp_dir)
+                    path_file = self.find_file(tmp_dir, padron_type)
                 if path_file:
-                    nro, aliquot = self.find_aliquot("/tmp/" + path_file, partner.vat)
+                    nro, aliquot = self.find_aliquot(os.path.join(tmp_dir, path_file), partner.vat)
                     if padron_type == "Per":
                         aliquot_per = aliquot and aliquot.replace(",", ".")
                     else:

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import test_arba
 from . import test_padron_cleanup_cron
+from . import test_padron_tmp_dir
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_kept_on_post
 from . import test_payment_withholding_validation

--- a/l10n_ar_tax/tests/test_padron_tmp_dir.py
+++ b/l10n_ar_tax/tests/test_padron_tmp_dir.py
@@ -1,0 +1,65 @@
+import base64
+import io
+import shutil
+import zipfile
+
+from dateutil.relativedelta import relativedelta
+from odoo.tests import common
+
+
+class TestPadronTmpDir(common.TransactionCase):
+    """Padron ARBA extraido a un dir por periodo, no a /tmp compartido."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.padron_model = cls.env["res.company.jurisdiction.padron"]
+        cls.state_arba = cls.env.ref("base.state_ar_b")
+        cls.cuit_type = cls.env.ref("l10n_ar.it_cuit")
+        cls.today = cls.env["res.partner"].create({"name": "dummy"}).create_date.date()
+
+    def _create_partner(self, vat):
+        return self.env["res.partner"].create(
+            {"name": "partner_%s" % vat, "l10n_latam_identification_type_id": self.cuit_type.id, "vat": vat}
+        )
+
+    def _line(self, nro, cuit, aliq):
+        return "f0;f1;f2;%s;%s;f5;f6;f7;%s" % (nro, cuit, aliq)
+
+    def _create_arba_padron(self, per_lines, ret_lines, from_date, to_date):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("Per.TXT", "\n".join(per_lines) + "\n")
+            zip_file.writestr("Ret.TXT", "\n".join(ret_lines) + "\n")
+        padron = self.padron_model.create(
+            {
+                "company_id": self.env.company.id,
+                "state_id": self.state_arba.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "padron_arba.zip",
+                "l10n_ar_padron_from_date": from_date,
+                "l10n_ar_padron_to_date": to_date,
+            }
+        )
+        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        return padron
+
+    def test_arba_different_months_do_not_share_extracted_files(self):
+        """Dos padrones de distinto mes no deben devolver la alícuota del otro."""
+        cuit = "30112223351"
+        padron_1 = self._create_arba_padron(
+            [self._line("NRO-1", cuit, "11,00")],
+            [self._line("NRO-1", cuit, "1,00")],
+            self.today,
+            self.today + relativedelta(days=30),
+        )
+        padron_2 = self._create_arba_padron(
+            [self._line("NRO-2", cuit, "22,00")],
+            [self._line("NRO-2", cuit, "2,00")],
+            self.today + relativedelta(months=1),
+            self.today + relativedelta(months=1, days=30),
+        )
+        partner = self._create_partner(cuit)
+
+        self.assertEqual(padron_1._get_aliquot(partner), ("NRO-1", "1.00", "11.00"))
+        self.assertEqual(padron_2._get_aliquot(partner), ("NRO-2", "2.00", "22.00"))

--- a/l10n_ar_tax/tests/test_padron_tmp_dir.py
+++ b/l10n_ar_tax/tests/test_padron_tmp_dir.py
@@ -1,7 +1,9 @@
 import base64
 import io
 import shutil
+import tempfile
 import zipfile
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
 from odoo.tests import common
@@ -15,6 +17,7 @@ class TestPadronTmpDir(common.TransactionCase):
         super().setUpClass()
         cls.padron_model = cls.env["res.company.jurisdiction.padron"]
         cls.state_arba = cls.env.ref("base.state_ar_b")
+        cls.state_santa_fe = cls.env.ref("base.state_ar_s")
         cls.cuit_type = cls.env.ref("l10n_ar.it_cuit")
         cls.today = cls.env["res.partner"].create({"name": "dummy"}).create_date.date()
 
@@ -25,6 +28,9 @@ class TestPadronTmpDir(common.TransactionCase):
 
     def _line(self, nro, cuit, aliq):
         return "f0;f1;f2;%s;%s;f5;f6;f7;%s" % (nro, cuit, aliq)
+
+    def _parp_line(self, cuit, per, ret):
+        return "d0;d1;d2;%s;d4;d5;d6;%s;%s" % (cuit, per, ret)
 
     def _create_arba_padron(self, per_lines, ret_lines, from_date, to_date):
         buffer = io.BytesIO()
@@ -39,6 +45,23 @@ class TestPadronTmpDir(common.TransactionCase):
                 "filename": "padron_arba.zip",
                 "l10n_ar_padron_from_date": from_date,
                 "l10n_ar_padron_to_date": to_date,
+            }
+        )
+        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        return padron
+
+    def _create_santa_fe_padron(self, lines):
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("PARP.TXT", "\n".join(lines) + "\n")
+        padron = self.padron_model.create(
+            {
+                "company_id": self.env.company.id,
+                "state_id": self.state_santa_fe.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "padron_santafe.zip",
+                "l10n_ar_padron_from_date": self.today,
+                "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
             }
         )
         self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
@@ -63,3 +86,41 @@ class TestPadronTmpDir(common.TransactionCase):
 
         self.assertEqual(padron_1._get_aliquot(partner), ("NRO-1", "1.00", "11.00"))
         self.assertEqual(padron_2._get_aliquot(partner), ("NRO-2", "2.00", "22.00"))
+
+    def test_santa_fe_does_not_redecode_binary_on_second_cuit(self):
+        """El binario se extrae una sola vez, no por cada CUIT consultado."""
+        cuit_a, cuit_b = "20222333440", "20222333459"
+        padron = self._create_santa_fe_padron(
+            [self._parp_line(cuit_a, "5,00", "3,00"), self._parp_line(cuit_b, "7,50", "4,25")]
+        )
+        partner_a = self._create_partner(cuit_a)
+        partner_b = self._create_partner(cuit_b)
+
+        calls = []
+        original = type(padron).descompress_file
+
+        def counting(self, file_padron, dest_dir="/tmp"):
+            calls.append(1)
+            return original(self, file_padron, dest_dir=dest_dir)
+
+        with patch.object(type(padron), "descompress_file", counting):
+            result_a = padron._get_aliquot(partner_a)
+            result_b = padron._get_aliquot(partner_b)
+
+        self.assertEqual(len(calls), 1, "no debe re-decodificar/re-unzipear en la 2da consulta")
+        self.assertEqual(result_a, (True, 3.0, 5.0))
+        self.assertEqual(result_b, (True, 4.25, 7.5))
+
+    def test_find_aliquot_ignores_substring_match(self):
+        """El CUIT aparece embebido en otro campo en la 1ra linea; debe matchear la exacta."""
+        cuit = "30112223335"
+        content = "%s\n%s\n" % (
+            self._line("DECOY", "RAZON%sSA" % cuit, "99,99"),
+            self._line("NRO789", cuit, "7,00"),
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".txt") as f:
+            f.write(content)
+            f.flush()
+            nro, aliq = self.padron_model.find_aliquot(f.name, cuit)
+
+        self.assertEqual((nro, aliq), ("NRO789", "7,00"))


### PR DESCRIPTION
## Summary

Split out from #1515 (per feedback): this PR is the structural/perf fix
for the per-CUIT padron lookup, without the ormcache-based cache and
without the awk lookup from that PR.

Two commits:

1. **`[IMP] extract each padron ARBA period into its own tmp dir`** —
   correctness fix. `_get_aliquot` extracted the ARBA padron to a shared
   `/tmp/`, with no distinction by period. With several padron records
   loaded (one per month, common in real installs), a payment computed
   for a different month could end up reading the already-extracted
   files of another month (the loose filename-matching regex in
   `find_file` doesn't reliably disambiguate by date). Now ARBA extracts
   into a directory scoped by `(padron.id, from_date, to_date)`.

2. **`[PERF] faster ARBA/Santa Fe aliquot lookup (grep + no re-decode)`** —
   two independent perf fixes, bundled together since both are pure
   performance work on top of commit 1:
   - ARBA: `find_aliquot` scanned the padron file line by line in
     Python. Replaced with `grep -F` to pre-filter candidates at C
     level; the exact column comparison still happens in Python
     afterwards, to discard false positives (a CUIT appearing as a
     substring of another field, e.g. razón social) — `grep`'s matches
     are only candidates, not the final answer.
   - Santa Fe: `_read_parp_from_binary` re-decoded the base64 and
     re-unzipped the whole binary on **every single CUIT lookup**,
     worse than ARBA (which at least reused the file already extracted
     to `/tmp`). Now it extracts/persists the file once per padron
     (reusing the tmp dir from commit 1) and reuses it on subsequent
     calls.

Functional behavior (aliquot, ref, "not registered" handling) is
unchanged in both commits.

## Real-world measurement

Measured directly against the real ARBA padron (Buenos Aires, current
period) on a client's test database, computing the aliquot for 30 new
partners (first-touch, the case that dominates a mass payment):

| | Pass 1 (30 partners nuevos) | Pass 2 (mismos 30, repetido) |
|---|---|---|
| **Sin este PR** | 123.64s total, 4.121s/partner | 119.72s total, 3.991s/partner |
| **Con este PR** | 11.88s total, 0.396s/partner | 8.26s total, 0.275s/partner |

~10x on first touch. Pass 2 is faster than Pass 1 because the file is
already extracted (commit 1) — no re-decompression, just `grep`.

## Test plan

- [x] Tests in `l10n_ar_tax/tests/test_padron_tmp_dir.py`:
  - Two ARBA padron records for different months return their own
    aliquot for the same CUIT (no cross-month mixing).
  - `find_aliquot` ignores a CUIT that appears as a substring of
    another field, matching only the exact column.
  - Santa Fe: the binary is decoded/extracted once, not once per CUIT.
- [x] `pre-commit` clean on the changed files.
- [x] Real-world benchmark on client data (see above).

Task: https://www.adhoc.inc/odoo/project.task/70296