### PR TITLE
[ADD] l10n_ar_tax_neuquen: IIBB base minimum evaluated per invoice for Neuquen

### DIFF
--- a/l10n_ar_tax_neuquen/README.rst
+++ b/l10n_ar_tax_neuquen/README.rst
@@ -1,0 +1,92 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===========================================
+Argentinean Withholding Minimum for Neuquén
+===========================================
+
+Este módulo implementa:
+
+* Para las retenciones de Ingresos Brutos cuya jurisdicción (``Jurisdiction`` /
+  ``l10n_ar_state_id``) es **Neuquén**, el mínimo sujeto a retención (campo
+  **Minimum Base** / ``l10n_ar_base_minimum_threshold``) se evalúa **por comprobante**:
+  se compara contra la base imponible de **cada factura**, no contra la suma de las
+  bases de todas las facturas del pago.
+
+* Cuando un pago cancela **2 o más facturas**, el cálculo nativo suma todas las bases
+  en una sola y compara ese total contra el mínimo. Este módulo, solo para Neuquén,
+  retiene únicamente sobre las facturas cuya base imponible individual supera el
+  mínimo, y deja fuera las que no lo alcanzan.
+
+* En un **pago parcial** de una factura que supera el mínimo, se retiene sobre la base
+  proporcional al importe pagado (prorrateo). El gate de base nativo anularía esa
+  retención cuando el proporcional queda por debajo del mínimo; para Neuquén no se
+  anula, porque la factura sí supera el mínimo (misma lógica que aplica ganancias).
+
+* Refleja lo dispuesto por la Res. Gral. 276/DPR/17 (art. 10): el importe mínimo
+  sujeto a retención debe analizarse sobre la base imponible correspondiente a cada
+  comprobante. La base comparada es el neto para impuestos *IIBB Untaxed* (IVA
+  discriminado) y el total para *IIBB Total Amount* (IVA no discriminado).
+
+* Aplica **solo** cuando la jurisdicción del impuesto es Neuquén. Para el resto de las
+  jurisdicciones el comportamiento no cambia.
+
+* En las retenciones de Neuquén se completa el campo *Ref* con el detalle del cálculo
+  del importe retenido (base * alícuota = importe), tal como lo hace ganancias. Para
+  IIBB el estándar deja ese campo vacío.
+
+* Aplica a facturas. Los adelantos puros (pagos sin comprobante asociado) mantienen el
+  comportamiento nativo.
+
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Definir en el impuesto de retención de IIBB la jurisdicción **Neuquén**
+   (campo *Jurisdiction*).
+#. Cargar el mínimo en el campo *Minimum Base* (``l10n_ar_base_minimum_threshold``).
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_tax_neuquen/__init__.py
+++ b/l10n_ar_tax_neuquen/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_tax_neuquen/__manifest__.py
+++ b/l10n_ar_tax_neuquen/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Argentinean Withholding Minimum for Neuquén",
+    "version": "18.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Evaluate the IIBB withholding base minimum per invoice (not on the summed base) for Neuquén",
+    "depends": ["l10n_ar_tax"],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/l10n_ar_tax_neuquen/models/__init__.py
+++ b/l10n_ar_tax_neuquen/models/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_ar_payment_withholding

