### PR TITLE
[FIX] l10n_ar_ux: transfer report language fallback

### DIFF
--- a/l10n_ar_ux/reports/report_account_transfer.xml
+++ b/l10n_ar_ux/reports/report_account_transfer.xml
@@ -26,7 +26,7 @@
     <template id="report_account_transfer">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-set="lang" t-value="o.partner_id.lang"/>
+                <t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
                 <t t-call="l10n_ar_ux.report_account_transfer_document" t-lang="lang"/>
             </t>
         </t>


### PR DESCRIPTION
### Problema

En el reporte de transferencia salen en inglés `Date:` y `- Activities Start:`. Los dos son términos de la plantilla `l10n_ar.custom_header`, que este módulo engancha al reporte vía `t-set="custom_header"`. Las traducciones existen (`es_419.po` de `l10n_ar`: *Fecha:* / *- Inicio de las actividades:*) y se cargan bien para los locales `es_*` — el problema no es la traducción sino el idioma con el que se renderiza el reporte.

La plantilla hace:

```xml
<t t-set="lang" t-value="o.partner_id.lang"/>
<t t-call="l10n_ar_ux.report_account_transfer_document" t-lang="lang"/>
```

pero en una transferencia interna `partner_id` es `False` por diseño (`account_internal_transfer` lo fuerza a `False` en `_compute_partner_id`). Con `lang` vacío, `t-lang` (alias de `t-options-lang`) termina en `with_context(lang=False)`, y la lectura de campos traducidos cae a `env.lang or 'en_US'` → término fuente en inglés.

El resto del cuerpo del reporte está escrito directamente en castellano, por eso solo se notan estos dos.

### Solución

Fallback al idioma del contacto de la compañía, mismo patrón que ya usa `l10n_ar_tax` en el reporte de recibo de pago:

```xml
<t t-set="lang" t-value="o.partner_id.lang or o.company_id.partner_id.lang"/>
```

Mismo fix para la plantilla base en https://github.com/ingadhoc/account-financial-tools/pull/1011 (misma rama, build compartido).

### Cómo probar

1. Base con un solo idioma activo distinto de inglés (ej. `es_AR`) y el contacto de la compañía con ese idioma.
2. Crear y confirmar una transferencia interna entre dos diarios de liquidez.
3. Imprimir el reporte de transferencia.
4. Antes: `Date:` / `- Activities Start:`. Después: `Fecha:` / `- Inicio de las actividades:`.

Ticket: https://www.adhoc.inc/odoo/helpdesk/124904