### PR TITLE
[FIX] l10n_ar_tax: keep the new check in sync when withholdings change

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -105,6 +105,28 @@ class AccountPayment(models.Model):
         for rec in self:
             rec.payment_total += rec.withholdings_amount
 
+    def _resync_new_check_amount(self):
+        """Absorber en el cheque nuevo la diferencia que dejó un cambio de retenciones.
+
+        El autollenado del importe del cheque (``_onchange_new_check_default_amount``) corre una
+        sola vez, mientras el cheque no tiene importe. Si las retenciones cambian después, el
+        cheque queda con el importe viejo y el pago se confirma con diferencia: la factura queda
+        con residual (o el partner con un crédito) por exactamente lo que cambió la retención.
+
+        Solo ajustamos si hay un único cheque, que es el caso donde no hay ambigüedad sobre cuál
+        de los cheques absorbe la diferencia.
+        """
+        self.ensure_one()
+        if not self.use_payment_pro or self.state != "draft":
+            return
+        if len(self.l10n_latam_new_check_ids) != 1 or not self.payment_difference:
+            return
+        amount = self.l10n_latam_new_check_ids.amount + self._get_payment_difference_in_currency_a()
+        # un cheque en cero o negativo no existe, asi que ahi dejamos el importe como estaba y la
+        # diferencia queda a la vista en el pago (el ajuste del amount, en cambio, lo lleva a cero)
+        if amount > 0:
+            self.l10n_latam_new_check_ids.amount = self.currency_id.round(amount)
+
     # por ahora no nos funciona computarlas, se duplica el importe. Igual conceptualemnte el onchange acá por ahí
     # está bien porque en realidad es una "sugerencia" actualizar el amount al usuario
     # @api.depends('withholdings_amount')
@@ -114,10 +136,18 @@ class AccountPayment(models.Model):
     #     for rec in (self - latam_checks):
     @api.onchange("withholdings_amount")
     def _onchange_withholdings(self):
