### PR TITLE
[IMP] l10n_ar_tax: single PDF with all withholding certificates on payment emails

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -360,7 +360,28 @@ class AccountPayment(models.Model):
         # under the same name, which would otherwise serve the stale cached PDF.
         # Drop the cached receipt so it is regenerated on the next render.
         self._unlink_cached_payment_receipt()
+        self._unlink_cached_withholding_certificates()
         return super().action_draft()
+
+    def _l10n_ar_withholding_certificates_filename(self):
+        """Filename of the single PDF holding all the withholding certificates
+        of this payment (one page per withholding). Shared by the preview and
+        the sending path of mail.compose.message."""
+        self.ensure_one()
+        return "Certificados de Retención - %s.pdf" % (self.name or "").replace("/", "_")
+
+    def _unlink_cached_withholding_certificates(self):
+        # Same rationale as _unlink_cached_payment_receipt: the certificate of
+        # each withholding line is cached (attachment_use on
+        # l10n_ar_tax.action_report_withholding_certificate) and becomes stale
+        # if the payment is edited and reposted under the same name.
+        report = self.env.ref("l10n_ar_tax.action_report_withholding_certificate", raise_if_not_found=False)
+        if not report:
+            return
+        for withholding in self.l10n_ar_withholding_line_ids:
+            attachment = report.retrieve_attachment(withholding)
+            if attachment:
+                attachment.unlink()
 
     def _unlink_cached_payment_receipt(self):
         report = self.env.ref("account.action_report_payment_receipt", raise_if_not_found=False)

--- a/l10n_ar_tax/models/mail_compose_message.py
+++ b/l10n_ar_tax/models/mail_compose_message.py
@@ -1,15 +1,19 @@
-import base64
-
 from odoo import models
-from odoo.tools import safe_eval
 
 
 class MailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
+    def _get_withholding_certificates_report(self):
+        return self.env.ref(
+            "l10n_ar_tax.action_report_withholding_certificate",
+            raise_if_not_found=False,
+        )
+
     def _compute_attachment_ids(self):
