### PR TITLE
[FIX] l10n_ar_tax: set the Santa Fe withholding base from the PARP contributor type

### DIFF
--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -7,7 +7,13 @@ from dateutil.relativedelta import relativedelta
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
+from .res_company_jurisdiction_padron import PARP_CONTRIBUTOR_MULTILATERAL
+
 _logger = logging.getLogger(__name__)
+
+# Sufijo para distinguir en la UI el impuesto que retiene sobre el total (Convenio
+# Multilateral) del que retiene sobre la base neta, cuando ambos comparten alícuota.
+IIBB_TOTAL_TAX_NAME_SUFFIX = "CM"
 
 
 class AccountFiscalPositionL10nArTax(models.Model):
@@ -98,7 +104,17 @@ class AccountFiscalPositionL10nArTax(models.Model):
     def _compute_tax_template_domain(self):
         for rec in self:
             domain = rec._get_tax_domain(filter_tax_group=False)
-            if not rec.l10n_ar_is_iibb:
+            if rec.l10n_ar_is_iibb:
+                # La variante de Convenio Multilateral la crea el padrón (ver _ensure_tax):
+                # elegirla a mano como impuesto por defecto haría que el flujo del padrón
+                # heredara esa base para cualquier contribuyente, incluido el local.
+                domain += [
+                    "!",
+                    "&",
+                    ("l10n_ar_tax_type", "=", "iibb_total"),
+                    ("l10n_ar_state_id.jurisdiction_code", "in", rec._get_base_defining_jurisdiction_codes()),
+                ]
+            else:
                 domain += [("l10n_ar_tax_type", "not in", ["iibb_untaxed", "iibb_total"])]
             rec.tax_template_domain = domain
 
@@ -187,7 +203,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
                 domain += [("tax_ids.l10n_ar_withholding_payment_type", "=", "supplier")]
             rec.tax_group_id_domain = json.dumps(domain)
 
-    def _get_tax_domain(self, filter_tax_group=True):
+    def _get_tax_domain(self, filter_tax_group=True, tax_type_domain=None):
         self.ensure_one()
         domain = self.env["account.tax"]._check_company_domain(self.fiscal_position_id.company_id)
         domain += [("amount_type", "=", "percent")]
@@ -223,52 +239,142 @@ class AccountFiscalPositionL10nArTax(models.Model):
         if self.tax_type == "perception":
             domain += [("type_tax_use", "=", "sale")]
         elif self.tax_type == "withholding":
-            # por ahora los 3 ws usan iibb_untaxed por eso esta hardcodeado
             domain += [("l10n_ar_withholding_payment_type", "=", "supplier")]
-            # domain += [WTH Tax = iibb untaxed, (Arg with type = supplier), (type = none)]
+        if tax_type_domain:
+            # La base es una dimensión más de búsqueda: un 0,6% iibb_untaxed y un 0,6%
+            # iibb_total son impuestos distintos y sin esto caen sobre el mismo account.tax.
+            # Recibe un dominio ya armado y no un valor porque no siempre se busca por
+            # igualdad: ver _get_tax_type_lookup.
+            domain += tax_type_domain
         return domain
 
-    def _ensure_tax(self, rate):
+    def _get_tax_type_lookup(self, l10n_ar_tax_type=None):
+        """Resuelve la base del impuesto para un lookup de _ensure_tax.
+
+        Separa dos cosas que no son la misma: con qué se *busca* (un dominio, porque no
+        siempre se busca por igualdad) y qué base se *escribe* en el impuesto que se crea
+        cuando no existe. Si el impuesto creado no matcheara la búsqueda que lo creó, cada
+        llamada crearía uno nuevo.
+
+        La base vacía cuenta como base neta: el campo no es required ni tiene default, en
+        las bases instaladas suele estar vacío, y así lo resuelve el cálculo de la retención
+        (sólo 'iibb_total' retiene sobre el total, ver l10n_ar.payment.withholding).
+
+        :param l10n_ar_tax_type: base pedida por el padrón ('iibb_total' es la única que
+            hoy se pide, ver _get_parp_tax_type). Sin pedido vale la del impuesto
+            configurado en la línea.
+        :return: (domain de la base, base a escribir en el impuesto nuevo)
+        """
         self.ensure_one()