--- a/l10n_ar_tax_neuquen/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_tax_neuquen/models/l10n_ar_payment_withholding.py
@@ -1,0 +1,100 @@
+from odoo import models
+
+
+class L10nArPaymentWithholding(models.Model):
+    _inherit = "l10n_ar.payment.withholding"
+
+    def _compute_base_amount(self):
+        """Neuquén evalúa el mínimo sujeto a retención de IIBB por comprobante: el mínimo
+        (campo "Minimum Base" / ``l10n_ar_base_minimum_threshold``) se compara contra el
+        neto de CADA factura, no contra la suma de las bases (Res. Gral. 276/DPR/17,
+        art. 10).
+
+        El cálculo nativo suma las bases de todas las facturas del pago en un único
+        ``base_amount`` y compara ese total contra el mínimo. Para Neuquén quitamos de
+        ``base_amount`` la contribución de las facturas cuya base imponible completa no
+        supera el mínimo, de modo que solo se retenga sobre las que sí lo superan. Los
+        pagos de una sola factura quedan idénticos al comportamiento nativo.
+
+        La base imponible que se compara es el neto para impuestos ``iibb_untaxed`` (IVA
+        discriminado) y el total para ``iibb_total`` (IVA no discriminado), en línea con
+        cómo ``base_amount`` construye la base.
+        """
+        super()._compute_base_amount()
+        neuquen = self.env.ref("base.state_ar_q", raise_if_not_found=False)
+        if not neuquen:
+            return
+        for wth in self.filtered(lambda x: x.partner_type == "supplier" and x._l10n_ar_is_neuquen_iibb()):
+            tax = wth._get_withholding_tax()
+            threshold = tax.l10n_ar_base_minimum_threshold
+            is_total = tax.l10n_ar_tax_type == "iibb_total"
+            sign = -1.0 if wth.partner_type == "supplier" else 1.0
+            excluded = 0.0
+            for line in wth.payment_id.to_pay_move_line_ids._origin:
+                invoice = line.move_id
+                if not invoice or not invoice.is_invoice():
+                    continue
+                # Base imponible COMPLETA de la factura para comparar con el mínimo.
+                invoice_base = abs(invoice.amount_total_signed if is_total else invoice.amount_untaxed_signed)
+                if invoice_base > threshold:
+                    continue
+                # La factura no supera el mínimo: quitamos su aporte a base_amount (mismo
+                # factor y signo con que _compute_selected_debt_untaxed lo sumó).
+                factor = 1.0 if is_total else (invoice._get_tax_factor() or 1.0)
+                excluded += line.amount_residual * factor * sign
+            wth.base_amount -= excluded
+
+    def _tax_compute_all_helper(self):
+        """Para Neuquén: retención sobre la base ya calificada incluso en pagos parciales,
+        y detalle del cálculo en ``ref`` (como ganancias).
+
+        Tras ``_compute_base_amount``, ``base_amount`` contiene solo las facturas cuya
+        base imponible supera el mínimo. En un pago parcial esa base es proporcional al
+        importe pagado y puede quedar por debajo del mínimo, con lo que el gate de base
+        nativo la anularía. Como la calificación ya se resolvió por comprobante, en
+        Neuquén retenemos sobre esa base (prorrateada) en lugar de anularla — igual que
+        hace ganancias con su lógica propia. Además, se completa ``ref`` con el cálculo
+        del importe retenido (para IIBB el nativo lo deja vacío)."""
+        tax_amount, tax_account_id, tax_repartition_line_id, ref = super()._tax_compute_all_helper()
+        if not self._l10n_ar_is_neuquen_iibb():
+            return tax_amount, tax_account_id, tax_repartition_line_id, ref
+        tax = self._get_withholding_tax()
+        # Intervención de pago parcial: el nativo anuló (tax_amount 0) habiendo base
+        # calificada (>0) proveniente de facturas → retenemos prorrateado. Los adelantos
+        # puros (sin factura) y el gate por monto de pago mantienen el comportamiento nativo.
+        invoices = self.payment_id.to_pay_move_line_ids.move_id.filtered(lambda m: m.is_invoice())
+        payment_gate_blocks = (
+            tax.l10n_ar_payment_minimum_threshold
+            and self.payment_id.to_pay_amount <= tax.l10n_ar_payment_minimum_threshold
+        )
+        if not tax_amount and invoices and self.base_amount and not payment_gate_blocks:
+            taxes_res = tax.compute_all(
+                self.base_amount,
+                currency=self.payment_id.currency_id,
+                quantity=1.0,
+                product=False,
+                partner=False,
+                is_refund=False,
+            )
+            tax_amount = self.currency_id.round(taxes_res["total_included"] - taxes_res["total_excluded"])
+            # Conservamos el gate de importe mínimo calculado.
+            if tax.l10n_ar_minimum_threshold > tax_amount:
+                tax_amount = 0.0
+        # Detalle del cálculo en ref (solo cuando corresponde retener).
+        if tax_amount:
+            f = self.currency_id.format
+            ref = f"{f(self.base_amount)} * {tax.amount}% = {f(tax_amount)}"
+        return tax_amount, tax_account_id, tax_repartition_line_id, ref
+
+    def _l10n_ar_is_neuquen_iibb(self):
+        """True si la línea es una retención de IIBB (untaxed/total) de jurisdicción
+        Neuquén con mínimo por base configurado."""
+        self.ensure_one()
+        neuquen = self.env.ref("base.state_ar_q", raise_if_not_found=False)
+        tax = self._get_withholding_tax()
+        return bool(
+            neuquen
+            and tax.l10n_ar_state_id == neuquen
+            and tax.l10n_ar_base_minimum_threshold
+            and tax.l10n_ar_tax_type in ("iibb_untaxed", "iibb_total")
+        )