-        """Extends original method so it is possible to attach and preview
-        withholding vouchers when sending payment reports by email.
+        """Extends original method so it is possible to attach and preview a
+        single PDF holding all the withholding certificates (one page per
+        withholding) when sending payment reports by email.
         Only works for SINGLE payment sending (preview mode)."""
         super()._compute_attachment_ids()
         for composer in self:
@@ -21,10 +25,7 @@ class MailComposeMessage(models.TransientModel):
             ):
                 continue
 
-            report = self.env.ref(
-                "l10n_ar_tax.action_report_withholding_certificate",
-                raise_if_not_found=False,
-            )
+            report = composer._get_withholding_certificates_report()
             if not report:
                 continue
 
@@ -32,45 +33,64 @@ class MailComposeMessage(models.TransientModel):
             if payment.partner_type != "supplier":
                 continue
 
-            attachments = []
-            for withholding in payment.l10n_ar_withholding_line_ids.filtered("amount"):
-                # Importante: si se modifica la manera de acceder al report_name acá, hay que modificarlo
-                # también en el método _prepare_mail_values
-                report_name = safe_eval.safe_eval(report.print_report_name, {"object": withholding})
-                report_content, _ = self.env["ir.actions.report"]._render(report.report_name, withholding.ids)
-                report_content_encoded = base64.b64encode(report_content)
+            withholdings = payment.l10n_ar_withholding_line_ids.filtered("amount")
+            if not withholdings:
+                continue
 
+            report_name = payment._l10n_ar_withholding_certificates_filename()
+
+            # El compute puede correr varias veces mientras el usuario edita el
+            # wizard: si ya renderizamos el PDF para este composer, reusarlo en
+            # vez de volver a renderizar y crear otro adjunto temporal.
+            attachment = self.env["ir.attachment"].search(
+                [
+                    ("name", "=", report_name),
+                    ("res_model", "=", "mail.compose.message"),
+                    ("res_id", "=", composer.id),
+                ],
+                limit=1,
+            )
+            if not attachment:
+                # Un solo _render con todas las retenciones: el template itera
+                # sobre docs, así que esto devuelve un único PDF de N páginas
+                # (una corrida de wkhtmltopdf en vez de una por retención).
+                report_content, _content_type = self.env["ir.actions.report"]._render(
+                    report.report_name, withholdings.ids
+                )
                 # Crear adjunto temporal para previsualización
                 attachment = self.env["ir.attachment"].create(
                     {
                         "name": report_name,
-                        "datas": report_content_encoded,
+                        "raw": report_content,
+                        "mimetype": "application/pdf",
                         "res_model": "mail.compose.message",
                         "res_id": composer.id,
                         "type": "binary",
                     }
                 )
-                attachments.append(attachment.id)
 
-            if attachments:
-                composer.attachment_ids = [(6, 0, composer.attachment_ids.ids + attachments)]
+            if attachment.id not in composer.attachment_ids.ids:
+                composer.attachment_ids = [(4, attachment.id)]
 
     def _prepare_mail_values(self, res_ids):
-        """Extended to add withholding attachments when sending payments by email.
-        Handles BOTH single (reuses preview attachments) and mass sending (creates new)."""
+        """Extended to attach a single PDF with all the withholding
+        certificates when sending payments by email in rendering mode (mass
+        mail or comment in batch), where the preview compute does not run.
+
+        In monorecord "rendered" mode there is nothing to do here: the PDF
+        rendered by _compute_attachment_ids is part of attachment_ids and
+        _prepare_mail_values_rendered already carries it to the message."""
         mail_values_all = super()._prepare_mail_values(res_ids)
 
-        if self.model != "account.payment":
+        rendering_mode = self.composition_mode == "mass_mail" or self.composition_batch
+        if self.model != "account.payment" or not rendering_mode:
             return mail_values_all
 
-        report = self.env.ref(
-            "l10n_ar_tax.action_report_withholding_certificate",
-            raise_if_not_found=False,
-        )
+        report = self._get_withholding_certificates_report()
         if not report:
             return mail_values_all
 
-        # Chequeamos si estamos en envío masivo (usa comandos) o en modo comentario (usa IDs simples)
+        # En mass_mail mode los attachments van como comandos (4, id), en comment mode como IDs simples
         email_mode = self.composition_mode == "mass_mail"
 
         payments = self.env["account.payment"].browse(res_ids).filtered(lambda p: p.partner_type == "supplier")
@@ -78,70 +98,31 @@ class MailComposeMessage(models.TransientModel):
             if payment.id not in mail_values_all:
                 continue
 
-            # Traer adjuntos del método padre
-            attachment_ids = mail_values_all[payment.id].get("attachment_ids", [])
+            withholdings = payment.l10n_ar_withholding_line_ids.filtered("amount")
+            if not withholdings:
+                continue
 
-            for withholding in payment.l10n_ar_withholding_line_ids.filtered("amount"):
-                try:
-                    report_name = safe_eval.safe_eval(report.print_report_name, {"object": withholding})
+            # Un solo render con todas las retenciones del pago. Gracias a
+            # attachment_use en el reporte, los certificados ya renderizados se
+            # recargan de su attachment cacheado en vez de volver a pasar por
+            # wkhtmltopdf.
+            report_content, _content_type = self.env["ir.actions.report"]._render(report.report_name, withholdings.ids)
+            attachment = self.env["ir.attachment"].create(
+                {
+                    "name": payment._l10n_ar_withholding_certificates_filename(),
+                    "raw": report_content,
+                    "mimetype": "application/pdf",
+                    "res_model": "mail.message",
+                    "res_id": 0,
+                    "type": "binary",
+                }
+            )
 
-                    # CASO 1: Envío individual - reutilizar adjuntos creados en compute
-                    if len(res_ids) == 1:
-                        # Buscar adjunto existente creado en la previsualización
-                        existing_attachment = self.attachment_ids.filtered(
-                            lambda a: (
-                                a.name == report_name and a.res_model == "mail.compose.message" and a.res_id == self.id
-                            )
-                        )
-
-                        # Reutilizar:  cambiar res_model para que se vincule al mensaje
-                        existing_attachment[0].write(
-                            {
-                                "res_model": "mail.message",
-                                "res_id": 0,
-                            }
-                        )
-                        attachment = existing_attachment[0]
-
-                    # CASO 2: Envío masivo - crear adjuntos directamente (sin previsualización previa)
-                    else:
-                        # Buscar si ya existe un attachment con el mismo nombre para evitar duplicados
-                        existing_attachment = self.env["ir.attachment"].search(
-                            [
-                                ("name", "=", report_name),
-                                ("res_model", "=", "l10n_ar.payment.withholding"),
-                                ("res_id", "=", withholding.id),
-                            ],
-                            limit=1,
-                        )
-
-                        if existing_attachment:
-                            attachment = existing_attachment
-                        else:
-                            report_content, _ = self.env["ir.actions.report"]._render(
-                                report.report_name, withholding.ids
-                            )
-                            report_content_encoded = base64.b64encode(report_content)
-                            attachment = self.env["ir.attachment"].create(
-                                {
-                                    "name": report_name,
-                                    "datas": report_content_encoded,
-                                    "res_model": "l10n_ar.payment.withholding",
-                                    "res_id": withholding.id,
-                                    "type": "binary",
-                                }
-                            )
-
-                    # Agregar adjunto usando el método más directo
-                    # En mass_mail mode usar comandos (4, id), en comment mode usar IDs simples
-                    if email_mode:
-                        attachment_ids.append((4, attachment.id))
-                    else:
-                        attachment_ids.append(attachment.id)
-
-                except Exception:
-                    continue
-
+            attachment_ids = mail_values_all[payment.id].get("attachment_ids") or []
+            if email_mode:
+                attachment_ids.append((4, attachment.id))
+            else:
+                attachment_ids.append(attachment.id)
             mail_values_all[payment.id]["attachment_ids"] = attachment_ids
 
         return mail_values_all

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -4,4 +4,5 @@ from . import test_padron_tmp_dir
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_kept_on_post
 from . import test_payment_withholding_validation
+from . import test_withholding_certificates_mail
 from . import test_withholding_thresholds

--- a/l10n_ar_tax/tests/test_withholding_certificates_mail.py
+++ b/l10n_ar_tax/tests/test_withholding_certificates_mail.py
@@ -1,0 +1,237 @@
+from odoo import Command, fields
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
+from odoo.tests import tagged
+from odoo.tools import safe_eval
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestWithholdingCertificatesMail(TestArWithholdingArRi):
+    """Task 71431 / ticket 120699: sending a supplier payment by email must
+    attach ONE PDF holding all its withholding certificates (one page per
+    withholding) instead of one PDF -and one wkhtmltopdf run- per withholding.
+
+    The per-withholding renders saturated the HTTP workers of a customer with
+    payments carrying 5/6 withholdings, taking the instance down (error 500).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.today = fields.Date.today()
+        self.company_bank_journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company_ri.id), ("type", "=", "bank")], limit=1
+        )
+        self.report = self.env.ref("l10n_ar_tax.action_report_withholding_certificate")
+        self.receipt_template = self.env.ref("account.mail_template_data_payment_receipt")
+
+    def _create_posted_payment_with_withholdings(self, document_number, withholding_vals):
+        """Supplier payment over a posted vendor bill, with the given manual
+        withholding lines, posted (so the certificates get their number)."""
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.res_partner_adhoc.id,
+                "move_type": "in_invoice",
+                "company_id": self.company_ri.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product_a.id,
+                            "quantity": 1,
+                            "price_unit": 100000,
+                            "tax_ids": [Command.set(self.tax_21.ids)],
+                        }
+                    ),
+                ],
+                "invoice_date": self.today,
+                "l10n_latam_document_number": document_number,
+            }
+        )
+        invoice.action_post()
+
+        action_context = invoice.action_register_payment()["context"]
+        payment = (
+            self.env["account.payment"]
+            .with_context(**action_context)
+            .create(
+                {
+                    "journal_id": self.company_bank_journal.id,
+                    "amount": invoice.amount_total,
+                    "date": self.today,
+                }
+            )
+        )
+        payment.l10n_ar_withholding_line_ids = [Command.create(vals) for vals in withholding_vals]
+        payment.action_post()
+        return payment
+
+    def _new_composer(self, payments, composition_mode="comment"):
+        return (
+            self.env["mail.compose.message"]
+            .with_context(active_model="account.payment", active_ids=payments.ids)
+            .create(
+                {
+                    "model": "account.payment",
+                    "res_ids": str(payments.ids),
+                    "template_id": self.receipt_template.id,
+                    "composition_mode": composition_mode,
+                }
+            )
+        )
+
+    def _certificate_attachments(self, attachments, payment):
+        return attachments.filtered(lambda a: a.name == payment._l10n_ar_withholding_certificates_filename())
+
+    def test_01_single_sending_attaches_one_pdf(self):
+        """The composer preview attaches ONE certificates PDF per payment (not
+        one per withholding), reuses it across recomputes and hands the same
+        attachment over to the outgoing message."""
+        payment = self._create_posted_payment_with_withholdings(
+            "1-714311",
+            [
+                {"tax_id": self.tax_wth_test_1.id, "base_amount": 100000.0, "amount": 3000.0},
+                {"tax_id": self.tax_wth_test_2.id, "base_amount": 121000.0, "amount": 2500.0},
+            ],
+        )
+        self.assertEqual(len(payment.l10n_ar_withholding_line_ids), 2)
+
+        composer = self._new_composer(payment)
+        certificates = self._certificate_attachments(composer.attachment_ids, payment)
+        self.assertEqual(
+            len(certificates), 1, "The preview must hold a single PDF with all the withholding certificates"
+        )
+        self.assertTrue(certificates.name.endswith(".pdf"))
+        self.assertEqual(certificates.mimetype, "application/pdf")
+
+        # Recomputing the preview (it runs every time the wizard is edited)
+        # must reuse the rendered attachment instead of creating another one.
+        composer._compute_attachment_ids()
+        self.assertEqual(
+            self.env["ir.attachment"].search_count(
+                [
+                    ("name", "=", payment._l10n_ar_withholding_certificates_filename()),
+                    ("res_model", "=", "mail.compose.message"),
+                    ("res_id", "=", composer.id),
+                ]
+            ),
+            1,
+            "Recomputing the preview must not render nor create a new attachment",
+        )
+
+        mail_values = composer._prepare_mail_values(payment.ids)
+        attachment_ids = mail_values[payment.id]["attachment_ids"]
+        self.assertIn(certificates.id, attachment_ids, "Sending must reuse the attachment rendered for the preview")
+        certificate_ids = [
+            attachment_id
+            for attachment_id in attachment_ids
+            if attachment_id
+            in self._certificate_attachments(self.env["ir.attachment"].browse(attachment_ids), payment).ids
+        ]
+        self.assertEqual(len(certificate_ids), 1, "The outgoing mail must carry a single certificates PDF")
+
+    def test_02_mass_sending_attaches_one_pdf_per_payment(self):
+        """Mass sending (no preview) renders and attaches a single certificates
+        PDF per payment."""
+        payment_1 = self._create_posted_payment_with_withholdings(
+            "1-714312",
+            [
+                {"tax_id": self.tax_wth_test_1.id, "base_amount": 100000.0, "amount": 3000.0},
+                {"tax_id": self.tax_wth_test_2.id, "base_amount": 121000.0, "amount": 2500.0},
+            ],
+        )
+        payment_2 = self._create_posted_payment_with_withholdings(
+            "1-714313",
+            [{"tax_id": self.tax_wth_test_1.id, "base_amount": 50000.0, "amount": 1500.0}],
+        )
+        payments = payment_1 + payment_2
+
+        composer = self._new_composer(payments, composition_mode="mass_mail")
+        mail_values = composer._prepare_mail_values(payments.ids)
+        for payment in payments:
+            attachment_commands = [
+                command for command in mail_values[payment.id]["attachment_ids"] if isinstance(command, tuple)
+            ]
+            attachments = self.env["ir.attachment"].browse([command[1] for command in attachment_commands])
+            certificates = self._certificate_attachments(attachments, payment)
+            self.assertEqual(
+                len(certificates),
+                1,
+                "Mass sending must attach a single certificates PDF to payment %s" % payment.name,
+            )
+
+    def test_03_zero_amount_withholdings_are_excluded(self):
+        """Withholdings at $0 (profits under the threshold) must not trigger
+        any certificate attachment."""
+        payment = self._create_posted_payment_with_withholdings(
+            "1-714314",
+            [{"tax_id": self.tax_wth_test_1.id, "base_amount": 100000.0, "amount": 0.0}],
+        )
+        composer = self._new_composer(payment)
+        self.assertFalse(
+            self._certificate_attachments(composer.attachment_ids, payment),
+            "A payment whose withholdings are all at $0 must not attach any certificate",
+        )
+
+    def test_04_report_renders_one_document_per_withholding(self):
+        """A single render call over all the withholdings produces one document
+        per withholding (the template iterates over docs), which the PDF engine
+        turns into one page each and merges into a single file."""
+        payment = self._create_posted_payment_with_withholdings(
+            "1-714315",
+            [
+                {"tax_id": self.tax_wth_test_1.id, "base_amount": 100000.0, "amount": 3000.0},
+                {"tax_id": self.tax_wth_test_2.id, "base_amount": 121000.0, "amount": 2500.0},
+            ],
+        )
+        withholdings = payment.l10n_ar_withholding_line_ids
+
+        html_content, _content_type = self.env["ir.actions.report"]._render_qweb_html(
+            self.report.report_name, withholdings.ids
+        )
+        self.assertEqual(
+            html_content.decode().count("CERTIFICADO DE RETENCIÓN"),
+            len(withholdings),
+            "The merged report must hold one certificate per withholding",
+        )
+
+    def test_05_cached_certificates_dropped_on_reset_to_draft(self):
+        """The certificate PDF of each withholding is cached (attachment_use on
+        the report): the attachment expression resolves on posted supplier
+        payments and the cache is dropped when the payment is reset to draft."""
+        payment = self._create_posted_payment_with_withholdings(
+            "1-714316",
+            [
+                {"tax_id": self.tax_wth_test_1.id, "base_amount": 100000.0, "amount": 3000.0},
+                {"tax_id": self.tax_wth_test_2.id, "base_amount": 121000.0, "amount": 2500.0},
+            ],
+        )
+        withholdings = payment.l10n_ar_withholding_line_ids
+
+        self.assertTrue(self.report.attachment_use)
+        # Simulate the cache the PDF engine saves on render (in test mode
+        # reports render as HTML, so the real caching path does not run):
+        # an attachment named as the report 'attachment' expression, linked to
+        # each withholding. retrieve_attachment evaluates that same expression.
+        for withholding in withholdings:
+            filename = safe_eval.safe_eval(self.report.attachment, {"object": withholding})
+            self.assertTrue(filename, "The attachment expression must resolve for posted supplier withholdings")
+            self.env["ir.attachment"].create(
+                {
+                    "name": filename,
+                    "raw": b"%PDF-fake",
+                    "res_model": withholding._name,
+                    "res_id": withholding.id,
+                    "type": "binary",
+                }
+            )
+            self.assertTrue(
+                self.report.retrieve_attachment(withholding),
+                "retrieve_attachment must find the cached certificate of %s" % withholding.name,
+            )
+
+        # Resetting to draft invalidates the cache (the payment may be edited
+        # and reposted under the same name).
+        payment.action_draft()
+        for withholding in withholdings:
+            self.assertFalse(
+                self.report.retrieve_attachment(withholding),
+                "The cached certificate of withholding %s must be dropped on reset to draft" % withholding.name,
+            )

