### PR TITLE
[FIX] l10n_ar_tax: allow branch fiscal positions to use parent company tax groups

### DIFF
--- a/l10n_ar_tax/README.md
+++ b/l10n_ar_tax/README.md
@@ -28,7 +28,7 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 ## Configuration
 
 1. **Taxes:** Accounting → Configuration → Taxes — configure withholding and perception taxes.
-2. **Fiscal positions:** Accounting → Configuration → Fiscal Positions — set up automatic tax assignment.
+2. **Fiscal positions:** Accounting → Configuration → Fiscal Positions — set up automatic tax assignment. In a multi-company setup with branches, a fiscal position of a branch can use the tax groups and taxes of its parent company (same behaviour as standard Odoo account mapping), so the chart of taxes only needs to be configured once on the parent.
 3. **Partner tax ID:** in Contacts, configure CUIT/CUIL/DNI.
 4. **Tax ratios:** set ratios (1–100) on percentage-based taxes to control the taxable base percentage.
 5. **Padron importers:** for Santa Fe (PARP) and ARBA, configure the corresponding fiscal position with the web service setting. See `doc/padron_santa_fe/` for specs and examples.

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -176,11 +176,11 @@ class AccountFiscalPositionL10nArTax(models.Model):
     @api.depends("fiscal_position_id.company_id", "tax_type")
     def _compute_tax_group_id_domain(self):
         for rec in self:
-            company_id = rec.fiscal_position_id.company_id.id or rec.env.company.id
-            domain = [
-                ("company_id", "=", company_id),
-                ("l10n_ar_vat_afip_code", "=", False),
-            ]
+            company = rec.fiscal_position_id.company_id or rec.env.company
+            # con _check_company_domain (parent_of) una sucursal puede elegir los grupos de impuestos
+            # de la compañía padre, igual que el dominio de default_tax_id (_get_tax_domain)
+            domain = self.env["account.tax.group"]._check_company_domain(company)
+            domain += [("l10n_ar_vat_afip_code", "=", False)]
             if rec.tax_type == "perception":
                 domain += [("tax_ids.type_tax_use", "=", "sale")]
             elif rec.tax_type == "withholding":


### PR DESCRIPTION
## Problema

En la solapa *Percepciones y Retenciones* de una posición fiscal, el dominio de la columna *Grupo de impuestos* filtraba con igualdad estricta de compañía. Una sucursal no tiene plan de impuestos propio — los grupos e impuestos viven en la compañía padre — así que el desplegable salía vacío y no se podía configurar ninguna retención/percepción de IIBB.

En la sucursal sí se podían cargar retenciones de **Ganancias**, porque esas se eligen directo por *Impuesto por Defecto*, cuyo dominio ya era parent-aware. Para IIBB ese campo queda `readonly` (se resuelve desde grupo + alícuota), así que el grupo es el único camino de carga — y era el que estaba roto.

## Cambio

`_compute_tax_group_id_domain` usa `account.tax.group._check_company_domain(company)` en lugar de la igualdad por compañía.

No amplía accesos: ese dominio resuelve a `parent_of`, igual que el record rule `account.tax_group_comp_rule` y que la constraint `check_company=True` ya declarada en el campo. El dominio de UI era más restrictivo que el ACL.

## Test plan

Sobre un runbot con `Casa Matriz SRL. RI` + `Sucursal Centro`:

1. Posicionarse en la sucursal → Contabilidad → Configuración → Posiciones Fiscales → Nueva.
2. Tipo de impuesto AR = *Retención*.
3. Agregar línea → *Grupo de impuestos* debe listar los grupos de IIBB de la casa matriz.
4. Elegir grupo y alícuota → el *Impuesto por Defecto* se resuelve al impuesto de la casa matriz y la línea guarda bien.
5. En una FP de la casa matriz el desplegable sigue listando solo sus propios grupos.

## Notas

- Sin migration script ni cambios de schema → `nobump`.
- Fuera de alcance: el padrón ARBA / Santa Fe y las credenciales (`arba_cit`) siguen filtrando por compañía exacta, y el número de certificado de retención sale de una secuencia que vive en el impuesto del padre, así que sucursales con CUIT distinto la comparten (ya pasaba con Ganancias).

Ref: ticket 121872
