### PR TITLE
[IMP] l10n_ar_tax: orden único de resolución de alícuota (padrón antes que web service) y padrón de AGIP

### DIFF
--- a/l10n_ar_tax/README.md
+++ b/l10n_ar_tax/README.md
@@ -11,7 +11,7 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 - Fiscal position-based tax automation.
 - Withholding certificate generation.
 - Integration with ARCA web services.
-- ARBA and Santa Fe (PARP) padron importers.
+- ARBA, Santa Fe (PARP) and AGIP (CABA) padron readers.
 - Same-period base accumulation for taxes like Ganancias with minimum thresholds.
 - Integration with `account_payment_pro` tri-currency model.
 
@@ -31,7 +31,15 @@ Implements automatic calculation of Argentine withholdings (retenciones) and per
 2. **Fiscal positions:** Accounting → Configuration → Fiscal Positions — set up automatic tax assignment. In a multi-company setup with branches, a fiscal position of a branch can use the tax groups and taxes of its parent company (same behaviour as standard Odoo account mapping), so the chart of taxes only needs to be configured once on the parent.
 3. **Partner tax ID:** in Contacts, configure CUIT/CUIL/DNI.
 4. **Tax ratios:** set ratios (1–100) on percentage-based taxes to control the taxable base percentage.
-5. **Padron importers:** for Santa Fe (PARP) and ARBA, configure the corresponding fiscal position with the web service setting. See `doc/padron_santa_fe/` for specs and examples.
+5. **Padron files:** for Santa Fe (PARP), ARBA and AGIP (CABA) the padron file is uploaded in Accounting → Configuration → Padron Alicuotas. The aliquot is read from the uploaded file on demand (AGIP accepts the `.rar` published by AGIP, or a `.zip`; reading `.rar` requires the `unrar` python library). See `doc/padron_santa_fe/` for specs and examples.
+
+### How the aliquot is resolved
+
+The same order applies to every jurisdiction, so a padron file always works as the contingency for a failing web service:
+
+1. **Aliquot loaded on the contact** (Contacts → Accounting) for the period: it wins over everything else.
+2. **Padron file** uploaded for that jurisdiction and period: it wins over the web service, even when the fiscal position line is set to query one.
+3. **Web service** of the jurisdiction (ARBA, Rentas Córdoba, AGIP). Setting the line to *Archivo de padrón* means this jurisdiction never queries a web service: with no padron uploaded the user is asked to upload it instead.
 
 ## Usage
 

--- a/l10n_ar_tax/demo/account_fiscal_position_demo.xml
+++ b/l10n_ar_tax/demo/account_fiscal_position_demo.xml
@@ -22,7 +22,7 @@
         <field name="fiscal_position_id" ref="fiscal_position_caba_cordoba_perc"/>
         <field name="default_tax_id" eval="ref('account.%s_%s' % (ref('base.company_ri'), 'ri_tax_percepcion_iibb_co_aplicada'))"/>
         <field name="tax_type">perception</field>
-        <field name="webservice">agip</field>
+        <field name="webservice">rentas_cordoba</field>
     </record>
 
     <!-- Perc. CABA -->

--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -457,6 +457,12 @@ msgid "AGIP (Regimen General)"
 msgstr "AGIP (Régimen General)"
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "AGIP padron aliquot (imported file)"
+msgstr "Alícuota padrón AGIP (archivo importado)"
+
+#. module: l10n_ar_tax
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_tax_form
 msgid "API"
 msgstr ""
@@ -803,6 +809,12 @@ msgstr "Impuesto por Defecto"
 
 #. module: l10n_ar_tax
 #. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "Default aliquot. Not found in AGIP padron"
+msgstr "Alícuota por defecto. No figura en padrón AGIP"
+
+#. module: l10n_ar_tax
+#. odoo-python
 #: code:addons/l10n_ar_tax/models/res_company.py:0
 msgid "Detail: %s"
 msgstr "Detalle: %s"
@@ -1122,6 +1134,12 @@ msgid "Only compressed ZIP files are allowed for Santa Fe."
 msgstr "Solo se permiten archivos ZIP comprimidos para Santa Fe."
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "Only compressed ZIP or RAR files are allowed for AGIP (CABA)."
+msgstr "Solo se permiten archivos ZIP o RAR comprimidos para AGIP (CABA)."
+
+#. module: l10n_ar_tax
 #: model:ir.actions.act_window,name:l10n_ar_tax.act_company_jurisdiction_padron
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_form
 #: model_terms:ir.ui.view,arch_db:l10n_ar_tax.view_res_company_jurisdiction_padron_tree
@@ -1381,6 +1399,30 @@ msgid "Taxes"
 msgstr ""
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid ""
+"The aliquot padron could not be read: looking up CUIT %s took too long. "
+"Please try again in a few minutes or enter the tax rate manually on the "
+"contact."
+msgstr ""
+"No se pudo leer el padrón de alícuotas: la búsqueda del CUIT %s tardó "
+"demasiado. Vuelva a intentar en unos minutos o cargue la alícuota "
+"manualmente en el contacto."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "The compressed file does not contain the padron in CSV or TXT format."
+msgstr "El archivo comprimido no contiene el padrón en formato CSV o TXT."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid "The padron for %s is not implemented."
+msgstr "El padrón para %s no está implementado."
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,help:l10n_ar_tax.field_account_tax__l10n_ar_state_code
 msgid "The state code."
 msgstr "El código del estado."
@@ -1392,6 +1434,16 @@ msgid ""
 "The total percentage (%s) should be greater than 0 and less than or equal to "
 "100."
 msgstr "El porcentaje total (%s) debe ser mayor que 0 y menor o igual que 100."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/res_company_jurisdiction_padron.py:0
+msgid ""
+"This database cannot read RAR files (the 'unrar' library is not "
+"installed). Please upload the AGIP padron as a ZIP file instead."
+msgstr ""
+"Esta base de datos no puede leer archivos RAR (la librería 'unrar' no está "
+"instalada). Suba el padrón de AGIP como archivo ZIP."
 
 #. module: l10n_ar_tax
 #. odoo-python

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -80,7 +80,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
                     raise ValidationError(
                         "Impuesto %s sin provincia establecida, no puede consultar padrón" % record.default_tax_id.name
                     )