--- a/l10n_ar_tax/views/report_withholding_certificate_templates.xml
+++ b/l10n_ar_tax/views/report_withholding_certificate_templates.xml
@@ -131,6 +131,16 @@
         <field name="print_report_name">'Certificado de Retención Slip - %s' % (object.name or '')</field>
         <field name="report_name">l10n_ar_tax.report_withholding_certificate</field>
         <field name="report_file">l10n_ar_tax.report_withholding_certificate</field>
+        <!-- Cache the rendered certificate PDF per withholding (attachment_use),
+             same pattern as the supplier payment receipt: the certificate is
+             immutable once the payment is processed. On multi-record renders the
+             core reloads cached pages and only sends the missing ones to
+             wkhtmltopdf, merging everything into a single PDF. Withholdings at
+             $0 are excluded (their name is '/', which is not unique). The cache
+             is invalidated on payment reset to draft (see
+             account.payment._unlink_cached_withholding_certificates). -->
+        <field name="attachment_use" eval="True"/>
+        <field name="attachment">(object.amount and object.name and object.payment_id.partner_type == 'supplier' and object.payment_id.state in ('in_process', 'paid')) and ('Certificado de Retención Slip - %s.pdf' % object.name.replace('/', '_')) or False</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
Sending a supplier payment by email rendered one PDF (one wkhtmltopdf run plus report queries) per withholding certificate, and twice per send: once in the composer preview compute and again when preparing the mail values. On payments carrying 5/6 withholdings this repeated rendering saturated the HTTP workers of instances under load, escalating to liveness-probe restarts (error 500).