-        domain = self._get_tax_domain()
+        base = l10n_ar_tax_type
+        if not base:
+            # Sin base pedida vale la del impuesto configurado, y sólo si es una base de
+            # IIBB: en ganancias (earnings, earnings_scale) la base no es una dimensión de
+            # búsqueda y filtrar por ella dejaría de reusar impuestos que hoy se reusan. Una
+            # base total configurada se respeta: es una decisión sobre los comprobantes del
+            # proveedor (IVA no discriminado), no sobre el régimen, y la variante CM ya no se
+            # puede elegir a mano (ver _compute_tax_template_domain). No heredamos si el
+            # usuario acaba de cambiar el grupo desde la UX (default_tax_id es todavía el del
+            # grupo anterior).
+            inherited = (
+                self.default_tax_id.l10n_ar_tax_type if self.tax_group_id == self.default_tax_id.tax_group_id else False
+            )
+            if inherited in ("iibb_untaxed", "iibb_total"):
+                base = inherited
+            elif self._padron_defines_base():
+                # Donde la variante CM existe hay que excluirla aunque no haya nada que
+                # heredar, y pedir la base neta es lo que la deja afuera. Fuera de esas
+                # jurisdicciones no filtramos: ahí iibb_total es una base configurada y
+                # excluirla crearía un duplicado sobre la base neta.
+                base = "iibb_untaxed"
+            else:
+                return None, False
+        if base == "iibb_untaxed":
+            # Los impuestos con la base vacía son de base neta: dejarlos afuera haría que se
+            # cree un duplicado con el mismo nombre en vez de reusarlos.
+            return [("l10n_ar_tax_type", "in", ["iibb_untaxed", False])], "iibb_untaxed"
+        return [("l10n_ar_tax_type", "=", base)], base
+
+    def _ensure_tax(self, rate, l10n_ar_tax_type=None):
+        """Devuelve (creando si no existe) el impuesto para la alícuota dada.
+
+        :param l10n_ar_tax_type: base del impuesto ('iibb_untaxed' / 'iibb_total'), porque
+            la misma alícuota puede aplicarse sobre base neta o sobre el total. Si no
+            viene, la resuelve _get_tax_type_lookup.
+        """
+        self.ensure_one()
+        tax_type_domain, tax_type_to_set = self._get_tax_type_lookup(l10n_ar_tax_type)
+        domain = self._get_tax_domain(tax_type_domain=tax_type_domain)
         tax = self.env["account.tax"].with_context(active_test=False).search(domain + [("amount", "=", rate)], limit=1)
         if tax and not tax.active:
             tax.active = True
         if not tax:
             # Buscar template desde el tax_group actual (puede ser un grupo nuevo/diferente).
             # Esto garantiza que el impuesto copiado tenga el estado/jurisdicción correcta.
-            template_domain = self._get_tax_domain(filter_tax_group=True)
+            # Si nos piden un iibb_total y sólo existe el iibb_untaxed, ese es el que queremos
+            # copiar cambiándole la base, así que no filtramos. Al revés no: la variante CM no
+            # puede ser template de un impuesto que retiene sobre la base neta, saldría con la
+            # base equivocada y con el sufijo CM en el nombre.
+            excludes_cm = tax_type_to_set != "iibb_total" and self._padron_defines_base()
+            template_domain = self._get_tax_domain(
+                filter_tax_group=True,
+                tax_type_domain=[("l10n_ar_tax_type", "!=", "iibb_total")] if excludes_cm else None,
+            )
             template_tax = self.env["account.tax"].with_context(active_test=False).search(template_domain, limit=1)
             if not template_tax:
                 template_tax = self.default_tax_id
             if not template_tax:
                 return self.env["account.tax"]
+            # El template puede ser el default_tax_id (fallback, sin pasar por el dominio) y
+            # ese sí puede ser la variante CM: no le propagamos esa base a un impuesto que no
+            # la pidió, o la búsqueda de arriba no volvería a encontrarlo nunca.
+            new_tax_type = tax_type_to_set or template_tax.l10n_ar_tax_type
+            if excludes_cm and new_tax_type == "iibb_total":
+                new_tax_type = "iibb_untaxed"
             if "%" not in template_tax.name:
                 name = f"{template_tax.name} {rate}%"
             else:
                 name = re.sub(r"\b\d+(\.\d+)?\s*%", f"{rate}%", template_tax.name)
 
+            if l10n_ar_tax_type == "iibb_total" and template_tax.l10n_ar_tax_type != "iibb_total":
+                # El sufijo distingue la variante que crea el padrón para el Convenio
+                # Multilateral, que si no quedaría con el mismo nombre que la de base neta.
+                # Cuelga de la base pedida y no de la del impuesto: una línea configurada
+                # sobre el total no crea variantes, crea su propio impuesto.
+                name = f"{name} {IIBB_TOTAL_TAX_NAME_SUFFIX}"
             tax = template_tax.copy(
                 default={
                     # dejamos sequencia mas baja para que siempre el que se duplica sea el que esta arriba
                     "sequence": 10,
                     "amount": rate,
                     "active": True,
+                    "l10n_ar_tax_type": new_tax_type,
                     "name": name,
                 }
             )
         return tax
 
+    @api.model
+    def _unpack_ws_data(self, ws_data):
+        """Desempaqueta lo que devuelve un método _get_<webservice>_data: (aliquot, ref)
+        más un tercer elemento opcional con el l10n_ar_tax_type de la base (hoy sólo lo
+        informa el padrón de Santa Fe). Lo usan todos los consumidores para que la
+        tolerancia a la tupla de 2 de los overrides no dependa del call-site.
+
+        :return: (aliquot, ref, l10n_ar_tax_type)
+        """
+        return ws_data[0], ws_data[1], (ws_data[2] if len(ws_data) > 2 else False)
+
     def _get_tax_from_ws(self, partner, date):
         self.ensure_one()
         from_date = date + relativedelta(day=1)
         to_date = from_date + relativedelta(days=-1, months=+1)
-        aliquot, ref = self._get_aliquot(partner, from_date, to_date)
+        aliquot, ref, l10n_ar_tax_type = self._unpack_ws_data(self._get_aliquot(partner, from_date, to_date))
         # devolvemos None si es no inscripto
         if aliquot is None:
             tax = self.default_tax_id
         else:
-            tax = self._ensure_tax(aliquot)
+            tax = self._ensure_tax(aliquot, l10n_ar_tax_type=l10n_ar_tax_type)
         # por mas que sea no inscripto creamos partner aliquot porque si no en cada
         # nueva linea o cambio se conecta a ws
         # TODO revisar porque necesitamos esto