+        # en los pagos con cheques nuevos el amount es computado a partir de los importes de los
+        # cheques, así que la diferencia no se puede absorber en el amount: hay que ajustar el cheque
+        for rec in self.filtered(lambda x: x._is_latam_check_payment(check_subtype="new_check")):
+            rec._resync_new_check_amount()
+        self._adjust_amount_for_withholdings()
+
+    def _adjust_amount_for_withholdings(self):
         # solo queremos re-computar en pagos de proveedor
         for rec in self.filtered(
             lambda x: (
                 x.partner_type == "supplier"
+                and not x._is_latam_check_payment(check_subtype="new_check")
                 and x.payment_method_code
                 not in [
                     "in_third_party_checks",
@@ -150,7 +180,9 @@ class AccountPayment(models.Model):
     def _onchange_partner_id(self):
         for rec in self:
             if rec.partner_id != rec._origin.partner_id:
-                rec._onchange_withholdings()
+                # solo el ajuste del amount: el importe del cheque lo escribe quien carga el pago y
+                # no lo tocamos por un cambio de partner, solo cuando cambian las retenciones
+                rec._adjust_amount_for_withholdings()
 
     # # ver mensaje en commit
     # @api.onchange('to_pay_amount', 'withholdable_advanced_amount', 'partner_id')

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -5,6 +5,7 @@ from . import test_vat_fiscal_position_eligibility
 from . import test_withholding_thresholds
 from . import test_payment_withholding_multimoneda
 from . import test_payment_withholding_checks_multimoneda
+from . import test_payment_withholding_check_resync
 from . import test_padron_cleanup_cron
 from . import test_padron_tmp_dir
 from . import test_payment_register_pro_wizard

--- a/l10n_ar_tax/tests/test_payment_withholding_check_resync.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_check_resync.py
@@ -1,0 +1,268 @@
+"""
+Tests de re-sincronización del cheque nuevo cuando cambian las retenciones
+=========================================================================
+
+El importe del cheque nuevo se autocompleta una sola vez, con la diferencia pendiente
+(``_onchange_new_check_default_amount`` de account_payment_pro, que solo pisa cheques sin
+importe). Si las retenciones cambian después de ese autollenado, el cheque queda con el
+importe viejo y el pago se confirma con diferencia: la factura queda con residual, o el
+partner con un crédito, por exactamente lo que cambió la retención.
+
+Ver ingadhoc/account-payment#1141.
+"""
+
+from odoo import Command
+from odoo.addons.l10n_ar_tax.tests.test_payment_withholding_multimoneda import TestPaymentWithholdingMultimoneda
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentCheckWithholdingResync(TestPaymentWithholdingMultimoneda):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        own_checks_method = cls.env.ref("l10n_latam_check.account_payment_method_own_checks")
+        if not cls.bank_ars.outbound_payment_method_line_ids.filtered(lambda line: line.code == "own_checks"):
+            cls.bank_ars.write(
+                {"outbound_payment_method_line_ids": [Command.create({"payment_method_id": own_checks_method.id})]}
+            )
+        cls.own_checks_pml = cls.bank_ars.outbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "own_checks"
+        )
+
+        new_third_party_method = cls.env.ref("l10n_latam_check.account_payment_method_new_third_party_checks")
+        if not cls.bank_ars.inbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "new_third_party_checks"
+        ):
+            cls.bank_ars.write(
+                {"inbound_payment_method_line_ids": [Command.create({"payment_method_id": new_third_party_method.id})]}
+            )
+        cls.new_third_party_pml = cls.bank_ars.inbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "new_third_party_checks"
+        )
+        cls.new_third_party_pml.payment_account_id = cls.env["account.account"].create(
+            {
+                "name": "Cheques de Terceros Test",
+                "code": "TCHQ",
+                "account_type": "asset_current",
+                "company_ids": [Command.set([cls.company.id])],
+            }
+        )
+
+        cls.sale_journal = cls.env["account.journal"].create(
+            {
+                "name": "Ventas Test",
+                "type": "sale",
+                "code": "STEST",
+                "company_id": cls.company.id,
+                "l10n_latam_use_documents": False,
+            }
+        )
+
+    def _create_check_payment(self, invoice, fiscal_position=None):
+        """Pago proveedor con cheques propios, en borrador y todavía sin cheques."""
+        debt = invoice.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        return self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_ars.id,
+                "partner_id": self.partner.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": self.today,
+                "payment_method_line_id": self.own_checks_pml.id,
+                "l10n_ar_fiscal_position_id": fiscal_position and fiscal_position.id or False,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+            }
+        )
+
+    def _create_customer_invoice(self, amount):
+        """Factura de cliente sin impuestos: la deuda es exactamente ``amount``."""
+        invoice = self.env["account.move"].create(
+            {
+                "partner_id": self.partner.id,
+                "invoice_date": self.today,
+                "date": self.today,
+                "move_type": "out_invoice",
+                "journal_id": self.sale_journal.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": self.account_expense.id,
+                        }
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _add_check(self, form, name="00000001"):
+        with form.l10n_latam_new_check_ids.new() as check:
+            check.name = name
+            check.payment_date = self.today
+
+    # ------------------------------------------------------------------
+    # Casos
+    # ------------------------------------------------------------------
+
+    def test_resync_al_agregar_retencion(self):
+        """Cheque primero y retención después: el cheque baja por la retención.
+
+        Sin la re-sincronización el cheque quedaba en la deuda completa y el pago cubría
+        deuda + retención, dejándole un crédito al proveedor.
+        """
+        invoice = self._create_invoice(1_000, self.ars)
+        payment = self._create_check_payment(invoice)
+
+        with Form(payment) as form:
+            self._add_check(form)
+            with form.l10n_latam_new_check_ids.edit(0) as check:
+                self.assertAlmostEqual(check.amount, 1_210, places=2)
+            form.l10n_ar_fiscal_position_id = self.fp_iibb
+
+        self.assertAlmostEqual(payment.withholdings_amount, 30, places=2)
+        self.assertAlmostEqual(payment.l10n_latam_new_check_ids.amount, 1_180, places=2)
+        self.assertAlmostEqual(payment.payment_difference, 0, places=2)
+
+        payment.action_post()
+        self.assertAlmostEqual(invoice.amount_residual, 0, places=2)
+
+    def test_resync_al_quitar_retencion(self):
+        """Se saca la retención después del autollenado: el cheque vuelve a la deuda completa.
+
+        Sin la re-sincronización el cheque quedaba corto y la factura quedaba parcial por el
+        importe de la retención que se sacó (el síntoma reportado en el issue).
+        """
+        invoice = self._create_invoice(1_000, self.ars)
+        payment = self._create_check_payment(invoice, self.fp_iibb)
+
+        with Form(payment) as form:
+            self._add_check(form)
+            with form.l10n_latam_new_check_ids.edit(0) as check:
+                self.assertAlmostEqual(check.amount, 1_180, places=2)
+            form.l10n_ar_fiscal_position_id = self.env["account.fiscal.position"]
+
+        self.assertAlmostEqual(payment.withholdings_amount, 0, places=2)
+        self.assertAlmostEqual(payment.l10n_latam_new_check_ids.amount, 1_210, places=2)
+        self.assertAlmostEqual(payment.payment_difference, 0, places=2)
+
+        payment.action_post()
+        self.assertAlmostEqual(invoice.amount_residual, 0, places=2)
+
+    def test_resync_al_editar_el_importe_retenido(self):
+        """Se edita a mano el importe de la retención: el cheque acompaña el nuevo importe."""
+        invoice = self._create_invoice(1_000, self.ars)
+        payment = self._create_check_payment(invoice, self.fp_iibb)
+
+        with Form(payment) as form:
+            self._add_check(form)
+            with form.l10n_ar_withholding_line_ids.edit(0) as withholding:
+                withholding.amount = 20
+
+        self.assertAlmostEqual(payment.withholdings_amount, 20, places=2)
+        self.assertAlmostEqual(payment.l10n_latam_new_check_ids.amount, 1_190, places=2)
+        self.assertAlmostEqual(payment.payment_difference, 0, places=2)
+
+    def test_resync_en_cobro_a_cliente(self):
+        """Dado un cobro a cliente con un cheque de terceros nuevo ya cargado, cuando se agrega la
+        retención que sufrió el cliente, entonces el cheque baja por esa retención.
+
+        Es el escenario reportado: en cobros a cliente las retenciones se cargan a mano (los
+        computes de la línea filtran ``partner_type == "supplier"``), así que el cheque siempre se
+        carga antes que la retención y el autollenado ya corrió.
+        """
+        invoice = self._create_customer_invoice(1_000)
+        debt = invoice.line_ids.filtered(lambda line: line.account_id.account_type == "asset_receivable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_ars.id,
+                "partner_id": self.partner.id,
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "date": self.today,
+                "payment_method_line_id": self.new_third_party_pml.id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+            }
+        )
+
+        with Form(payment) as form:
+            self._add_check(form)
+            with form.l10n_latam_new_check_ids.edit(0) as check:
+                self.assertAlmostEqual(check.amount, 1_000, places=2)
+            with form.l10n_ar_withholding_line_ids.new() as withholding:
+                withholding.tax_id = self.tax_ret_iibb
+                withholding.amount = 30
+
+        self.assertAlmostEqual(payment.withholdings_amount, 30, places=2)
+        self.assertAlmostEqual(payment.l10n_latam_new_check_ids.amount, 970, places=2)
+        self.assertAlmostEqual(payment.payment_difference, 0, places=2)
+
+    def test_no_resync_al_cambiar_el_partner(self):
+        """Dado un pago con un cheque ya cargado, cuando se cambia el partner, entonces el importe
+        del cheque no se toca.
+
+        ``_onchange_partner_id`` re-dispara el ajuste del ``amount``, pero el importe del cheque lo
+        escribe quien carga el pago: solo lo movemos cuando cambian las retenciones, que es el bug
+        que este fix corrige.
+
+        No chequeamos el ``amount`` del pago porque en este camino queda desincronizado de los
+        cheques (lo pisa ``_onchange_to_pay_lines_adjust_amount`` de account_payment_pro al
+        recomputarse la deuda del partner nuevo), con o sin este fix. Es otro problema.
+        """
+        self._create_invoice(1_000, self.ars)
+        invoice_cf = self.env["account.move"].create(
+            {
+                "partner_id": self.partner_cf.id,
+                "invoice_date": self.today,
+                "date": self.today,
+                "move_type": "in_invoice",
+                "journal_id": self.purchase_journal.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {"name": "Test", "quantity": 1, "price_unit": 500, "account_id": self.account_expense.id}
+                    )
+                ],
+            }
+        )
+        invoice_cf.action_post()
+
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_ars.id,
+                "partner_id": self.partner.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": self.today,
+                "payment_method_line_id": self.own_checks_pml.id,
+            }
+        )
+
+        with Form(payment) as form:
+            self._add_check(form)
+            with form.l10n_latam_new_check_ids.edit(0) as check:
+                self.assertAlmostEqual(check.amount, 1_210, places=2)
+            form.partner_id = self.partner_cf
+
+        self.assertAlmostEqual(payment.to_pay_amount, 500, places=2)
+        self.assertAlmostEqual(payment.l10n_latam_new_check_ids.amount, 1_210, places=2)
+
+    def test_no_resync_con_varios_cheques(self):
+        """Con más de un cheque no ajustamos ninguno: no hay cuál elegir sin adivinar.
+
+        Queda la diferencia a la vista en el pago para que la resuelva quien lo carga.
+        """
+        invoice = self._create_invoice(1_000, self.ars)
+        payment = self._create_check_payment(invoice)
+
+        with Form(payment) as form:
+            self._add_check(form, "00000001")
+            with form.l10n_latam_new_check_ids.edit(0) as check:
+                check.amount = 610
+            self._add_check(form, "00000002")
+            form.l10n_ar_fiscal_position_id = self.fp_iibb
+
+        self.assertAlmostEqual(sum(payment.l10n_latam_new_check_ids.mapped("amount")), 1_210, places=2)
+        self.assertAlmostEqual(payment.payment_difference, -30, places=2)


