### PR TITLE
[FIX] l10n_ar_tax: drop zero-amount withholding lines on confirm

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -143,10 +143,25 @@ class AccountPayment(models.Model):
                     % (previous_to_pay, rec.to_pay_amount)
                 )
         self.compute_withholdings()
+        self._l10n_ar_remove_zero_withholding_lines()
         res = super().action_confirm()
         # por ahora primero computamos retenciones y luego conifmamos porque si no en caso de cheques siempre da error
         # TODO tal vez mejorar y advertir de que se va a computar el importe?
         return res
+
+    def _l10n_ar_remove_zero_withholding_lines(self):
+        """Elimina las líneas de retención que no arrojan retención (importe 0) antes de
+        confirmar el pago, para que no queden en el pago ni ensucien la vista/reportes.
+        Ganancias se conserva siempre: su base acumulada puede requerir el apunte contable
+        aunque el importe sea 0. Usamos ``currency_id.is_zero`` (mismo criterio que
+        account_tax_settlement al saltear líneas en cero) para contemplar el redondeo."""
+        for rec in self:
+            is_zero = rec.company_id.currency_id.is_zero
+            zero_lines = rec.l10n_ar_withholding_line_ids.filtered(
+                lambda line: line.tax_id.l10n_ar_tax_type not in ["earnings", "earnings_scale"] and is_zero(line.amount)
+            )
+            if zero_lines:
+                rec.l10n_ar_withholding_line_ids = [Command.unlink(line.id) for line in zero_lines]
 
     def _prepare_move_withholding_lines(self, default_values):
         res = super()._prepare_move_withholding_lines(default_values)

--- a/l10n_ar_tax/tests/test_withholding_thresholds.py
+++ b/l10n_ar_tax/tests/test_withholding_thresholds.py
@@ -242,3 +242,37 @@ class TestWithholdingThresholds(TestArWithholdingArRi):
         invoice2 = self._make_vendor_invoice(price_unit=80.0, doc_number="3-6")
         __, wth2 = self._make_withholding_line(self.tax_earnings_10pct, base_amount=80.0, invoice=invoice2)
         self.assertEqual(wth2.amount, 6.0, "Pago2: base acumulada 160 - no imponible 100 = 60 → 10% = 6")
+
+    # ─── Case 6: línea de retención en 0 se elimina al confirmar ─────────────
+
+    def test_06_zero_withholding_line_removed_on_confirm(self):
+        """Una línea de retención que no arroja retención (importe 0) se elimina
+        (_l10n_ar_remove_zero_withholding_lines). Aplica a cualquier régimen no-ganancias."""
+        self.tax_iibb_3pct.write(
+            {
+                "l10n_ar_payment_minimum_threshold": 0,
+                "l10n_ar_base_minimum_threshold": 105,
+                "l10n_ar_minimum_threshold": 0,
+            }
+        )
+        invoice = self._make_vendor_invoice(price_unit=100.0, doc_number="3-7")
+        payment, wth = self._make_withholding_line(self.tax_iibb_3pct, base_amount=100.0, invoice=invoice)
+        self.assertEqual(wth.amount, 0.0)
+        self.assertTrue(payment.l10n_ar_withholding_line_ids, "la línea existe antes de confirmar")
+        payment._l10n_ar_remove_zero_withholding_lines()
+        self.assertFalse(payment.l10n_ar_withholding_line_ids, "la línea en 0 se elimina")
+
+    def test_07_nonzero_withholding_line_kept(self):
+        """Una línea que sí retiene se conserva."""
+        self.tax_iibb_3pct.write(
+            {
+                "l10n_ar_payment_minimum_threshold": 0,
+                "l10n_ar_base_minimum_threshold": 0,
+                "l10n_ar_minimum_threshold": 0,
+            }
+        )
+        invoice = self._make_vendor_invoice(price_unit=100.0, doc_number="3-8")
+        payment, wth = self._make_withholding_line(self.tax_iibb_3pct, base_amount=100.0, invoice=invoice)
+        self.assertEqual(wth.amount, 3.0)
+        payment._l10n_ar_remove_zero_withholding_lines()
+        self.assertTrue(payment.l10n_ar_withholding_line_ids, "la línea con retención se conserva")


### PR DESCRIPTION
## Qué

Al confirmar un pago, se eliminan las líneas de retención/percepción **no-ganancias** cuyo importe queda en **0** (por ejemplo, cuando no se alcanza el mínimo del régimen). Hoy esas líneas quedan en el pago aunque no generan ningún apunte contable, sumando ruido en la vista y en el recibo.

## Por qué

La línea de retención se crea una por cada impuesto de la posición fiscal (`_compute_l10n_ar_withholding_line_ids`), sin mirar el importe, y se conserva aunque sea 0 (`action_post` solo le pone `name = "/"`). El asiento ya la saltea (`lines_with_accounting_entry`), pero la línea permanece visible/persistida. No debería quedar una línea de retención en 0 en ningún régimen.

## Cómo

- Nuevo `_l10n_ar_remove_zero_withholding_lines()`, invocado en `action_confirm` luego de `compute_withholdings()` (con los importes ya finales).
- Elimina las líneas no-ganancias con importe 0. **Ganancias se conserva siempre**: su base acumulada puede requerir el apunte contable aunque el importe sea 0.
- Se hace al confirmar (no en el compute que crea las líneas) porque ese compute se dispara por posición fiscal/partner, no por la selección de deudas ni por el importe; filtrarlo ahí borraría líneas antes de elegir las deudas y no volverían a crearse. En borrador la línea puede previsualizarse (sugerencia viva); al confirmar ya no queda.

## Tests

- `test_06`: una línea que no retiene (importe 0) se elimina.
- `test_07`: una línea que sí retiene se conserva.
- Suite de thresholds existente sin regresiones.

Task 70313