@@ -324,13 +430,13 @@ class AccountFiscalPositionL10nArTax(models.Model):
         )
         return res
 
-    def _get_padron_config(self, state):
+    def _get_padron_configs(self):
         """Jurisdicciones que publican padrón de alícuotas en archivo, y cómo se lee ese
         archivo: con qué referencia se registra la alícuota encontrada, con cuál la del
         contribuyente ausente, y cómo se parsea el valor cuando no viene como float.
 
         Sumar una jurisdicción es sumar una entrada acá, no un if en la lógica de
-        resolución. Devuelve False si la jurisdicción no tiene padrón implementado.
+        resolución. Indexado por jurisdiction_code.
         """
         return {
             "901": {  # CABA (AGIP, Regímenes Generales)
@@ -346,8 +452,34 @@ class AccountFiscalPositionL10nArTax(models.Model):
             "921": {  # Santa Fe (PARP)
                 "found_ref": _("Santa Fe padron aliquot"),
                 "missing_ref": _("Penalty aliquot. Not found in Santa Fe padron"),
+                # Único padrón que informa el régimen del contribuyente, y en Santa Fe ese
+                # dato define la base de la retención (ver _get_parp_tax_type).
+                "contributor_type_defines_base": True,
             },
-        }.get(state.jurisdiction_code if state else "", False)
+        }
+
+    def _get_padron_config(self, state):
+        """Config del padrón de una jurisdicción. False si no tiene padrón implementado."""
+        return self._get_padron_configs().get(state.jurisdiction_code if state else "", False)
+
+    def _get_base_defining_jurisdiction_codes(self):
+        """Jurisdicciones cuyo padrón informa el régimen del contribuyente y por lo tanto
+        la base de la retención: son las únicas donde existe la variante de Convenio
+        Multilateral que crea _ensure_tax. En el resto, iibb_total es una base que se
+        configura como cualquier otra (ej. Neuquén, IVA no discriminado)."""
+        return [
+            code for code, config in self._get_padron_configs().items() if config.get("contributor_type_defines_base")
+        ]
+
+    def _padron_defines_base(self):
+        """True si la línea opera sobre una jurisdicción cuyo padrón define la base."""
+        self.ensure_one()
+        # El grupo puede tener impuestos sin jurisdicción: el estado lo da el primero que la
+        # tenga, igual que en _sync_default_tax_from_ux_fields.
+        group_taxes = self.tax_group_id.tax_ids.filtered("l10n_ar_state_id")
+        state = self.default_tax_id.l10n_ar_state_id or group_taxes[:1].l10n_ar_state_id
+        config = self._get_padron_config(state)
+        return bool(config and config.get("contributor_type_defines_base"))
 
     def _get_aliquot(self, partner, date, to_date):
         """Orden de resolución de la alícuota, único para todas las jurisdicciones:
@@ -362,8 +494,11 @@ class AccountFiscalPositionL10nArTax(models.Model):
         La alícuota cargada en el contacto (l10n_ar.partner.tax) tiene prioridad sobre todo
         esto y se resuelve antes, en account.fiscal.position._get_taxes, sin llegar acá.
 
-        :return: (float|None, string) alícuota y referencia. None = no inscripto, se usa el
-            impuesto por defecto de la línea.
+        :return: (float|None, string[, string]) alícuota y referencia, más la base a
+            aplicar cuando el padrón la informa (hoy sólo Santa Fe, ver
+            _get_aliquot_from_padron). None en la alícuota = no inscripto, se usa el
+            impuesto por defecto de la línea. Los consumidores desempaquetan con
+            _unpack_ws_data porque el tercer elemento es opcional.
         """
         self.ensure_one()
         padron_file = self._search_padron_file(self.default_tax_id.l10n_ar_state_id, date)
@@ -380,6 +515,10 @@ class AccountFiscalPositionL10nArTax(models.Model):
     def _get_aliquot_from_padron(self, padron_file, partner):
         """Lee la alícuota del archivo de padrón cargado en la base. Mismo tratamiento para
         todas las jurisdicciones: lo único propio de cada una está en _get_padron_config.
+
+        :return: (float|None, string, string|False) alícuota, referencia y base a aplicar.
+            La base sólo la informa el padrón que trae el régimen del contribuyente (Santa
+            Fe); en el resto viene False y se usa la del impuesto configurado.
         """
         self.ensure_one()
         # Sin CUIT no hay nada que buscar en el archivo: un vat vacío matchearía la línea de
@@ -390,13 +529,18 @@ class AccountFiscalPositionL10nArTax(models.Model):
         # sin dummy de demo: si el padrón está cargado se lee, también en bases demo (el dummy
         # de demo está donde no hay de dónde leer: el web service y el padrón sin archivo).
         config = self._get_padron_config(self.default_tax_id.l10n_ar_state_id)
-        is_in_padron, aliquot_ret, aliquot_per = padron_file._get_aliquot(partner)
+        is_in_padron, aliquot_ret, aliquot_per, contributor_type = padron_file._get_aliquot(partner)
         if not is_in_padron:
-            return None, config["missing_ref"]
+            # No figura en padrón: no sabemos su régimen, así que la alícuota de castigo (o
+            # la por defecto) se aplica con la base del impuesto configurado.
+            return None, config["missing_ref"], False
         aliquot = aliquot_ret if self.tax_type == "withholding" else aliquot_per
         if config.get("parse"):
             aliquot = config["parse"](aliquot)