-                if record.default_tax_id.l10n_ar_state_id.jurisdiction_code not in ["902", "921"]:
+                if not record._get_padron_config(record.default_tax_id.l10n_ar_state_id):
                     raise ValidationError(
                         "Padrón no implementado para la provincia de %s." % record.default_tax_id.l10n_ar_state_id.name
                     )
@@ -263,7 +263,7 @@ class AccountFiscalPositionL10nArTax(models.Model):
         self.ensure_one()
         from_date = date + relativedelta(day=1)
         to_date = from_date + relativedelta(days=-1, months=+1)
-        aliquot, ref = getattr(self, "_get_%s_data" % self.webservice)(partner, from_date, to_date)
+        aliquot, ref = self._get_aliquot(partner, from_date, to_date)
         # devolvemos None si es no inscripto
         if aliquot is None:
             tax = self.default_tax_id
@@ -324,11 +324,106 @@ class AccountFiscalPositionL10nArTax(models.Model):
         )
         return res
 
+    def _get_padron_config(self, state):
+        """Jurisdicciones que publican padrón de alícuotas en archivo, y cómo se lee ese
+        archivo: con qué referencia se registra la alícuota encontrada, con cuál la del
+        contribuyente ausente, y cómo se parsea el valor cuando no viene como float.
+
+        Sumar una jurisdicción es sumar una entrada acá, no un if en la lógica de
+        resolución. Devuelve False si la jurisdicción no tiene padrón implementado.
+        """
+        return {
+            "901": {  # CABA (AGIP, Regímenes Generales)
+                "found_ref": _("AGIP padron aliquot (imported file)"),
+                "missing_ref": _("Default aliquot. Not found in AGIP padron"),
+            },
+            "902": {  # Buenos Aires (ARBA)
+                "found_ref": _("ARBA padron aliquot (imported file)"),
+                "missing_ref": _("ARBA unregistered aliquot (imported file)"),
+                # ARBA publica las alícuotas como texto con coma decimal
+                "parse": lambda value: float(value.replace(",", ".")),
+            },
+            "921": {  # Santa Fe (PARP)
+                "found_ref": _("Santa Fe padron aliquot"),
+                "missing_ref": _("Penalty aliquot. Not found in Santa Fe padron"),
+            },
+        }.get(state.jurisdiction_code if state else "", False)
+
+    def _get_aliquot(self, partner, date, to_date):
+        """Orden de resolución de la alícuota, único para todas las jurisdicciones:
+
+        1) Padrón cargado en esta base y vigente para el período: manda siempre. Es la
+           contingencia para cuando el web service de la jurisdicción falla, así que gana
+           incluso si la línea está configurada para consultar web service.
+        2) Sin padrón cargado: se consulta el web service de la jurisdicción, salvo que la
+           línea esté configurada como "Archivo de padrón", que es la forma de decir "esta
+           jurisdicción no consulta web service nunca" y entonces pedimos que lo carguen.
+
+        La alícuota cargada en el contacto (l10n_ar.partner.tax) tiene prioridad sobre todo
+        esto y se resuelve antes, en account.fiscal.position._get_taxes, sin llegar acá.
+
+        :return: (float|None, string) alícuota y referencia. None = no inscripto, se usa el
+            impuesto por defecto de la línea.
+        """
+        self.ensure_one()
+        padron_file = self._search_padron_file(self.default_tax_id.l10n_ar_state_id, date)
+        if padron_file:
+            return self._get_aliquot_from_padron(padron_file, partner)
+        if self.webservice == "padron":
+            # Mientras se carga data demo no hay archivo de padrón que subir: la demo de
+            # l10n_ar_account_reports crea líneas de Santa Fe, que se derivan a "padron".
+            if self.env.ref("base.user_demo", raise_if_not_found=False):
+                return (2.5 if self.tax_type == "withholding" else 3.0, "VALOR DUMMY | dummy")
+            raise self._no_padron_uploaded_error(date, to_date)
+        return getattr(self, "_get_%s_data" % self.webservice)(partner, date, to_date)
+
+    def _get_aliquot_from_padron(self, padron_file, partner):
+        """Lee la alícuota del archivo de padrón cargado en la base. Mismo tratamiento para
+        todas las jurisdicciones: lo único propio de cada una está en _get_padron_config.
+        """
+        self.ensure_one()
+        # Sin CUIT no hay nada que buscar en el archivo: un vat vacío matchearía la línea de
+        # cualquier otro contribuyente. Va acá y no en _get_aliquot para no cambiarles el
+        # comportamiento a los web services, que resuelven el partner sin CUIT cada uno a su
+        # manera (rentas_cordoba lo trata como no inscripto y aplica el impuesto por defecto).
+        partner.ensure_vat()
+        # sin dummy de demo: si el padrón está cargado se lee, también en bases demo (el dummy
+        # de demo está donde no hay de dónde leer: el web service y el padrón sin archivo).
+        config = self._get_padron_config(self.default_tax_id.l10n_ar_state_id)
+        is_in_padron, aliquot_ret, aliquot_per = padron_file._get_aliquot(partner)
+        if not is_in_padron:
+            return None, config["missing_ref"]
+        aliquot = aliquot_ret if self.tax_type == "withholding" else aliquot_per
+        if config.get("parse"):
+            aliquot = config["parse"](aliquot)
+        return aliquot, config["found_ref"]
+
     def _get_agip_data(self, partner, date, to_date):
+        """Metodo que obtiene la alicuota de AGIP (CABA) del padron que Adhoc baja y procesa
+        en su propia base
+
+        :return: (float, string) alícuota y referencia
+
+        Se llama solo cuando el cliente no cargó el padron de AGIP en su base (ver
+        _get_aliquot). En las bases SaaS de Adhoc, saas_client_l10n_ar extiende este método
+        para consultar ese padron; sin esa integración no tenemos de dónde sacar la alícuota
+        y pedimos que carguen el padron.
+        """
+        self.ensure_one()
+
         # si es base en data demo devolvemos una alicuota demo para que no falle la demo data
         if self.env.ref("base.user_demo", raise_if_not_found=False):
             return (2.5 if self.tax_type == "withholding" else 3.0, "VALOR DUMMY | dummy")
