### PR TITLE
[FIX] l10n_ar_purchase: drop expected arrival column from purchase order report

### DIFF
--- a/l10n_ar_purchase/i18n/es.po
+++ b/l10n_ar_purchase/i18n/es.po
@@ -21,6 +21,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
 
 #. module: l10n_ar_purchase
+#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
+msgid "<strong>Expected Arrival:</strong>"
+msgstr "<strong>Entrega esperada:</strong>"
+
+#. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchasequotation_document
 msgid "<br/><strong>Payment Terms: </strong>"
 msgstr "<br/><strong>Términos de Pago: </strong>"
@@ -41,11 +46,6 @@ msgstr "<br/><strong>Su referencia de pedido:</strong>"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
 msgid "<strong>% VAT</strong>"
 msgstr "% IVA"
-
-#. module: l10n_ar_purchase
-#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
-msgid "<strong>Expected Arrival</strong>"
-msgstr "<strong>Entrega esperada</strong>"
 
 #. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document

--- a/l10n_ar_purchase/i18n/l10n_ar_purchase.pot
+++ b/l10n_ar_purchase/i18n/l10n_ar_purchase.pot
@@ -16,6 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_ar_purchase
+#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
+msgid "<strong>Expected Arrival:</strong>"
+msgstr ""
+
+#. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchasequotation_document
 msgid "<br/><strong>Payment Terms: </strong>"
 msgstr ""
@@ -35,11 +40,6 @@ msgstr ""
 #. module: l10n_ar_purchase
 #: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
 msgid "<strong>% VAT</strong>"
-msgstr ""
-
-#. module: l10n_ar_purchase
-#: model_terms:ir.ui.view,arch_db:l10n_ar_purchase.report_purchaseorder_document
-msgid "<strong>Expected Arrival</strong>"
 msgstr ""
 
 #. module: l10n_ar_purchase

--- a/l10n_ar_purchase/views/purchase_report_templates.xml
+++ b/l10n_ar_purchase/views/purchase_report_templates.xml
@@ -191,6 +191,14 @@
                         <span t-field="o.partner_ref"/>
                     </t>
 
+                    <!-- The native report shows the earliest expected arrival of the order
+                         in the "informations" block that we replace above. We keep it here
+                         so the supplier still gets that date on the AR report. -->
+                    <t t-if="o.date_planned">
+                        <strong>Expected Arrival:</strong>
+                        <span t-field="o.date_planned" t-options="{'date_only': 'true'}"/>
+                    </t>
+
                     <t t-if="o.dest_address_id">
                         <br/><strong>Shipping address:</strong>
                         <span t-field="o.dest_address_id.name"/>
@@ -202,22 +210,6 @@
 
             </div>
         </div>
-
-        <!-- Re-add the expected arrival date per order line.
-             In v16 the AR purchase order report showed the expected arrival
-             ("Llegada prevista") per product line. In v18 the confirmed purchase
-             order report (both native and AR) dropped it, and the data
-             (purchase.order.line.date_planned) is only printed on the RFQ /
-             quotation report. We re-add it as a column on the AR purchase order
-             report so suppliers receive the expected delivery date per product. -->
-        <xpath expr="//th[@name='th_description']" position="after">
-            <th name="th_date_planned" class="text-center"><strong>Expected Arrival</strong></th>
-        </xpath>
-        <xpath expr="//td[@id='product']" position="after">
-            <td class="text-center">
-                <span t-field="line.date_planned" t-options="{'date_only': 'true'}"/>
-            </td>
-        </xpath>
 
     </template>
 


### PR DESCRIPTION
Reverts the per line **Expected Arrival** column added on #1487, and restores the
order level expected arrival date on the header of the AR purchase order report.

## Why

#1487 added a `date_planned` column per order line to
`l10n_ar_purchase.report_purchaseorder_document`, unconditionally for every
database on 18.0. The PDF of a purchase order is sent to the supplier, and the
planned date of each line is an internal scheduling date, not a commitment, so
another customer started getting date disputes from its suppliers over dates
that were never agreed with them. Product decided to go back to the native
behaviour.

While reviewing it we found a second, older problem: the AR report replaces the
whole native `div#informations` block, and our replacement never included the
native `Expected Arrival` field (the earliest `date_planned` of the order). So
the date was not printed anywhere on the AR report, even though native 18.0
prints it in the header. That field is restored here.

Net result on the AR purchase order report:

- No `Expected Arrival` column per line (as native 18.0).
- `Expected Arrival:` in the header with the earliest expected arrival of the
  order, only when the order has one (as native 18.0).

The RFQ / quotation report is untouched: the expected date column it shows per
line is native and was never added by us.

## Test plan

1. Install / update `l10n_ar_purchase` on an AR company.
2. Confirm a purchase order with several lines and different `date_planned` per line.
3. Print **Purchase Order**:
   - the lines table has no expected arrival column (Description / Qty / Unit Price / Disc. / % VAT / Amount);
   - the header shows `Llegada esperada:` with the earliest planned date of the order.
4. Print a draft order as **Request for Quotation** and check nothing changed there.
5. Check the PDF in Spanish (the new header term is translated in `i18n/es.po`).

## Notes for the reviewer

- No migration script, but the change lives in a QWeb report template, so the
  module needs to be updated for customers to see it. Suggested merge commands:
  `@roboadhoc r+` and `@roboadhoc bump`.
- The manifest is deliberately not bumped by hand, so the bot owns the version.
- @jue-adhoc heads up, this reverts the report change of #1487.