-        return aliquot, config["found_ref"]
+        l10n_ar_tax_type = (
+            self._get_parp_tax_type(contributor_type) if config.get("contributor_type_defines_base") else False
+        )
+        return aliquot, config["found_ref"], l10n_ar_tax_type
 
     def _get_agip_data(self, partner, date, to_date):
         """Metodo que obtiene la alicuota de AGIP (CABA) del padron que Adhoc baja y procesa
@@ -553,3 +697,24 @@ class AccountFiscalPositionL10nArTax(models.Model):
         misma para todas las jurisdicciones y vive en _get_aliquot.
         """
         return self._get_aliquot(partner, date, to_date)
+
+    def _get_parp_tax_type(self, contributor_type):
+        """Traduce el tipo de contribuyente del PARP de Santa Fe ('C'/'D') al
+        l10n_ar_tax_type que define la base de la retención.
+
+        Sólo aplica a retenciones: en percepciones la base no cambia por el régimen de
+        convenio (lo que define si se detrae el IVA es la condición del adquirente
+        frente al IVA, art. 385 inc. j) pto. 2), y el 50% del art. 387 es otro
+        mecanismo que queda fuera de este alcance.
+
+        Sólo el Convenio Multilateral desvía la base. Al local le corresponde la base neta,
+        pero no la pedimos: esa es ya la base de las retenciones de Santa Fe, y forzarla
+        pisaría una base total configurada a propósito, que es una decisión sobre los
+        comprobantes del proveedor (IVA no discriminado) y no sobre el régimen. Sin base
+        pedida se resuelve la del impuesto configurado, y la variante CM queda excluida
+        igual (ver _get_tax_type_lookup).
+        """
+        self.ensure_one()
+        if self.tax_type != "withholding":
+            return False
+        return "iibb_total" if contributor_type == PARP_CONTRIBUTOR_MULTILATERAL else False

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -16,6 +16,15 @@ GREP_TIMEOUT = 30
 # Magic bytes de un ZIP: archivo con contenido, vacio y multi-volumen.
 ZIP_MAGIC_BYTES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 
+# Posición 40 del diseño de registro del PARP (RG 37/2025 de API Santa Fe, Anexo I):
+# 'C' = Convenio Multilateral, 'D' = Local Santa Fe. Ese dato define la base de la
+# retención de IIBB: el contribuyente de Convenio Multilateral se retiene sobre el
+# total "sin deducción alguna" (art. 380 apartado 1, RG 36/2026) y el local sobre la
+# base neta, sin IVA (art. 380, primer párrafo), que es la base con la que ya están
+# configuradas las retenciones de IIBB de Santa Fe. Sólo el 'C' necesita desviar la
+# base, así que es el único valor que mapeamos (ver _get_parp_tax_type).
+PARP_CONTRIBUTOR_MULTILATERAL = "C"
+
 
 class ResCompanyJurisdictionPadron(models.Model):
     _name = "res.company.jurisdiction.padron"
@@ -178,11 +187,12 @@ class ResCompanyJurisdictionPadron(models.Model):
     def _read_padron_lines(self, lines, cuit):
         """Layout del padrón de archivo único, compartido por Santa Fe (PARP) y AGIP:
         F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (is_in_padron, aliquot_ret, aliquot_per)
+        Returns: (is_in_padron, aliquot_ret, aliquot_per, contributor_type)
         """
         aliquot_ret = False
         aliquot_per = False
         is_in_padron = False
+        contributor_type = False
         for line in lines:
             if not line:
                 continue
@@ -196,13 +206,15 @@ class ResCompanyJurisdictionPadron(models.Model):
                 # Convert to float, handling comma as decimal separator
                 aliquot_per = float(values[7].replace(",", "."))
                 aliquot_ret = float(values[8].replace(",", "."))
+                # Tipo de contribuyente ('C'/'D') at index 4: define la base de la retención
+                contributor_type = values[4].upper()
                 is_in_padron = True
                 break