-        raise UserError(_("Missing ADHOC credential configuration for AGIP tax rate queries"))
+
+        raise self._no_padron_uploaded_error(date, to_date)
+
+    def _no_padron_uploaded_error(self, date, to_date):
+        return UserError(
+            _(
+                "No padron uploaded for the indicated date %s to %s. You must upload it in 'Accounting / Configuration / AFIP / Tax Rate Padron by Company' or manually enter the tax rate on the contact for the current period."
+            )
+            % (date, to_date)
+        )
 
     def _get_arba_data(self, partner, date, to_date):
         """Metodo que obtiene la alicuota de ARBA de un partner y fecha dado
@@ -339,8 +434,8 @@ class AccountFiscalPositionL10nArTax(models.Model):
             float valor alicuota (retencion o percepcion depende del caso)
             string "numero comprobante codigohast GrupoRetencion/Percepcion"
 
-        Si hay un padron de alicuotas ya cargado en el sistema, lo usamos
-        para obtener la alícuota, sino consultamos el webservice de ARBA
+        Solo consulta el webservice: si hay padrón cargado en la base no se llega hasta acá
+        (ver _get_aliquot).
         """
         self.ensure_one()
 
@@ -350,11 +445,6 @@ class AccountFiscalPositionL10nArTax(models.Model):
 
         cuit = partner.ensure_vat()
         _logger.info("Getting ARBA data for cuit %s from date %s to date %s" % (date, to_date, cuit))
-
-        # Si no existe padron NO devolvemos ref y pasamos a consultar alícuota al webservice
-        alicuot, ref = self._get_padron_data(partner, date, to_date)
-        if ref:
-            return alicuot, ref
 
         arba_cit = self.fiscal_position_id.company_id.arba_consultar_contribuyente(cuit, date, to_date)
         if arba_cit.get("NumeroComprobante"):
@@ -458,54 +548,8 @@ class AccountFiscalPositionL10nArTax(models.Model):
         return aliquot, ref
 
     def _get_padron_data(self, partner, date, to_date):