--- a/l10n_ar_tax_neuquen/tests/__init__.py
+++ b/l10n_ar_tax_neuquen/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_neuquen_minimum

--- a/l10n_ar_tax_neuquen/tests/test_neuquen_minimum.py
+++ b/l10n_ar_tax_neuquen/tests/test_neuquen_minimum.py
@@ -1,0 +1,159 @@
+from odoo import Command
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
+from odoo.tests import tagged
+
+
+@tagged("-at_install", "post_install")
+class TestNeuquenMinimum(TestArWithholdingArRi):
+    """Tests de aceptación del mínimo sujeto a retención de IIBB Neuquén.
+
+    En Neuquén el mínimo (campo "Minimum Base" / ``l10n_ar_base_minimum_threshold``) se
+    evalúa por comprobante: se compara contra el neto de CADA factura, no contra la suma
+    de las bases (Res. Gral. 276/DPR/17, art. 10). El módulo solo cambia el caso de pago
+    de 2+ facturas; los pagos de una sola factura quedan como el comportamiento nativo.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.neuquen = cls.env.ref("base.state_ar_q")
+        cls.wth_seq_nqn = cls.env["ir.sequence"].create(
+            {"implementation": "standard", "name": "wth neuquen test", "padding": 8, "number_increment": 1}
+        )
+        cls.tax_iibb_nqn = cls.tax_wth_test_1.copy(
+            default={
+                "name": "IIBB Neuquén 2%",
+                "amount": 2,
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_state_id": cls.neuquen.id,
+                "l10n_ar_withholding_sequence_id": cls.wth_seq_nqn.id,
+                "l10n_ar_non_taxable_amount": 0,
+                "l10n_ar_payment_minimum_threshold": 0,
+                "l10n_ar_base_minimum_threshold": 300000,
+                "l10n_ar_minimum_threshold": 0,
+            }
+        )
+        # Control: misma config pero sin jurisdicción Neuquén
+        cls.tax_iibb_no_nqn = cls.tax_iibb_nqn.copy(
+            default={"name": "IIBB Otra Jurisdicción 2%", "l10n_ar_state_id": False}
+        )
+
+    def _make_vendor_invoice(self, price_unit, doc_number):
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "date": "2023-01-01",
+                "invoice_date": "2023-01-01",
+                "partner_id": self.res_partner_adhoc.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product_a.id,
+                            "price_unit": price_unit,
+                            "tax_ids": [Command.set(self.tax_21.ids)],
+                        }
+                    )
+                ],
+                "l10n_latam_document_number": doc_number,
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _withholding_for(self, invoices, tax):
+        """Crea un pago que cancela `invoices` y su línea de retención `tax`, dejando que
+        base_amount se calcule desde to_pay_move_line_ids (sin fijarlo a mano)."""
+        payable_lines = invoices.line_ids.filtered(lambda l: l.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": invoices[0].partner_id.id,
+                "amount": sum(invoices.mapped("amount_total")),
+                "date": "2023-01-01",
+                "journal_id": self.company_data["default_journal_bank"].id,
+            }
+        )
+        payment.to_pay_move_line_ids = [Command.set(payable_lines.ids)]
+        wth = self.env["l10n_ar.payment.withholding"].create({"payment_id": payment.id, "tax_id": tax.id})
+        return wth
+
+    # ─── Caso 3: pago de 2+ facturas → mínimo por factura, no sobre la suma ─────
+
+    def test_01_neuquen_two_invoices_min_per_invoice(self):
+        """Factura A neto 250.000 (< 300.000) + Factura B neto 350.000 (> 300.000),
+        pagadas juntas. Nativo sumaría (600.000 > 300.000 → retiene sobre todo). En
+        Neuquén solo se retiene sobre B: base 350.000, 2% = 7.000."""
+        inv_a = self._make_vendor_invoice(250000.0, "6-11")
+        inv_b = self._make_vendor_invoice(350000.0, "6-12")
+        wth = self._withholding_for(inv_a + inv_b, self.tax_iibb_nqn)
+        self.assertEqual(wth.base_amount, 350000.0, "Base = solo el neto de la factura que supera el mínimo")
+        self.assertEqual(wth.amount, 7000.0, "2% de 350.000 = 7.000 (sin sumar la factura de 250.000)")
+
+    def test_02_neuquen_two_invoices_both_below(self):
+        """Dos facturas, ambas por debajo del mínimo (250.000 y 280.000) → no retiene,
+        aunque la suma (530.000) supere el mínimo."""
+        inv_a = self._make_vendor_invoice(250000.0, "6-21")
+        inv_b = self._make_vendor_invoice(280000.0, "6-22")
+        wth = self._withholding_for(inv_a + inv_b, self.tax_iibb_nqn)
+        self.assertEqual(wth.base_amount, 0.0)
+        self.assertEqual(wth.amount, 0.0, "Ninguna factura supera el mínimo → sin retención")
+
+    def test_03_neuquen_two_invoices_both_above(self):
+        """Dos facturas, ambas por encima del mínimo (350.000 y 400.000) → retiene sobre
+        la suma de ambas: base 750.000, 2% = 15.000."""
+        inv_a = self._make_vendor_invoice(350000.0, "6-31")
+        inv_b = self._make_vendor_invoice(400000.0, "6-32")
+        wth = self._withholding_for(inv_a + inv_b, self.tax_iibb_nqn)
+        self.assertEqual(wth.base_amount, 750000.0)
+        self.assertEqual(wth.amount, 15000.0)
+
+    # ─── Factura única: se mantiene el comportamiento nativo ───────────────────
+
+    def test_04_neuquen_single_invoice_below(self):
+        """Una factura neto 250.000 < 300.000 → no retiene (igual que nativo)."""
+        inv = self._make_vendor_invoice(250000.0, "5-4")
+        wth = self._withholding_for(inv, self.tax_iibb_nqn)
+        self.assertEqual(wth.amount, 0.0)
+
+    def test_05_neuquen_single_invoice_above(self):
+        """Una factura neto 350.000 > 300.000 → retiene 2% = 7.000 (igual que nativo)."""
+        inv = self._make_vendor_invoice(350000.0, "5-5")
+        wth = self._withholding_for(inv, self.tax_iibb_nqn)
+        self.assertEqual(wth.base_amount, 350000.0)
+        self.assertEqual(wth.amount, 7000.0)
+        # El campo ref muestra el cálculo del importe retenido (como ganancias).
+        self.assertTrue(wth.ref, "ref debe mostrar el cálculo de la retención")
+        self.assertIn("2.0%", wth.ref)
+
+    # ─── Control: sin Neuquén se suman las bases (comportamiento nativo) ───────
+
+    def test_06_non_neuquen_sums_bases(self):
+        """Mismas dos facturas (250.000 + 350.000) con jurisdicción distinta de Neuquén:
+        el nativo suma las bases (600.000 > 300.000) y retiene sobre el total: 2% = 12.000."""
+        inv_a = self._make_vendor_invoice(250000.0, "6-61")
+        inv_b = self._make_vendor_invoice(350000.0, "6-62")
+        wth = self._withholding_for(inv_a + inv_b, self.tax_iibb_no_nqn)
+        self.assertEqual(wth.base_amount, 600000.0)
+        self.assertEqual(wth.amount, 12000.0)
+
+    # ─── Pago parcial de una factura que supera el mínimo → prorrateo ──────────
+
+    def test_07_neuquen_partial_payment_qualifying_prorates(self):
+        """Pago parcial (50%) de una factura de neto 350.000 (> mínimo). La base baja al
+        proporcional (175.000, < mínimo), pero como la factura supera el mínimo se
+        retiene prorrateado: 2% de 175.000 = 3.500 (el nativo lo anularía)."""
+        inv = self._make_vendor_invoice(350000.0, "6-71")
+        wth = self._withholding_for(inv, self.tax_iibb_nqn)
+        wth.base_amount = 175000.0  # base proporcional de un pago del 50%
+        wth._compute_amount()
+        self.assertEqual(wth.amount, 3500.0, "Prorrateo: 2% de 175.000 = 3.500")
+
+    def test_08_non_neuquen_partial_payment_blocks(self):
+        """Mismo escenario con jurisdicción distinta de Neuquén: el gate de base nativo
+        anula la retención (175.000 <= 300.000) → 0."""
+        inv = self._make_vendor_invoice(350000.0, "6-81")
+        wth = self._withholding_for(inv, self.tax_iibb_no_nqn)
+        wth.base_amount = 175000.0
+        wth._compute_amount()
+        self.assertEqual(wth.amount, 0.0)


### PR DESCRIPTION
## Qué

Nuevo módulo `l10n_ar_tax_neuquen`. Para las retenciones de IIBB cuya jurisdicción (`l10n_ar_state_id`) es Neuquén, el mínimo sujeto a retención (campo *Minimum Base* / `l10n_ar_base_minimum_threshold`) se evalúa **por comprobante**, no sobre la suma de las bases del pago (Res. Gral. 276/DPR/17, art. 10).

## Por qué

Casos que el cálculo nativo resuelve mal para Neuquén:

- **Pago de 2+ facturas**: el nativo suma todas las bases y compara ese total contra el mínimo, reteniendo sobre todo aunque alguna factura no supere el mínimo. Debe compararse el neto de cada factura por separado.
- **Pago parcial de una factura que supera el mínimo**: el nativo baja la base al proporcional y el gate de base la anula cuando ese proporcional queda por debajo del mínimo. Debe retenerse prorrateado (igual que hace ganancias con su lógica propia).

## Cómo

- `_compute_base_amount`: quita de `base_amount` la contribución de las facturas cuya base imponible individual no supera el mínimo (neto para `iibb_untaxed`, total para `iibb_total`).
- `_tax_compute_all_helper`: si el nativo anuló la retención habiendo base calificada de facturas (pago parcial), la recompone sobre la base proporcional. Respeta el gate por monto de pago y el de importe mínimo. Además completa el campo *Ref* con el detalle del cálculo del importe retenido (base * alícuota = importe), como ganancias (para IIBB el estándar lo deja vacío).
- No modifica el módulo base `l10n_ar_tax`. Facturas únicas full-payment y adelantos puros mantienen el comportamiento nativo. Aplica solo a jurisdicción Neuquén.

## Tests (8)

- Multi-factura: mínimo por factura (250k+350k → retiene solo 350k; ambas <min → 0; ambas >min → suma).
- Factura única (<min → 0; >min → retiene) = nativo.
- Pago parcial de factura >min → prorratea (175k → 3.500).
- Ref con el detalle del cálculo.
- Controles sin jurisdicción Neuquén (suma bases / gate nativo anula).

## Relacionado

La limpieza de la línea de retención en importe 0 (comportamiento nativo, todas las provincias) va en un PR aparte sobre `l10n_ar_tax` (#1524).

Task 70313

Reemplaza al PR #1501 (cerrado).