-        return is_in_padron, aliquot_ret, aliquot_per
+        return is_in_padron, aliquot_ret, aliquot_per, contributor_type
 
     def _find_padron_aliquot(self, path, cuit):
         """Busca el CUIT en un padrón de archivo único (ver _is_single_file_padron) y
-        devuelve (is_in_padron, aliquot_ret, aliquot_per).
+        devuelve (is_in_padron, aliquot_ret, aliquot_per, contributor_type).
 
         Filtra los candidatos con grep -F (en C) porque el padrón de AGIP tiene del
         orden de 1.5M de líneas; la comparación exacta por columna la hace
@@ -347,6 +359,12 @@ class ResCompanyJurisdictionPadron(models.Model):
         return res
 
     def _get_aliquot(self, partner):
+        """:return: (nro, aliquot_ret, aliquot_per, contributor_type)
+
+        ``contributor_type`` es el "TIPO CONTRIB" de los padrones de archivo único
+        (Santa Fe informa 'C'/'D'); en los que vienen en archivos separados (ARBA) viene
+        False porque el archivo no trae el dato.
+        """
         nro = False
         aliquot_ret = 0.0
         aliquot_per = 0.0
@@ -369,7 +387,7 @@ class ResCompanyJurisdictionPadron(models.Model):
                         aliquot_per = aliquot and aliquot.replace(",", ".")
                     else:
                         aliquot_ret = aliquot and aliquot.replace(",", ".")
-        return nro, aliquot_ret, aliquot_per
+        return nro, aliquot_ret, aliquot_per, False
 
     @api.model
     def _cron_clean_old_padron_files(self):

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_payment_withholding_checks_multimoneda
 from . import test_own_check_net_amount
 from . import test_padron_cleanup_cron
 from . import test_padron_tmp_dir
+from . import test_padron_santa_fe_contributor_type
 from . import test_payment_register_pro_wizard
 from . import test_payment_withholding_kept_on_post
 from . import test_payment_form_withholding_net

--- a/l10n_ar_tax/tests/test_aliquot_source_order.py
+++ b/l10n_ar_tax/tests/test_aliquot_source_order.py
@@ -91,7 +91,7 @@ class TestAliquotSourceOrder(common.TransactionCase):
         fp_line = self._create_fp_line("agip")
 
         with self._patch_agip_ws():
-            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+            aliquot, ref, __ = fp_line._unpack_ws_data(fp_line._get_aliquot(self.partner, self.date, self.to_date))
 
         self.assertEqual(aliquot, 4.5, "la percepción tiene que salir del padrón, no del ws")
         self.assertIn("AGIP", ref)
@@ -101,7 +101,7 @@ class TestAliquotSourceOrder(common.TransactionCase):
         fp_line = self._create_fp_line("agip")
 
         with self._patch_agip_ws():
-            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+            aliquot, ref, __ = fp_line._unpack_ws_data(fp_line._get_aliquot(self.partner, self.date, self.to_date))
 
         self.assertEqual((aliquot, ref), (9.99, "WS"))
 
@@ -117,7 +117,7 @@ class TestAliquotSourceOrder(common.TransactionCase):
             if self.env.ref("base.user_demo", raise_if_not_found=False):
                 # En base demo no hay padrón que cargar (la demo de l10n_ar_account_reports
                 # crea líneas de Santa Fe): se devuelve el dummy, tampoco el web service.
-                aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+                aliquot, ref, __ = fp_line._unpack_ws_data(fp_line._get_aliquot(self.partner, self.date, self.to_date))
                 self.assertIn("dummy", ref)
             else:
                 with self.assertRaisesRegex(UserError, "No padron uploaded"):
@@ -135,7 +135,7 @@ class TestAliquotSourceOrder(common.TransactionCase):
         fp_line = self._create_fp_line("agip")
 
         with self._patch_agip_ws():
-            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+            aliquot, ref, __ = fp_line._unpack_ws_data(fp_line._get_aliquot(self.partner, self.date, self.to_date))
 
         self.assertEqual((aliquot, ref), (9.99, "WS"))
 
@@ -163,7 +163,7 @@ class TestAliquotSourceOrder(common.TransactionCase):
         fp_line = self._create_fp_line("agip")
 
         with self._patch_agip_ws():
-            aliquot, ref = fp_line._get_aliquot(other_partner, self.date, self.to_date)
+            aliquot, ref, __ = fp_line._unpack_ws_data(fp_line._get_aliquot(other_partner, self.date, self.to_date))
 
         self.assertIsNone(aliquot)
         self.assertIn("Not found in AGIP padron", ref)

--- a/l10n_ar_tax/tests/test_padron_santa_fe_contributor_type.py
+++ b/l10n_ar_tax/tests/test_padron_santa_fe_contributor_type.py
@@ -1,0 +1,230 @@
+"""
+Tests de la base imponible de la retención de IIBB Santa Fe según el tipo de
+contribuyente informado por el padrón PARP.
+
+El PARP informa en la posición 40 del registro (columna E, índice 4 del CSV) si el
+sujeto retenido es contribuyente Local ('D') o de Convenio Multilateral ('C'). Ese
+dato define la base de la retención (art. 380 de la RG 36/2026 de API Santa Fe):
+
+    * Local ('D')                → base neta, sin IVA        → l10n_ar_tax_type iibb_untaxed
+    * Conv. Multilateral ('C')   → total "sin deducción alguna" → l10n_ar_tax_type iibb_total
+
+Antes de este cambio el importador descartaba la columna y siempre aplicaba base neta.
+
+En percepciones la base NO cambia por el régimen de convenio, así que el mapeo sólo
+aplica a retenciones.
+"""
+
+import base64
+import io
+import shutil
+import zipfile
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.api import Environment
+from odoo.tests import tagged
+from odoo.tools import file_path
+
+# CUITs del padrón de ejemplo commiteado en el repo (l10n_ar_tax/doc/padron_santa_fe/)
+PARP_EXAMPLE_FILE = "l10n_ar_tax/doc/padron_santa_fe/PARP_999999_ejemplo_padron_santa_fe.csv"
+CUIT_MULTILATERAL = "20188192514"  # tipo 'C', alícuota retención 0,60
+CUIT_LOCAL = "20203032723"  # tipo 'D', alícuota retención 0,80
+CUIT_NOT_IN_PADRON = "30111111118"
+# Periodo de vigencia del padron de ejemplo
+PADRON_FROM, PADRON_TO = "2026-03-01", "2026-03-31"
+
+
+@tagged("-at_install", "post_install")
+class TestPadronSantaFeContributorType(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.santa_fe = cls.env.ref("base.state_ar_s")
+
+        # Grupo e impuesto de retención de IIBB Santa Fe sobre base neta (el que hoy
+        # existe en las bases). El caso de Convenio Multilateral debe derivar de acá.
+        tax_group = cls.env["account.tax.group"].create(
+            {
+                "name": "Test Ret. IIBB Santa Fe",
+                "company_id": cls.company_ri.id,
+            }
+        )
+        cls.wth_tax_untaxed = cls.env["account.tax"].create(
+            {
+                "name": "Ret. IIBB Santa Fe Aplicada 0.6%",
+                "amount": 0.6,
+                "amount_type": "percent",
+                "type_tax_use": "none",
+                "country_id": cls.env.ref("base.ar").id,
+                "company_id": cls.company_ri.id,
+                "l10n_ar_withholding_payment_type": "supplier",
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_state_id": cls.santa_fe.id,
+                "tax_group_id": tax_group.id,
+            }
+        )
+        fiscal_position = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test Padrón Santa Fe",
+                "company_id": cls.company_ri.id,
+                "l10n_ar_tax_ids": [
+                    Command.create(
+                        {
+                            "default_tax_id": cls.wth_tax_untaxed.id,
+                            "tax_type": "withholding",
+                            "webservice": "padron",
+                        }
+                    )
+                ],
+            }
+        )
+        cls.wth_line = fiscal_position.l10n_ar_tax_ids
+
+    def _read_example_padron(self, cuit):
+        with open(file_path(PARP_EXAMPLE_FILE), encoding="latin-1") as fp:
+            return self.env["res.company.jurisdiction.padron"]._read_padron_lines(fp.readlines(), cuit)
+
+    def _create_example_padron(self):
+        """Carga el padrón de ejemplo del repo como res.company.jurisdiction.padron.
+        Santa Fe sólo acepta ZIP, así que lo comprimimos."""
+        with open(file_path(PARP_EXAMPLE_FILE), encoding="latin-1") as fp:
+            content = fp.read()
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("PARP.TXT", content)
+        padron = self.env["res.company.jurisdiction.padron"].create(
+            {
+                "company_id": self.company_ri.id,
+                "state_id": self.santa_fe.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "parp_santa_fe.zip",
+                "l10n_ar_padron_from_date": PADRON_FROM,
+                "l10n_ar_padron_to_date": PADRON_TO,
+            }
+        )
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
+        return padron
+
+    def _create_partner(self, vat):
+        return self.env["res.partner"].create(
+            {
+                "name": "partner_%s" % vat,
+                "l10n_latam_identification_type_id": self.env.ref("l10n_ar.it_cuit").id,
+                "vat": vat,
+            }
+        )
+
+    @contextmanager
+    def _without_demo_user(self):
+        """La resolución de alícuota devuelve un dummy si la base tiene demo data, así que
+        para ejercitar el camino real hacemos que ese ref no resuelva. Los demás xmlid
+        siguen resolviendo normal."""
+        real_ref = Environment.ref
+
+        def _ref(env, xml_id, raise_if_not_found=True):
+            if xml_id == "base.user_demo":
+                return None
+            return real_ref(env, xml_id, raise_if_not_found=raise_if_not_found)
+
+        with patch.object(Environment, "ref", _ref):
+            yield
+
+    def test_parp_reads_the_contributor_type(self):
+        """El parser informa el tipo de contribuyente en vez de descartar la columna."""
+        self.assertEqual(self._read_example_padron(CUIT_MULTILATERAL), (True, 0.6, 1.25, "C"))
+        self.assertEqual(self._read_example_padron(CUIT_LOCAL), (True, 0.8, 3.25, "D"))
+        self.assertEqual(self._read_example_padron(CUIT_NOT_IN_PADRON), (False, False, False, False))
+
+    def test_parp_tax_type_mapping(self):
+        """Sólo el Convenio Multilateral desvía la base, y sólo en retenciones. El local no
+        pide base: se resuelve la del impuesto configurado en la línea."""
+        self.assertEqual(self.wth_line._get_parp_tax_type("C"), "iibb_total")
+        self.assertFalse(self.wth_line._get_parp_tax_type("D"))
+        self.wth_line.tax_type = "perception"
+        self.assertFalse(self.wth_line._get_parp_tax_type("C"))
+
+    def test_ensure_tax_creates_and_reuses_the_cm_variant(self):
+        """Un CM con la misma alícuota no cae sobre el impuesto de base neta: se crea la
+        variante que retiene sobre el total, y la segunda consulta la reusa."""
+        tax = self.wth_line._ensure_tax(0.6, l10n_ar_tax_type="iibb_total")
+
+        self.assertNotEqual(tax, self.wth_tax_untaxed)
+        self.assertEqual((tax.amount, tax.l10n_ar_tax_type), (0.6, "iibb_total"))
+        self.assertIn("CM", tax.name, "el nombre debe distinguirlo del de base neta")
+        self.assertEqual(self.wth_line._ensure_tax(0.6, l10n_ar_tax_type="iibb_total"), tax, "no debe duplicarla")
+
+    def test_ensure_tax_never_resolves_the_cm_variant_for_a_local(self):
+        """El local no puede resolver a la variante CM ni derivar de ella: quedaría retenido
+        sobre el total con IVA. Tampoco cuando el impuesto configurado tiene la base vacía,
+        que es el estado normal (l10n_ar_tax_type no es required ni tiene default)."""
+        cm_tax = self.wth_line._ensure_tax(0.6, l10n_ar_tax_type="iibb_total")
+        cm_tax.sequence = self.wth_tax_untaxed.sequence - 1  # primera en el orden de búsqueda
+        self.wth_tax_untaxed.l10n_ar_tax_type = False
+        local_base = self.wth_line._get_parp_tax_type("D")
+
+        self.assertEqual(self.wth_line._ensure_tax(0.6, l10n_ar_tax_type=local_base), self.wth_tax_untaxed)
+
+        # a otra alícuota tampoco puede copiar la variante CM
+        new_tax = self.wth_line._ensure_tax(0.9, l10n_ar_tax_type=local_base)
+        self.assertNotEqual(new_tax.l10n_ar_tax_type, "iibb_total")
+        self.assertNotIn("CM", new_tax.name)
+
+    def test_ensure_tax_keeps_a_configured_total_base_for_a_local(self):
+        """Una base total configurada a propósito (proveedor que no discrimina IVA) no la
+        pisa el padrón: el local no pide base y se resuelve la de la línea."""
+        self.wth_tax_untaxed.l10n_ar_tax_type = "iibb_total"
+
+        tax = self.wth_line._ensure_tax(0.6, l10n_ar_tax_type=self.wth_line._get_parp_tax_type("D"))
+
+        self.assertEqual(tax, self.wth_tax_untaxed)
+
+    def test_ensure_tax_does_not_exclude_a_total_base_outside_a_padron_jurisdiction(self):
+        """Donde el padrón no informa el régimen no existe la variante CM: un impuesto sobre
+        el total (IVA no discriminado, ej. Neuquén) se reusa como cualquier otro. Excluirlo
+        crearía un duplicado que retiene sobre la base neta."""
+        neuquen_group = self.env["account.tax.group"].create(
+            {"name": "Test Ret. IIBB Neuquén", "company_id": self.company_ri.id}
+        )
+        # la línea tiene la base vacía, que es el estado normal de las bases instaladas
+        neuquen_vals = {
+            "l10n_ar_state_id": self.env.ref("base.state_ar_q").id,
+            "tax_group_id": neuquen_group.id,
+            "l10n_ar_tax_type": False,
+        }
+        default_tax = self.wth_tax_untaxed.copy({"name": "Ret. IIBB Neuquén 1.5%", "amount": 1.5, **neuquen_vals})
+        total_tax = self.wth_tax_untaxed.copy(
+            {"name": "Ret. IIBB Neuquén 2.0%", "amount": 2.0, **neuquen_vals, "l10n_ar_tax_type": "iibb_total"}
+        )
+        fiscal_position = self.env["account.fiscal.position"].create(
+            {
+                "name": "Test Neuquén",
+                "company_id": self.company_ri.id,
+                "l10n_ar_tax_ids": [Command.create({"default_tax_id": default_tax.id, "tax_type": "withholding"})],
+            }
+        )
+
+        tax = fiscal_position.l10n_ar_tax_ids._ensure_tax(2.0)
+
+        self.assertEqual(tax, total_tax, "debe reusar el impuesto existente, no crear uno de base neta")
+
+    def test_padron_data_threads_the_base_down_to_the_tax(self):
+        """Hilo completo: padrón cargado -> _get_padron_data -> _get_parp_tax_type ->
+        _ensure_tax. El CM resuelve al impuesto sobre el total, el local al de base neta y
+        el que no figura en padrón no pide base (alícuota de castigo)."""
+        self._create_example_padron()
+
+        with self._without_demo_user():
+            cm_data = self.wth_line._get_padron_data(self._create_partner(CUIT_MULTILATERAL), PADRON_FROM, PADRON_TO)
+            local_data = self.wth_line._get_padron_data(self._create_partner(CUIT_LOCAL), PADRON_FROM, PADRON_TO)
+            missing = self.wth_line._get_padron_data(self._create_partner(CUIT_NOT_IN_PADRON), PADRON_FROM, PADRON_TO)
+
+        self.assertEqual((cm_data[0], cm_data[2]), (0.6, "iibb_total"))
+        self.assertEqual((local_data[0], local_data[2]), (0.8, False))
+        self.assertEqual((missing[0], missing[2]), (None, False))
+
+        cm_tax = self.wth_line._ensure_tax(cm_data[0], l10n_ar_tax_type=cm_data[2])
+        self.assertEqual(cm_tax.l10n_ar_tax_type, "iibb_total")
+        self.assertEqual(self.wth_line._ensure_tax(0.6, l10n_ar_tax_type=local_data[2]), self.wth_tax_untaxed)

--- a/l10n_ar_tax/tests/test_padron_tmp_dir.py
+++ b/l10n_ar_tax/tests/test_padron_tmp_dir.py
@@ -29,8 +29,8 @@ class TestPadronTmpDir(common.TransactionCase):
     def _line(self, nro, cuit, aliq):
         return "f0;f1;f2;%s;%s;f5;f6;f7;%s" % (nro, cuit, aliq)
 
-    def _parp_line(self, cuit, per, ret):
-        return "d0;d1;d2;%s;d4;d5;d6;%s;%s" % (cuit, per, ret)
+    def _parp_line(self, cuit, per, ret, contributor_type="D"):
+        return "d0;d1;d2;%s;%s;d5;d6;%s;%s" % (cuit, contributor_type, per, ret)
 
     def _create_arba_padron(self, per_lines, ret_lines, from_date, to_date):
         buffer = io.BytesIO()
@@ -84,8 +84,9 @@ class TestPadronTmpDir(common.TransactionCase):
         )
         partner = self._create_partner(cuit)
 
-        self.assertEqual(padron_1._get_aliquot(partner), ("NRO-1", "1.00", "11.00"))
-        self.assertEqual(padron_2._get_aliquot(partner), ("NRO-2", "2.00", "22.00"))
+        # el padrón de ARBA no informa tipo de contribuyente, por eso el 4to elemento es False
+        self.assertEqual(padron_1._get_aliquot(partner), ("NRO-1", "1.00", "11.00", False))
+        self.assertEqual(padron_2._get_aliquot(partner), ("NRO-2", "2.00", "22.00", False))
 
     def test_santa_fe_does_not_redecode_binary_on_second_cuit(self):
         """El binario se extrae una sola vez, no por cada CUIT consultado."""
@@ -108,8 +109,8 @@ class TestPadronTmpDir(common.TransactionCase):
             result_b = padron._get_aliquot(partner_b)
 
         self.assertEqual(len(calls), 1, "no debe re-decodificar/re-unzipear en la 2da consulta")
-        self.assertEqual(result_a, (True, 3.0, 5.0))
-        self.assertEqual(result_b, (True, 4.25, 7.5))
+        self.assertEqual(result_a, (True, 3.0, 5.0, "D"))
+        self.assertEqual(result_b, (True, 4.25, 7.5, "D"))
 
     def test_find_aliquot_ignores_substring_match(self):
         """El CUIT aparece embebido en otro campo en la 1ra linea; debe matchear la exacta."""


### PR DESCRIPTION
Task: https://www.adhoc.inc/odoo/project.task/71951

## Problema

En Santa Fe la base de la retención de IIBB depende del régimen del sujeto retenido, y el padrón PARP lo informa en la posición 40 del registro (`'C'` = Convenio Multilateral, `'D'` = Local). El importador descartaba esa columna, así que **todas** las retenciones de Santa Fe se calculaban sobre la base neta.

Art. 380 de la RG 36/2026 (API Santa Fe):

| Contribuyente | Base de la retención |
|---|---|
| Local (`'D'`) | base neta, sin IVA (primer párrafo) |
| Convenio Multilateral (`'C'`) | total, "sin deducción alguna" (apartado 1) |

## Solución

El atributo que modela esto ya existe en el core (`account.tax.l10n_ar_tax_type`: `iibb_untaxed` / `iibb_total`) y el cálculo de la retención ya lo respeta. Faltaba que el padrón eligiera cuál aplica.

- El parser devuelve el tipo de contribuyente y el lector del padrón lo mapea a un `l10n_ar_tax_type`.
- La base pasa a ser parte de la búsqueda del impuesto: un 0,6% `iibb_untaxed` y un 0,6% `iibb_total` ya no caen sobre el mismo `account.tax`. Si sólo existe el de base neta, la variante de Convenio Multilateral se crea copiándolo, con el sufijo `CM` en el nombre. La base vacía cuenta como base neta, así que los impuestos que hoy tienen el campo vacío se reusan en vez de duplicarse.
- Ese sufijo es lo que deja la variante fuera del selector de impuesto por defecto: elegirla a mano aplicaría la base total a cualquier contribuyente, incluido el local. Una base total configurada a propósito (IVA no discriminado) sigue siendo elegible y el padrón no la pisa.
- **Sólo el `'C'` pide base.** Forzar la base neta al local pisaría esa base total puesta a propósito, que es una decisión sobre los comprobantes del proveedor y no sobre el régimen. Las percepciones no se tocan: ahí la base no cambia por el régimen de convenio.
- Todo esto está acotado a las jurisdicciones cuyo padrón define la base (`BASE_DEFINING_JURISDICTION_CODES`, hoy sólo Santa Fe). En el resto `iibb_total` es una base configurada como cualquier otra —Neuquén la usa para comprobantes con IVA no discriminado— y filtrar por ella cambiaría la base en silencio y duplicaría impuestos.
- Compatibilidad: `_get_aliquot` devuelve ahora tres elementos siempre; el punto de dispatch normaliza lo que devuelven los web services y los overrides downstream (ej. `saas_client_l10n_ar._get_agip_data`), que siguen devolviendo `(alícuota, referencia)`.

## Tests

6 casos en `test_padron_santa_fe_contributor_type.py`, contra el padrón de ejemplo ya commiteado en `l10n_ar_tax/doc/padron_santa_fe/`: el parser informa el tipo de contribuyente, el mapeo (`'C'` → `iibb_total`, nada para un local ni para percepciones), la variante CM se crea y se reusa, un local nunca resuelve a ella ni deriva de ella, una base total configurada se respeta, y el hilo completo desde el padrón cargado hasta el impuesto.

```
odoo-bin -d <db> -u l10n_ar_tax --test-enable --test-tags=/l10n_ar_tax:TestPadronSantaFeContributorType
```

## Fuera de alcance

Cada uno necesita definición funcional previa:

- **Normalizar `l10n_ar_tax_type`** en las retenciones de IIBB que hoy lo tienen vacío.
- **Régimen cuando el CUIT no figura en el padrón**: hoy se aplica la alícuota de castigo (art. 381) con la base del impuesto configurado.
- **Invalidar el cache de `l10n_ar.partner.tax`** cuando un partner cambia de régimen a mitad de mes.
- **Migrar lo que ya quedó mal**: alícuotas cacheadas y retenciones ya calculadas sobre la base neta para partners `'C'`.
- **Percepciones**: es otro problema (el 50% de la base del art. 387) y no tiene mecanismo nativo.

## Puntos funcionales a confirmar en review

Sobre la norma, no sobre el código:

- El padrón no distingue Régimen General de Regímenes Especiales de Convenio Multilateral; se asume Régimen General.
- Si el coeficiente unificado (F-1276) debería reducir la base — el art. 380 apartado 1 dice "sin deducción alguna", pero la guía de API menciona el coeficiente.