-        """Método implementado para obtener alícuota de padrón ARBA y Santa Fe:
-        jurisdiction_code de Santa Fe = 921, de ARBA = 902
-        1) Santa Fe:
-         * si no existe padrón para el período correspondiente entonces devuelve UserError para que lo cargue.
-         * si existe padrón para el período correspondiente, busca el CUIT en el padrón y:
-            a) si lo encuentra devuelve la tasa y "Alícuota padrón Santa Fe",
-            b) si no lo encuentra devuelve None, "Alícuota castigo. No figura en padrón Santa Fe"
-        2) ARBA:
-         * si no existe padrón devuelve None, None
-         * si existe padrón para el período correspondiente, busca el CUIT en el padrón y:
-            a) si lo encuentra devuelve la tasa y "Alícuota padrón ARBA (archivo importado)",
-            b) si no lo encuentra devuelve None, "Alícuota no inscripto ARBA (archivo importado)"
-
-        return: alicuot, ref
+        """Alícuota de una línea configurada como "Archivo de padrón" (nunca consulta web
+        service). Es el método que despacha `webservice = padron`; la resolución en sí es la
+        misma para todas las jurisdicciones y vive en _get_aliquot.
         """
-        self.ensure_one()
-        if self.env.ref("base.user_demo", raise_if_not_found=False):
-            return (2.5 / 3.0, "VALOR DUMMY | dummy")
-        state = self.default_tax_id.l10n_ar_state_id
-        padron_file = self._search_padron_file(state, date)
-        if not padron_file:
-            # si la consulta de padron viene por "contingencia" (por ej. se usa ws de arba o agip) y no hay padron, no queremos raise
-            if self.webservice != "padron":
-                return None, None
-            # Si se está consultando alícuota con tipo "padron" y no hay, entonces damos error.
-            raise UserError(
-                _(
-                    "No padron uploaded for the indicated date %s to %s. You must upload it in 'Accounting / Configuration / AFIP / Tax Rate Padron by Company' or manually enter the tax rate on the contact for the current period."
-                )
-                % (date, to_date)
-            )
-        nro, alicuot_ret, alicuot_per = padron_file._get_aliquot(partner)
-        if state.jurisdiction_code == "921":
-            if nro:
-                # en santa fe en realidad no hay nro, viene True/False (Segun si lo encontramos), por eso no devolvemos string genérica
-                return (
-                    alicuot_ret if self.tax_type == "withholding" else alicuot_per,
-                    _("Santa Fe padron aliquot"),
-                )
-            else:
-                return None, _("Penalty aliquot. Not found in Santa Fe padron")
-        if state.jurisdiction_code == "902":
-            if nro:
-                return (
-                    float(alicuot_ret.replace(",", "."))
-                    if self.tax_type == "withholding"
-                    else float(alicuot_per.replace(",", ".")),
-                    _("ARBA padron aliquot (imported file)"),
-                )
-            else:
-                return None, _("ARBA unregistered aliquot (imported file)")
+        return self._get_aliquot(partner, date, to_date)

--- a/l10n_ar_tax/models/res_company_jurisdiction_padron.py
+++ b/l10n_ar_tax/models/res_company_jurisdiction_padron.py
@@ -1,18 +1,20 @@
 import base64
-import io
 import logging
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import zipfile
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
 GREP_TIMEOUT = 30
+# Magic bytes de un ZIP: archivo con contenido, vacio y multi-volumen.
+ZIP_MAGIC_BYTES = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
 
 
 class ResCompanyJurisdictionPadron(models.Model):
@@ -43,8 +45,8 @@ class ResCompanyJurisdictionPadron(models.Model):
     @api.constrains("state_id")
     def check_state_id(self):
         for rec in self:
-            if rec.state_id.jurisdiction_code not in ["902", "921"]:
-                raise ValidationError("El padron para (%s) no está implementado." % rec.state_id.name)
+            if rec.state_id.jurisdiction_code not in ["901", "902", "921"]:
+                raise ValidationError(_("The padron for %s is not implemented.") % rec.state_id.name)
 
     @api.constrains("state_id", "file_padron")
     def _check_santa_fe_file_padron_format(self):
@@ -57,6 +59,27 @@ class ResCompanyJurisdictionPadron(models.Model):
             if not rec._has_zip_filename() or not rec._is_zip_content(file_content):
                 raise ValidationError(_("Only compressed ZIP files are allowed for Santa Fe."))
 
+    @api.constrains("state_id", "file_padron")
+    def _check_agip_file_padron_format(self):
+        """Validar que para AGIP (CABA) solo se permiten archivos comprimidos: RAR
+        tal como lo publica AGIP, o ZIP si se re-comprime."""
+        for rec in self:
+            if not rec._is_agip_jurisdiction() or not rec.file_padron:
+                continue
+
+            file_content = base64.b64decode(rec.file_padron)
+            if not rec._has_compressed_filename() or not rec._is_compressed_content(file_content):
+                raise ValidationError(_("Only compressed ZIP or RAR files are allowed for AGIP (CABA)."))
+            # Validamos acá y no al liquidar: si falta la lib de rar queremos que se
+            # entere quien sube el archivo, no quien emite el comprobante.
+            if rec._is_rar_content(file_content) and not rec._rar_support_available():
+                raise ValidationError(
+                    _(
+                        "This database cannot read RAR files (the 'unrar' library is not installed). "
+                        "Please upload the AGIP padron as a ZIP file instead."
+                    )
+                )
+
     @api.depends("company_id", "state_id")
     def name_get(self):
         res = []
@@ -66,20 +89,26 @@ class ResCompanyJurisdictionPadron(models.Model):
         return res
 
     def descompress_file(self, file_padron, dest_dir="/tmp"):
-        _logger.log(25, "Descompress zip file")
-        try:
-            file = base64.b64decode(file_padron)
-        except:
-            file = base64.decodestring(file_padron)
+        """Extrae el padrón comprimido en dest_dir. Soporta ZIP (ARBA, Santa Fe) y
+        RAR (AGIP publica el padrón de Regímenes Generales en .rar)."""
+        file = base64.b64decode(file_padron)
         fobj = tempfile.NamedTemporaryFile(delete=False)
         fname = fobj.name
         fobj.write(file)
         fobj.close()
-        f = open(fname, "r+b")
-        f.write(base64.b64decode(file_padron))
-        with zipfile.ZipFile(f, "r") as zip_file:
-            zip_file.extractall(path=dest_dir)
-            zip_file.close()
+        os.makedirs(dest_dir, exist_ok=True)
+        if self._is_rar_content(file):
+            _logger.log(25, "Descompress rar file")
+            # Import lazy: no declaramos unrar en external_dependencies para no
+            # romper instalaciones que no usan el padrón de AGIP. Que la lib esté
+            # disponible se valida al subir el archivo (_check_agip_file_padron_format).
+            from unrar import rarfile
+
+            rarfile.RarFile(fname).extractall(path=dest_dir)
+        else:
+            _logger.log(25, "Descompress zip file")
+            with zipfile.ZipFile(fname, "r") as zip_file:
+                zip_file.extractall(path=dest_dir)
 
     def find_aliquot(self, path, cuit):
         """We try to find aliqut and number for a partner given"""
@@ -102,21 +131,63 @@ class ResCompanyJurisdictionPadron(models.Model):
         self.ensure_one()
         return self.state_id and self.state_id.jurisdiction_code == "921"
 
+    def _is_agip_jurisdiction(self):
+        """Check if jurisdiction is CABA / AGIP (Regímenes Generales padron)"""
+        self.ensure_one()
+        return self.state_id and self.state_id.jurisdiction_code == "901"
+
+    def _is_single_file_padron(self):
+        """Jurisdicciones cuyo padrón viene en un único archivo con las dos alícuotas por
+        CUIT y las mismas columnas, así que se leen igual (ver _read_padron_lines): Santa Fe
+        (921, padrón PARP de API) y AGIP / CABA (901, Regímenes Generales). ARBA (902) no
+        entra acá: publica percepciones y retenciones en archivos separados."""
+        self.ensure_one()
+        return self._is_santa_fe_jurisdiction() or self._is_agip_jurisdiction()
+
     def _is_zip_content(self, file_content):
-        return zipfile.is_zipfile(io.BytesIO(file_content))
+        # Miramos los magic bytes en lugar de zipfile.is_zipfile(io.BytesIO(...)): el
+        # BytesIO duplica en memoria todo el contenido, y el padron de AGIP pesa >100 MB.
+        # Como efecto, alcanza con pasar los primeros bytes del archivo.
+        return file_content[:4] in ZIP_MAGIC_BYTES
+
+    def _is_rar_content(self, file_content):
+        # Magic bytes de RAR: "Rar!\x1a\x07" (común a v4 y v5).
+        return file_content.startswith(b"Rar!\x1a\x07")
+
+    def _rar_support_available(self):
+        """La lib unrar no está en external_dependencies (no queremos condicionar la
+        instalación del módulo a un padrón puntual), así que chequeamos en runtime."""
+        try:
+            from unrar import rarfile  # noqa: F401
+
+            return True
+        except Exception:
+            return False
+
+    def _is_compressed_content(self, file_content):
+        return self._is_zip_content(file_content) or self._is_rar_content(file_content)
 
     def _has_zip_filename(self):
         self.ensure_one()
         return bool(self.filename and self.filename.lower().endswith(".zip"))
 
-    def _read_parp_lines(self, lines, cuit):
+    def _has_compressed_filename(self):
+        self.ensure_one()
+        return bool(self.filename and self.filename.lower().endswith((".zip", ".rar")))
+
+    def _read_padron_lines(self, lines, cuit):
+        """Layout del padrón de archivo único, compartido por Santa Fe (PARP) y AGIP:
+        F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
+        Returns: (is_in_padron, aliquot_ret, aliquot_per)
+        """
         aliquot_ret = False
         aliquot_per = False
         is_in_padron = False
         for line in lines:
             if not line:
                 continue
-            values = [value.strip() for value in line.split(";")]
+            # Algunos padrones (AGIP) traen bytes nulos y BOM en la primera columna.
+            values = [value.replace("\0", "").strip() for value in line.split(";")]
             if len(values) <= 8:
                 continue
             # CUIT is at index 3, compare as strings
@@ -129,19 +200,91 @@ class ResCompanyJurisdictionPadron(models.Model):
                 break
         return is_in_padron, aliquot_ret, aliquot_per
 
-    def _find_parp_file(self, rootdir):
+    def _find_padron_aliquot(self, path, cuit):
+        """Busca el CUIT en un padrón de archivo único (ver _is_single_file_padron) y
+        devuelve (is_in_padron, aliquot_ret, aliquot_per).
+
+        Filtra los candidatos con grep -F (en C) porque el padrón de AGIP tiene del
+        orden de 1.5M de líneas; la comparación exacta por columna la hace
+        _read_padron_lines para descartar falsos positivos (CUIT como substring de otro
+        campo). Si grep timeoutea damos error en lugar de devolver una alícuota de castigo
+        por no haber podido leer el padrón.
+        """
+        try:
+            result = subprocess.run(
+                # -a: los padrones pueden traer bytes nulos y grep los trataría como binarios
+                ["grep", "-a", "-F", cuit, path],
+                capture_output=True,
+                encoding="latin-1",
+                timeout=GREP_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            _logger.warning("Padrón: la búsqueda del cuit %s en %s superó el timeout.", cuit, path)
+            raise UserError(
+                _(
+                    "The aliquot padron could not be read: looking up CUIT %s took too long. Please try "
+                    "again in a few minutes or enter the tax rate manually on the contact."
+                )
+                % cuit
+            )
+        # grep devuelve 0 si encontró, 1 si no encontró y >= 2 ante un error (el archivo lo
+        # borró otro worker mientras publicaba el padrón, permisos, path inválido). Sin este
+        # chequeo un error se lee como "el CUIT no figura" y termina aplicando la alícuota de
+        # castigo (Santa Fe) o la por defecto (AGIP) en silencio, que es justo lo que este
+        # método intenta evitar con el timeout.
+        if result.returncode >= 2:
+            _logger.warning(
+                "Padrón: grep terminó con código %s buscando el cuit %s en %s: %s",
+                result.returncode,
+                cuit,
+                path,
+                result.stderr,
+            )
+            raise UserError(
+                _(
+                    "The aliquot padron could not be read: looking up CUIT %s failed. Please try "
+                    "again in a few minutes or enter the tax rate manually on the contact."
+                )
+                % cuit
+            )
+        return self._read_padron_lines(result.stdout.splitlines(), cuit)
+
+    def _find_padron_file(self, rootdir):
+        """Busca el padrón dentro del directorio ya descomprimido: primero por nombre y, como
+        último recurso, cualquier archivo cuyo contenido tenga el layout del padrón (el .rar
+        de AGIP lo trae con nombre y extensión variables). Miramos el contenido y no cualquier
+        archivo suelto porque leer un readme o un pdf como padrón no falla: devuelve "no
+        figura" y aplica la alícuota por defecto en silencio.
+        """
         fallback_match = False
+        any_file_match = False
         for subdir, dirs, files in os.walk(rootdir):
             for filename in files:
                 lower_filename = filename.lower()
+                path_file = os.path.join(subdir, filename)
                 if lower_filename.endswith((".csv", ".txt")):
                     if "parp" in lower_filename:
-                        return os.path.join(subdir, filename)
+                        return path_file
                     if not fallback_match:
-                        fallback_match = os.path.join(subdir, filename)
-        return fallback_match
+                        fallback_match = path_file
+                elif not any_file_match and self._has_padron_layout(path_file):
+                    any_file_match = path_file
+        return fallback_match or any_file_match
 
-    def _get_parp_tmp_dir(self):
+    def _has_padron_layout(self, path_file):
+        """El padrón es un CSV de más de 8 columnas separadas por ';' (ver
+        _read_padron_lines). Alcanza con mirar la primera línea no vacía.
+        """
+        try:
+            with open(path_file, encoding="latin-1") as fp:
+                for line in fp:
+                    if line.strip():
+                        return len(line.split(";")) > 8
+        except OSError:
+            return False
+        return False
+
+    def _get_padron_tmp_dir(self):
         # Dir por padron+periodo: no mezcla archivos de otro mes.
         self.ensure_one()
         return "/tmp/l10n_ar_padron_%s_%s_%s" % (
@@ -150,38 +293,47 @@ class ResCompanyJurisdictionPadron(models.Model):
             self.l10n_ar_padron_to_date,
         )
 
-    def _ensure_parp_file_extracted(self):
-        # Extrae/persiste una sola vez y reutiliza (antes se re-decodificaba/re-unzipeaba por CUIT).
+    def _ensure_padron_file_extracted(self):
+        """Descomprime el padrón una sola vez y lo deja en el directorio temporal del
+        período: de ahí en más todas las búsquedas usan ese archivo, hasta que se reinicie
+        el pod (igual que el padrón de Santa Fe).
+
+        La descompresión va a un directorio staging que ninguna búsqueda mira y recién al
+        terminar se publica moviéndolo con os.rename, que es atómico. Por eso ningún worker
+        puede encontrar el archivo antes de que esté completamente descomprimido: o el
+        directorio del período no existe, o tiene la extracción completa.
+        """
         self.ensure_one()
-        tmp_dir = self._get_parp_tmp_dir()
-        path_file = self._find_parp_file(tmp_dir)
+        tmp_dir = self._get_padron_tmp_dir()
+        path_file = self._find_padron_file(tmp_dir)
         if path_file:
             return path_file
 
-        file_content = base64.b64decode(self.file_padron)
-        if self._is_zip_content(file_content):
-            self.descompress_file(self.file_padron, dest_dir=tmp_dir)
-            path_file = self._find_parp_file(tmp_dir)
+        # Sniff de los primeros bytes: alcanza para saber si viene comprimido y evita
+        # decodificar 100 MB de base64 (padron de AGIP) solo para chequear el formato.
+        if self._is_compressed_content(base64.b64decode(self.file_padron[:8])):
+            staging_dir = tempfile.mkdtemp(prefix="l10n_ar_padron.staging-", dir=os.path.dirname(tmp_dir))
+            try:
+                self.descompress_file(self.file_padron, dest_dir=staging_dir)
+                # rename no reemplaza un directorio con contenido, y acá sabemos que lo que
+                # haya en tmp_dir no sirve (no encontramos el padrón).
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                os.rename(staging_dir, tmp_dir)
+            except Exception:
+                shutil.rmtree(staging_dir, ignore_errors=True)
+                raise
+            path_file = self._find_padron_file(tmp_dir)
             if not path_file:
-                raise ValidationError("El archivo ZIP no contiene un padrón PARP en formato CSV o TXT.")
+                raise ValidationError(_("The compressed file does not contain the padron in CSV or TXT format."))
             return path_file
 
-        # CSV directo (no ZIP): lo persistimos para no re-decodificar cada vez.
+        # CSV directo (no comprimido): lo persistimos para no re-decodificar cada vez.
+        file_content = base64.b64decode(self.file_padron)
         os.makedirs(tmp_dir, exist_ok=True)
         path_file = os.path.join(tmp_dir, "padron.csv")
         with open(path_file, "w", encoding="latin-1") as fp:
             fp.write(file_content.decode("latin-1"))
         return path_file
-
-    def _read_parp_from_binary(self, cuit):
-        """Read PARP (padrón Santa Fe) CSV directly from file_padron binary field
-        or from ZIP if the binary is a ZIP file.
-        PARP format: F.PUBLIC;F.VIGEN.DESDE;F.VIGEN.HASTA;NRO.CUIT   ;TIPO CONTRIB;MARCA ALTA;MARCA ALICUOTA;ALIC.PERCEP;ALICUOTA RETENC;GRUPO PER.;GRUPO RETEN;RAZON SOCIAL
-        Returns: (aliquot_ret, aliquot_per)
-        """
-        path_file = self._ensure_parp_file_extracted()
-        with open(path_file, encoding="latin-1") as fp:
-            return self._read_parp_lines(fp.readlines(), cuit)
 
     def find_file(self, rootdir, type_code):
         res = False
@@ -199,14 +351,12 @@ class ResCompanyJurisdictionPadron(models.Model):
         aliquot_ret = 0.0
         aliquot_per = 0.0
 
-        # Check if this is Santa Fe PARP format
-        if self._is_santa_fe_jurisdiction():
-            # Read PARP directly from binary field
-            is_in_padron, aliquot_ret, aliquot_per = self._read_parp_from_binary(partner.vat)
-            return is_in_padron, aliquot_ret, aliquot_per
+        # Check if the whole padron comes in a single file (Santa Fe, AGIP)
+        if self._is_single_file_padron():
+            return self._find_padron_aliquot(self._ensure_padron_file_extracted(), partner.vat)
         else:
             # Original logic for other padron types (ARBA, etc)
-            tmp_dir = self._get_parp_tmp_dir()
+            tmp_dir = self._get_padron_tmp_dir()
             padron_types = ["Per", "Ret"]
             for padron_type in padron_types:
                 path_file = self.find_file(tmp_dir, padron_type)

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_aliquot_source_order
 from . import test_arba
 from . import test_map_tax_fiscal_position
 from . import test_perception_base_minimum_threshold

--- a/l10n_ar_tax/tests/test_aliquot_source_order.py
+++ b/l10n_ar_tax/tests/test_aliquot_source_order.py
@@ -1,0 +1,169 @@
+import base64
+import io
+import shutil
+import zipfile
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests import common
+
+
+class TestAliquotSourceOrder(common.TransactionCase):
+    """El orden de resolución de la alícuota es único para todas las jurisdicciones:
+    padrón cargado en la base primero, web service de la jurisdicción después.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.state_caba = cls.env.ref("base.state_ar_c")
+        cls.date = fields.Date.start_of(fields.Date.today(), "month")
+        cls.to_date = fields.Date.end_of(cls.date, "month")
+        cls.cuit = "30112223351"
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "partner padron",
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
+                "vat": cls.cuit,
+            }
+        )
+        tax_group = cls.env["account.tax.group"].create(
+            {"name": "IIBB CABA test", "country_id": cls.env.ref("base.ar").id}
+        )
+        cls.tax_caba = cls.env["account.tax"].create(
+            {
+                "name": "P. IIBB CABA test",
+                "type_tax_use": "sale",
+                "amount_type": "percent",
+                "amount": 3.0,
+                "country_id": cls.env.ref("base.ar").id,
+                "tax_group_id": tax_group.id,
+                "l10n_ar_state_id": cls.state_caba.id,
+            }
+        )
+        cls.fiscal_position = cls.env["account.fiscal.position"].create({"name": "CABA test"})
+
+    def _create_fp_line(self, webservice):
+        return self.env["account.fiscal.position.l10n_ar_tax"].create(
+            {
+                "fiscal_position_id": self.fiscal_position.id,
+                "default_tax_id": self.tax_caba.id,
+                "tax_type": "perception",
+                "webservice": webservice,
+            }
+        )
+
+    def _create_caba_padron(self):
+        """Padrón de AGIP: mismo layout que el PARP de Santa Fe (percepción en la columna 7,
+        retención en la 8)."""
+        line = "d0;d1;d2;%s;d4;d5;d6;%s;%s" % (self.cuit, "4,50", "2,25")
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr("padron_agip.txt", line + "\n")
+        padron = self.env["res.company.jurisdiction.padron"].create(
+            {
+                "company_id": self.env.company.id,
+                "state_id": self.state_caba.id,
+                "file_padron": base64.b64encode(buffer.getvalue()).decode(),
+                "filename": "padron_agip.zip",
+                "l10n_ar_padron_from_date": self.date,
+                "l10n_ar_padron_to_date": self.to_date,
+            }
+        )
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
+        return padron
+
+    def _patch_agip_ws(self, result=(9.99, "WS")):
+        """El web service de AGIP (el padrón de la base de Adhoc) lo provee
+        saas_client_l10n_ar, que no está instalado acá."""
+        return patch.object(
+            type(self.env["account.fiscal.position.l10n_ar_tax"]),
+            "_get_agip_data",
+            lambda self, partner, date, to_date: result,
+        )
+
+    def test_padron_file_wins_over_webservice(self):
+        """Con padrón cargado la alícuota sale del archivo, incluso si la línea está
+        configurada para consultar web service (es la contingencia cuando el ws falla)."""
+        self._create_caba_padron()
+        fp_line = self._create_fp_line("agip")
+
+        with self._patch_agip_ws():
+            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+
+        self.assertEqual(aliquot, 4.5, "la percepción tiene que salir del padrón, no del ws")
+        self.assertIn("AGIP", ref)
+
+    def test_webservice_used_when_no_padron_uploaded(self):
+        """Sin padrón cargado, una línea con web service lo consulta."""
+        fp_line = self._create_fp_line("agip")
+
+        with self._patch_agip_ws():
+            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+
+        self.assertEqual((aliquot, ref), (9.99, "WS"))
+
+    def test_padron_only_never_queries_webservice(self):
+        """Configurada como "Archivo de padrón", la línea no consulta web service nunca: sin
+        padrón cargado pide que lo carguen."""
+        fp_line = self._create_fp_line("padron")
+
+        def fail(self, partner, date, to_date):
+            raise AssertionError("no debe consultar el web service")
+
+        with patch.object(type(self.env["account.fiscal.position.l10n_ar_tax"]), "_get_agip_data", fail):
+            if self.env.ref("base.user_demo", raise_if_not_found=False):
+                # En base demo no hay padrón que cargar (la demo de l10n_ar_account_reports
+                # crea líneas de Santa Fe): se devuelve el dummy, tampoco el web service.
+                aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+                self.assertIn("dummy", ref)
+            else:
+                with self.assertRaisesRegex(UserError, "No padron uploaded"):
+                    fp_line._get_aliquot(self.partner, self.date, self.to_date)
+
+    def test_padron_of_another_period_is_not_used(self):
+        """Un padrón de otro período no aplica: se va al web service."""
+        padron = self._create_caba_padron()
+        padron.write(
+            {
+                "l10n_ar_padron_from_date": self.date + relativedelta(months=1),
+                "l10n_ar_padron_to_date": self.to_date + relativedelta(months=1),
+            }
+        )
+        fp_line = self._create_fp_line("agip")
+
+        with self._patch_agip_ws():
+            aliquot, ref = fp_line._get_aliquot(self.partner, self.date, self.to_date)
+
+        self.assertEqual((aliquot, ref), (9.99, "WS"))
+
+    def test_partner_without_vat_does_not_read_someone_elses_aliquot(self):
+        """Sin CUIT no se busca en el padrón: un vat vacío matchearía cualquier línea."""
+        self._create_caba_padron()
+        partner_without_vat = self.env["res.partner"].create({"name": "partner sin cuit"})
+        fp_line = self._create_fp_line("agip")
+
+        with self._patch_agip_ws():
+            with self.assertRaises(UserError):
+                fp_line._get_aliquot(partner_without_vat, self.date, self.to_date)
+
+    def test_partner_not_in_padron_falls_back_to_default_tax(self):
+        """Si el CUIT no figura en el padrón devolvemos None (la línea usa su impuesto por
+        defecto), no la alícuota del web service."""
+        self._create_caba_padron()
+        other_partner = self.env["res.partner"].create(
+            {
+                "name": "partner ausente",
+                "l10n_latam_identification_type_id": self.env.ref("l10n_ar.it_cuit").id,
+                "vat": "30112223335",
+            }
+        )
+        fp_line = self._create_fp_line("agip")
+
+        with self._patch_agip_ws():
+            aliquot, ref = fp_line._get_aliquot(other_partner, self.date, self.to_date)
+
+        self.assertIsNone(aliquot)
+        self.assertIn("Not found in AGIP padron", ref)

