### PR TITLE
[IMP] l10n_ar_tax: test resync in draft with checks, withholding and write-off

### DIFF
--- a/l10n_ar_tax/tests/test_payment_withholding_checks_multimoneda.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_checks_multimoneda.py
@@ -301,3 +301,39 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
         self.assertAlmostEqual(abs(wth_ml.balance), 36_000, places=0)
 
         self.assertAlmostEqual(sum(lines.mapped("balance")), 0, places=2)
+
+    # ------------------------------------------------------------------
+    # TC.10 — re-sincronización en borrador con retención + write-off
+    # ------------------------------------------------------------------
+
+    def test_tc10_resync_en_borrador_con_retencion_y_write_off(self):
+        """TC.10 · Re-sincronización del asiento en borrador con N cheques +
+        retención + write-off.
+
+        Es el único escenario donde el mapeo de líneas de core corre sobre un pago
+        con varias líneas de liquidez (``_synchronize_to_moves`` sale antes si el
+        asiento ya está posteado). Escribir ``amount`` sin cambiar el importe no
+        debe perder ni duplicar las líneas extra: cubre el corte
+        ``line_vals_list[len(liquidity) + 1:]``, que asume que después de las
+        líneas de liquidez viene exactamente una de contrapartida.
+        """
+        invoice = self._create_invoice(1_000, self.usd)
+        payment = self._create_check_payment_with_wth(
+            self.bank_ars,
+            invoice,
+            [{"name": "00000130", "amount": 678_000}, {"name": "00000131", "amount": 678_000}],
+            write_off_type_id=self.write_off_type.id,
+            write_off_amount=50,
+        )
+        payment.action_post()
+        expected = len(payment.move_id.line_ids)
+
+        payment.action_draft()
+        payment.write({"amount": payment.amount})
+
+        lines = payment.move_id.line_ids
+        self.assertEqual(len(lines), expected, "La re-sincronización no debe agregar ni quitar líneas")
+        self.assertEqual(len(lines.filtered(lambda l: l.account_id == payment.outstanding_account_id)), 2)
+        self.assertEqual(len(self._wth_move_lines(payment)), 1, "1 línea de retención")
+        self.assertEqual(len(lines.filtered(lambda l: l.account_id == self.write_off_type.account_id)), 1)
+        self.assertAlmostEqual(sum(lines.mapped("balance")), 0, places=2)


### PR DESCRIPTION
Adds one test to `TestPaymentChecksWithholding`: re-synchronizing a draft move on
a payment that carries several own checks plus a withholding plus a write-off.
Task 70884.

Draft moves are the only state where base's line mapping actually runs on a
payment with more than one liquidity line — `_synchronize_to_moves` returns early
when the move is already posted. So this is the only way to cover the slicing of
the extra lines (`line_vals_list[len(liquidity) + 1:]`, which assumes exactly one
counterpart line after the liquidity ones) when withholdings and a write-off sit
on top of one liquidity line per check.

Reuses the existing fixture and the `_create_check_payment_with_wth` helper of
the class, so it adds no setup.

Part of the test harness for task 70884, whose other half is
https://github.com/ingadhoc/account-payment/pull/1153 (same branch name, so
runbot bundles both into a single build). The harness pins the behaviour of the
check patch the ADHOC image carries, so that relocating it into our modules can
be measured; the relocation itself is a separate PR.

## Test plan

```bash
odoo-bin -d <db> -u l10n_ar_tax --test-enable \
  --test-tags '/l10n_ar_tax:TestPaymentChecksWithholding'
```

5/5 with the current (patched) core. Note that on a vanilla core the four
pre-existing tests of this class already fail, with a difference equal to the
withholding amount and a couple of unbalanced entries — the patch is load bearing
for this accounting, not cosmetic.