### PR DESCRIPTION
### Qué pasa hoy

El importe de un cheque nuevo se autocompleta con la diferencia pendiente, pero
`_onchange_new_check_default_amount` (account_payment_pro) solo pisa cheques **sin** importe:
corre una sola vez. Si las retenciones cambian después de ese autollenado, el cheque queda con
el importe viejo, nada lo re-sincroniza y el pago se confirma con diferencia. El resultado es
una factura con residual, o un crédito al partner, por exactamente lo que cambió la retención.

Casos reproducidos (deuda 1210, retención 30):

| secuencia | antes | ahora |
|---|---|---|
| cheque → agrego retención | cheque 1210, se paga deuda + retención (crédito al partner) | cheque 1180 |
| retención → cheque → saco la retención | cheque 1180, factura parcial por 30 | cheque 1210 |
| retención → cheque → edito el importe retenido a 20 | cheque 1180, factura parcial por 10 | cheque 1190 |

### Qué cambia

`_onchange_withholdings` ya re-sincroniza el `amount` cuando cambian las retenciones, pero en
los pagos con cheques nuevos el `amount` es computado a partir de los importes de los cheques,
así que ahí no puede absorber la diferencia. Esos pagos ahora ajustan el cheque
(`_resync_new_check_amount`) en lugar del `amount`.