--- a/l10n_ar_tax/tests/test_padron_tmp_dir.py
+++ b/l10n_ar_tax/tests/test_padron_tmp_dir.py
@@ -47,7 +47,7 @@ class TestPadronTmpDir(common.TransactionCase):
                 "l10n_ar_padron_to_date": to_date,
             }
         )
-        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
         return padron
 
     def _create_santa_fe_padron(self, lines):
@@ -64,7 +64,7 @@ class TestPadronTmpDir(common.TransactionCase):
                 "l10n_ar_padron_to_date": self.today + relativedelta(days=30),
             }
         )
-        self.addCleanup(shutil.rmtree, padron._get_parp_tmp_dir(), ignore_errors=True)
+        self.addCleanup(shutil.rmtree, padron._get_padron_tmp_dir(), ignore_errors=True)
         return padron
 
     def test_arba_different_months_do_not_share_extracted_files(self):

--- a/l10n_ar_tax/tests/test_payment_withholding_validation.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_validation.py
@@ -87,7 +87,7 @@ class TestPaymentWithholdingValidation(TestArWithholdingArRi):
                 "fiscal_position_id": fiscal_position_caba.id,
                 "default_tax_id": self.caba_tax_perception.id,
                 "tax_type": "perception",
-                "webservice": "agip",
+                "webservice": "padron",
             }
         )
 