This PR reworks the flow so a payment always carries **one** certificates PDF with one page per withholding:

- **`mail.compose.message`**: render all the payment withholdings in a single `_render` call — the report template already iterates over `docs`, so this natively produces a single multi-page PDF — and attach one file per payment. The preview compute reuses its rendered attachment across recomputes instead of re-rendering on every wizard edit. In monorecord rendered mode, `_prepare_mail_values` no longer duplicates the preview attachment (core `_prepare_mail_values_rendered` already carries composer attachments to the message); certificates are only rendered there in rendering mode (mass mail / batch), where the preview compute does not run.
- **Report action**: enable `attachment_use` so each certificate page is cached on its withholding line, same pattern as the supplier payment receipt (#1485) — certificates are immutable once the payment is processed, so re-sends and re-prints reload cached pages instead of re-rendering. Withholdings at $0 are excluded (their name is not unique).
- **`account.payment.action_draft`**: drop the cached certificates alongside the existing receipt-cache invalidation, since the payment may be edited and reposted under the same numbers.

The attachment now also carries the `.pdf` extension and mimetype, so mail clients no longer receive it as an extensionless file.

Internal task: https://www.adhoc.inc/odoo/project.task/71431

## Test plan

New test class `TestWithholdingCertificatesMail` (5 tests, all green locally; full `l10n_ar_tax` suite green — 26 tests):

- single sending attaches exactly one certificates PDF and reuses it across preview recomputes and into the outgoing message;
- mass sending attaches one certificates PDF per payment;
- withholdings at $0 attach nothing;
- one rendered document per withholding in a single render call;
- the attachment-cache expression resolves on posted supplier withholdings and the cache is dropped on reset to draft.

Functional check: on a payment with several withholdings, open *Send receipt by email* — the popup should show a single "Certificados de Retención - <payment>.pdf" attachment with one page per withholding, and the send should reuse it.