### PR TITLE
[IMP] l10n_ar_tax: add "IVA" withholding tax type

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -928,6 +928,11 @@ msgid "ID"
 msgstr "ID (identificación)"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__l10n_ar_tax_type__iva
+msgid "IVA"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,help:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid ""
@@ -1437,6 +1442,7 @@ msgid "WTH Sequence"
 msgstr "Secuencia de Retención"
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_tax_type
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__l10n_ar_tax_type
 msgid "WTH Tax"
 msgstr "Impuesto de Retencion"

--- a/l10n_ar_tax/i18n/l10n_ar_tax.pot
+++ b/l10n_ar_tax/i18n/l10n_ar_tax.pot
@@ -890,6 +890,11 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields.selection,name:l10n_ar_tax.selection__account_tax__l10n_ar_tax_type__iva
+msgid "IVA"
+msgstr ""
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_withholding_sequence_id
 #: model:ir.model.fields,help:l10n_ar_tax.field_l10n_ar_payment_withholding__withholding_sequence_id
 msgid ""
@@ -1381,6 +1386,7 @@ msgid "WTH Sequence"
 msgstr ""
 
 #. module: l10n_ar_tax
+#: model:ir.model.fields,field_description:l10n_ar_tax.field_account_tax__l10n_ar_tax_type
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__l10n_ar_tax_type
 msgid "WTH Tax"
 msgstr ""

--- a/l10n_ar_tax/models/account_chart_template.py
+++ b/l10n_ar_tax/models/account_chart_template.py
@@ -5,7 +5,7 @@
 import logging
 import re
 
-from odoo import Command, api, models
+from odoo import api, models
 
 _logger = logging.getLogger(__name__)
 
@@ -15,7 +15,16 @@ class AccountChartTemplate(models.AbstractModel):
 
     @api.model
     def _add_wh_taxes(self, company):
-        """Agregamos etiquetas en repartition lines de impuestos de percepciones de iva, ganancias e ingresos brutos."""
+        """Completa la configuración de percepciones y retenciones que el plan de cuentas no trae.
+
+        Sobre los impuestos recién creados para la compañía:
+        - Asigna la jurisdicción (`l10n_ar_state_id`) a las percepciones y
+          retenciones de IIBB, que se identifican por su identificador externo.
+        - Crea la secuencia de numeración de cada retención de proveedor: una
+          propia por impuesto, salvo las de ganancias, que comparten una sola.
+        - Marca las retenciones de IVA con el tipo de retención "iva", para que
+          los reportes puedan identificarlas sin depender del nombre.
+        """
         # TODO deberia ir en odoo nativo
         company.ensure_one()
 
@@ -152,43 +161,21 @@ class AccountChartTemplate(models.AbstractModel):
                 lambda tax: not tax.l10n_ar_withholding_sequence_id
             ).l10n_ar_withholding_sequence_id = sequence.id
 