--- a/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
+++ b/l10n_ar_tax/views/res_company_jurisdiction_padron_view.xml
@@ -42,6 +42,8 @@
                             </li>
                             <li>Santa Fe: debe subir el archivo con formato zip que descarga del padrón PARP (Padrón de Alícuotas de Retención/Percepción) de la oficina virtual de API y que tiene nombre de forma "PARP_999999.zip"
                             </li>
+                            <li>AGIP (CABA): debe subir el archivo comprimido (rar o zip) del padrón de Regímenes Generales que descarga de la web de AGIP. La alícuota se lee del archivo cuando se necesita, no hace falta procesarlo.
+                            </li>
                         </ul>
                     </p>
                 </sheet>


### PR DESCRIPTION
## Qué hace

Unifica el **orden de resolución de la alícuota** para todas las jurisdicciones y, sobre esa base, habilita el padrón de AGIP (CABA) subido por el cliente.

Toma el trabajo de @pablohmontenegro en #1488 (lector de archivo único compartido con el PARP de Santa Fe, búsqueda con `grep -F` en lugar de importar ~1.5M de líneas, descompresión atómica vía staging + `os.rename`, sniff de magic bytes, soporte `.rar`) y cambia el diseño de la resolución. El detalle del por qué está en el comentario de #1488.

