### PR TITLE
[FIX] l10n_ar_tax: do not allow editing the fiscal position from the perceptions alert

### DIFF
--- a/l10n_ar_tax/views/account_move_views.xml
+++ b/l10n_ar_tax/views/account_move_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <header position="after">
                 <div class="alert alert-warning" role="alert" invisible="invoice_date or not perceptions_fiscal_positon">
-                    Esta utilizando la posición fiscal <strong>"<field name="fiscal_position_id" options="{'no_open': True}" readonly="1"/>"</strong> que tiene impuestos de percepciones. Como las alicuotas podrían variar según la fecha del comprobante, cambiar la fecha o validar la factura re-computará los impuestos.
+                    Esta utilizando la posición fiscal <field name="fiscal_position_id" widget="badge"/> que tiene impuestos de percepciones. Como las alicuotas podrían variar según la fecha del comprobante, cambiar la fecha o validar la factura re-computará los impuestos en todas las líneas de factura.
                 </div>
             </header>
         </field>


### PR DESCRIPTION
## Qué

En el aviso de percepciones que aparece en una factura sin fecha, el nombre de la posición fiscal se mostraba como un campo selection: se podía **editar la posición fiscal desde el texto del propio aviso**, y además el nombre salía cortado en medio de la oración.

## Por qué pasaba

El aviso tenía embebido el campo `fiscal_position_id` con el widget de many2one, que es un campo editable con desplegable. Ese widget no está pensado para ir dentro de un texto: aporta su propia caja y su propio ancho, y en este caso además dejaba el valor modificable.

## Cómo se arregla

Se usa `widget="badge"`, que solo muestra el valor como una etiqueta. No es un campo selection, así que la posición fiscal ya no se puede modificar desde el aviso, y el nombre queda inline dentro del texto sin cortarse. Los atributos `readonly` y `options="{'no_open': True}"` se quitan porque dejan de aplicar.

Se agrega también una aclaración al final del aviso: el recálculo de impuestos aplica a **todas las líneas de la factura**.

## Test plan

1. Factura de cliente en borrador, sin fecha, con una posición fiscal que tenga impuestos de percepción.
2. El aviso amarillo muestra el nombre de la posición fiscal como una etiqueta dentro del texto, sin cortarlo.
3. La posición fiscal del aviso no se puede editar ni abre desplegable al hacer click.
4. El texto termina con "...re-computará los impuestos en todas las líneas de factura."