El ajuste del `amount` se separó en `_adjust_amount_for_withholdings`, que es lo único que
re-dispara `_onchange_partner_id`: el importe del cheque lo escribe quien carga el pago y no se
mueve por un cambio de partner, solo cuando cambian las retenciones.

Se ajusta solo si hay **un** cheque, que es el caso donde no hay que adivinar cuál absorbe la
diferencia. Con varios cheques no se toca ninguno y la diferencia queda a la vista en el pago
(antes, en cheques propios, el `amount` se pisaba y quedaba desincronizado de la suma de los
cheques sin que se notara).

### Tests

6 tests nuevos en `l10n_ar_tax/tests/test_payment_withholding_check_resync.py`, con `Form`
porque el bug vive en un onchange y no se dispara con `create()`/`write()` directo:

- cheque → agrego / saco / edito la retención (proveedor, cheques propios)
- cobro a **cliente** con cheques de terceros nuevos, que es el escenario reportado (ahí las
  retenciones se cargan a mano, así que el cheque siempre va primero)
- varios cheques: no se toca ninguno y la diferencia queda visible
- cambio de partner: el importe del cheque no se toca (guarda de regresión — también pasa sin el
  fix, está para que el resync no se extienda a ese camino)

Los 5 primeros fallan sin el fix y pasan con él; `TestPaymentChecksWithholding` y
`TestPaymentWithholdingMultimoneda` siguen verdes (20 tests en total).

Reportado en ingadhoc/account-payment#1141.