## Orden de resolución (único, para toda jurisdicción)

1. **Alícuota cargada en el contacto** para el período — se resuelve antes, en `account.fiscal.position._get_taxes`.
2. **Padrón cargado en la base** y vigente para el período — gana sobre el web service **incluso si la línea está configurada para consultarlo**. Es la contingencia para cuando el web service de la jurisdicción falla.
3. **Web service de la jurisdicción** (ARBA, Rentas Córdoba, AGIP). Configurar la línea como *Archivo de padrón* significa "esta jurisdicción no consulta web service nunca": sin padrón cargado se pide que lo carguen.

Antes esto valía **solo para ARBA**, y con el padrón consultado desde adentro de `_get_arba_data`; cada jurisdicción resolvía su orden en una rama de `_get_padron_data`.

## Cambios

- **`account_fiscal_position_l10n_ar_tax.py`**: `_get_aliquot` concentra el orden; `_get_padron_config` concentra lo único propio de cada jurisdicción (cómo se lee el archivo y qué referencia se registra) — sumar una jurisdicción es sumar una entrada, no un `if`. Los métodos de web service (`_get_arba_data`, `_get_agip_data`, `_get_rentas_cordoba_data`) quedan como clientes puros y no saben nada de padrones. Córdoba entra al camino de padrón solo cuando se implemente su lector.
- **CABA (901)** entra por el mismo flujo: lee el padrón subido por el cliente y, si no hay, la alícuota sale del padrón que Adhoc baja y procesa en su propia base (`saas_client_l10n_ar` extiende `_get_agip_data`). **Se mantiene la opción `agip`** del campo Webservice, así CABA también puede configurarse como solo-padrón y no pasar nunca por Adhoc — y **no hace falta migrar** ninguna posición fiscal.
- **`res_company_jurisdiction_padron.py`**: lector de archivo único compartido (Santa Fe + AGIP), `.rar`, descompresión atómica y magic bytes (todo de #1488). Suma: dentro del comprimido el padrón se reconoce **por su layout**, así un readme o un pdf que venga adentro no se lee como padrón (devolvía "no figura" y aplicaba la alícuota por defecto en silencio).
- **CUIT requerido** antes de leer el archivo: buscar un vat vacío en el padrón matcheaba la línea de cualquier otro contribuyente.
- **`tests/test_aliquot_source_order.py`** (nuevo): padrón gana sobre web service, web service cuando no hay padrón, *Archivo de padrón* no consulta web service nunca, padrón de otro período no aplica, CUIT ausente del padrón → impuesto por defecto, contacto sin CUIT → error del contacto.
- Demo (arregla la línea de Córdoba que tenía `agip`), ayuda de la vista, README y traducciones.

## Diferencias con #1488

- No saca la opción `agip` del campo Webservice → **sin script de migración** (#1488 pasaba las líneas `agip` a `padron`) y se conserva el "nunca consulto web service" para CABA.
- El orden padrón → web service es genérico, no una rama por `jurisdiction_code`.
- Sin `try/except` alrededor del padrón de Adhoc: el error real llega al usuario en lugar de aplanarse a "cargá el padrón".

## Tamaño del diff vs #1488

Este PR **contiene** el diff de #1488, así que es más grande en total (+521/-114 vs +313/-70). Dónde está esa diferencia:

| | #1488 | este |
|---|---|---|
| Solo código productivo (models/demo/views/migrations) | +250 / -65 | +292 / -109 |
| `account_fiscal_position_l10n_ar_tax.py` | +64 / -14 | +99 / -60 |
| Largo final de ese archivo (en `19.0`: 511) | 561 | **550** |
| Tests nuevos | 0 | 163 líneas |
| Migration script | 11 líneas | no hace falta |

Casi todo el extra es el archivo de tests. En el archivo con la lógica se mueven más líneas porque **reemplaza** la cadena de `if jurisdiction_code` en lugar de agregarle una rama, y el resultado queda más corto que con #1488 (+39 sobre la base en vez de +50), soportando además una jurisdicción más.

## Notas de merge

- **Sin migration script** → no se toca el manifest. Toca `demo/` y `views/`, así que el merge va con **`bump`**.
- Leer `.rar` necesita la lib `unrar`, que no se declara en `external_dependencies`: si no está, el error salta al subir el archivo y el padrón se puede subir como `.zip`.
- Chequear que los impuestos de IIBB de CABA tengan la jurisdicción cargada si se los quiere configurar como *Archivo de padrón*: el constraint la exige y `ex_tax_withholding_iibb_caba_applied` no la recibe del chart template.

## Test plan

- `l10n_ar_tax` suite completa en base 19.0: `0 failed` sobre lo nuevo; quedan 1 failed + 4 errors en `TestPaymentChecksWithholding`, **idénticos en `origin/19.0` sin este PR** (preexistentes).
- Cargar el padrón comprimido del período en "Contabilidad / Configuración / Padron Alicuotas" para CABA y verificar que un partner presente toma la alícuota del archivo y uno ausente la del impuesto por defecto.
- Verificar que se descomprime una sola vez (la segunda consulta no vuelve a descomprimir).
- Borrar el padrón y verificar que se consulta el padrón de la base de Adhoc.
- Cargar un padrón de ARBA y verificar que la alícuota sale del archivo aunque la línea esté en `ARBA` (antes ya era así) y que Santa Fe sigue devolviendo alícuota de castigo cuando el CUIT no figura.

Task: https://www.adhoc.inc/odoo/project.task/38027