-        # agregado de etiquetas para liquidacion de impuestos sicore
-        sicore_taxes = profits_taxes
-        tag = self.env.ref("l10n_ar_ux.tag_ret_perc_sicore_aplicada", raise_if_not_found=False)
-        if tag:
-            for xml_id in ["ri_tax_percepcion_iva_aplicada", "ri_tax_percepcion_ganancias_aplicada"]:
-                xml_id_percep = "account.%s_%s" % (company.id, xml_id)
-                # en profits_taxes tenemos todas las retenciones, agregamos el impuesto de percepcion de ganancias y de iva
-                tax = self.env.ref(xml_id_percep, raise_if_not_found=False)
-                if tax:
-                    sicore_taxes += tax
-            sicore_tags = self.env["account.tax.repartition.line"].search(
-                [("tax_id", "in", sicore_taxes.ids), ("repartition_type", "=", "tax")]
-            )
-            sicore_tags_to_update = sicore_tags.filtered(lambda line: tag not in line.tag_ids)
-            sicore_tags_to_update.tag_ids = [Command.link(tag.id)]
-
-        # agregado de etiquetas para liquidacion de impuestos pago IIBB a cuenta (sifere web)
-        # consideramos de IIBB a todo lo que tiene 10n_ar_state_id
-        tag = self.env.ref("l10n_ar_ux.tax_tag_a_cuenta_iibb", raise_if_not_found=False)
-        if tag:
-            domain = [
-                ("repartition_type", "=", "tax"),
-                ("tax_id.company_id", "=", company.id),
-                ("tax_id.l10n_ar_state_id", "!=", False),
-                ("tax_id.country_code", "=", "AR"),
-                "|",
-                ("tax_id.type_tax_use", "=", "purchase"),
-                "&",
-                ("tax_id.type_tax_use", "=", "none"),
-                ("tax_id.l10n_ar_withholding_payment_type", "=", "customer"),
-            ]
-            repartition_lines = self.env["account.tax.repartition.line"].search(domain)
-            if repartition_lines_without_tag := repartition_lines.filtered(lambda line: tag not in line.tag_ids):
-                repartition_lines_without_tag.tag_ids = [Command.link(tag.id)]
+        # marcamos las retenciones de IVA (aplicadas y sufridas) con el tipo "iva"
+        # para poder identificarlas en los reportes (SICORE, IVA sufridas). Las
+        # reconocemos por su identificador externo del chart template:
+        # - ex_tax_withholding_vat_applied: retención sobre pago a proveedor (aplicadas).
+        # - ri_tax_withholding_vat_incurred: retención sobre cobro a cliente (sufridas).
+        for suffix in ("ex_tax_withholding_vat_applied", "ri_tax_withholding_vat_incurred"):
+            tax = self.env.ref("account.%s_%s" % (company.id, suffix), raise_if_not_found=False)
+            if tax:
+                tax.l10n_ar_tax_type = "iva"
 
     def _load(self, template_code, company, install_demo, force_create=True):
-        """Luego de que creen los impuestos del archivo account.tax-ar_ri.csv de l10n_ar al instalar el plan de cuentas en la nueva compañìa argentina agregamos en este método las etiquetas que correspondan en los repartition lines."""
+        """Completamos la configuración de los impuestos una vez creados por el plan de cuentas.
+
+        Los impuestos de account.tax-ar_ri.csv de l10n_ar se crean al instalar el plan de cuentas en la
+        nueva compañía argentina; recién ahí podemos completarlos con `_add_wh_taxes`."""
         # Llamamos a super para que se creen los impuestos
         res = super()._load(template_code, company, install_demo, force_create)
         company = company or self.env.company

--- a/l10n_ar_tax/models/account_tax.py
+++ b/l10n_ar_tax/models/account_tax.py
@@ -7,6 +7,16 @@ from odoo.tools import SQL
 class AccountTax(models.Model):
     _inherit = "account.tax"
 
+    # Sumamos el tipo "IVA" para identificar las retenciones de IVA (aplicadas y
+    # sufridas) sin depender del nombre del impuesto ni del grupo. Se usa en los
+    # reportes de l10n_ar_account_reports (SICORE, IVA sufridas). No lleva cálculo
+    # propio: el impuesto se configura como cualquier otra retención, y la alícuota
+    # importa porque de ella depende el código de condición del régimen 602.
+    l10n_ar_tax_type = fields.Selection(
+        selection_add=[("iva", "IVA")],
+        ondelete={"iva": "set null"},
+    )
+
     # mejora de usabilidad, duplicar un impuesto mantiene la secuencia
     l10n_ar_withholding_sequence_id = fields.Many2one(
         copy=True,


### PR DESCRIPTION
Agrega la opción 'iva' al campo selection "WTH Tax" (l10n_ar_tax_type) del campo mencionado en los impuestos de retención de IVA aplicadas y sufridas al momento de la instalación del plan de cuentas y creación de impuestos. Para las bases ya migradas a 19 no hacemos nada (si necesitan establecer esa configuración la tienen que hacer a mano). A las bases que van a migrar a 19 les establecemos 'iva' al campo selection "WTH Tax" (l10n_ar_tax_type) a las retenciones de iva aplicadas y sufridas en el upgrade line "[RET19] Provincia y grupos de impuestos en 19".
Quitamos el agregado de etiquetas de ganancias en repartition lines de impuestos ya que no se necesita más para la versión 19.
Task: 70765


