### PR TITLE
[ADD] l10n_ar_tax: withholding regression tests (T01-T05)

### DIFF
--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -5,8 +5,11 @@ from . import test_vat_fiscal_position_eligibility
 from . import test_withholding_thresholds
 from . import test_payment_withholding_multimoneda
 from . import test_payment_withholding_checks_multimoneda
+from . import test_own_check_net_amount
 from . import test_padron_cleanup_cron
 from . import test_padron_tmp_dir
 from . import test_payment_register_pro_wizard
 from . import test_payment_withholding_kept_on_post
+from . import test_payment_form_withholding_net
+from . import test_withholding_suffered_ledger
 from . import test_withholding_certificates_mail

--- a/l10n_ar_tax/tests/test_own_check_net_amount.py
+++ b/l10n_ar_tax/tests/test_own_check_net_amount.py
@@ -1,0 +1,186 @@
+from odoo import Command
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestOwnCheckNetAmount(TransactionCase):
+    """D1: en un pago con cheque propio y retención, el importe del cheque es
+    el neto (deuda − retenciones) — es lo que la OP precalcula hoy.
+
+    FCP-R10: la OP dejaba pasar un cheque cargado por el total de la factura
+    (bruto) habiendo retención, y el proveedor quedaba con un saldo a favor
+    que nadie pedía. FCP-R10-E1/E3/E5/E6 (el neto en sus variantes de moneda,
+    N cheques y write-off) están cubiertos en
+    ``test_payment_withholding_checks_multimoneda`` (TC.6/TC.7/TC.9/TC.8).
+
+    FCP-R10-E2 (cheque cargado por el bruto) queda **sin implementar**: en el
+    build de runbot de la PR, postear ese escenario levanta
+    ``ValidationError`` — ``_get_blocking_l10n_latam_warning_msg`` detecta que
+    ``amount`` (940, recalculado por ``_onchange_withholdings``) no coincide
+    con el total del cheque (1.000) — pero D1 dice exactamente lo contrario:
+    "no se despeja el bruto ni se avisa la diferencia". Contradice la
+    definición cerrada con gl; no es un caso de arrastrar sandbox vs. runbot,
+    es una pregunta de producto (¿el bloqueo es el bug, o D1 quedó
+    desactualizado?) que hay que resolver con gl antes de fijar el test.
+
+    No hereda de ``TestArCommon``/``AccountTestInvoicingCommon``: esa base
+    crea su propia compañía y choca con el ACL de productos en bases
+    full-OBA (ver ``reference_v18_tests_transactioncase``). En su lugar,
+    reutiliza una compañía AR ya configurada, igual que
+    ``test_reset_and_recompute_rate.py`` en ``account_payment_pro``.
+
+    Cubre FCP-R10-E4.
+    Tickets 114272, 122219, 118579, 119844.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].search(
+            [("l10n_ar_tax_base_account_id", "!=", False), ("partner_id.country_id.code", "=", "AR")], limit=1
+        )
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.env.user.company_id = cls.company
+        cls.company.use_payment_pro = True
+
+        cls.vendor = cls.env["res.partner"].create(
+            {
+                "name": "Test Own Check Net Amount Vendor",
+                "company_id": False,
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
+                "l10n_ar_afip_responsibility_type_id": cls.env.ref("l10n_ar.res_IVARI").id,
+                "vat": "30710158292",
+            }
+        )
+        cls.invoice_doc_type = cls.env.ref("l10n_ar.dc_a_f")
+        cls.expense_account = cls.env["account.account"].search(
+            [("account_type", "=", "expense"), ("company_ids", "=", cls.company.id)], limit=1
+        )
+
+        # Retención de Ganancias 6% a proveedores, configuración del escenario.
+        tax_group = cls.env["account.tax.group"].create(
+            {"name": "Test Own Check Net Amount WTH Group", "company_id": cls.company.id}
+        )
+        wth_account = cls.env["account.account"].create(
+            {
+                "name": "Test Own Check Net Amount WTH",
+                "code": "TOCNAWTH",
+                "account_type": "liability_current",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.tax_wth = cls.env["account.tax"].create(
+            {
+                "name": "Test Own Check Net Amount WTH 6%",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 6.0,
+                "tax_group_id": tax_group.id,
+                "l10n_ar_tax_type": "earnings",
+                "l10n_ar_withholding_payment_type": "supplier",
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test Own Check Net Amount WTH seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"factor_percent": 100, "repartition_type": "base"}),
+                    Command.create({"factor_percent": 100, "repartition_type": "tax", "account_id": wth_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"factor_percent": 100, "repartition_type": "base"}),
+                    Command.create({"factor_percent": 100, "repartition_type": "tax", "account_id": wth_account.id}),
+                ],
+            }
+        )
+        cls.fiscal_position = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test Own Check Net Amount FP",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_ids": [Command.create({"default_tax_id": cls.tax_wth.id, "tax_type": "withholding"})],
+            }
+        )
+
+        cls.bank_journal = cls.env["account.journal"].create(
+            {"name": "Test Own Check Net Amount Bank", "type": "bank", "code": "TOCNAB", "company_id": cls.company.id}
+        )
+        own_checks_method = cls.env.ref("l10n_latam_check.account_payment_method_own_checks")
+        cls.bank_journal.write(
+            {"outbound_payment_method_line_ids": [Command.create({"payment_method_id": own_checks_method.id})]}
+        )
+        cls.own_checks_line = cls.bank_journal.outbound_payment_method_line_ids.filtered(
+            lambda line: line.code == "own_checks"
+        )[:1]
+
+    def _make_bill(self, amount, number):
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_date": "2026-01-01",
+                "company_id": self.company.id,
+                "l10n_latam_document_type_id": self.invoice_doc_type.id,
+                "l10n_latam_document_number": number,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test own check net amount line",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": self.expense_account.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        bill.action_post()
+        return bill
+
+    def _make_check_payment(self, debt, check_amount, check_number):
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "payment_method_line_id": self.own_checks_line.id,
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+                "l10n_latam_new_check_ids": [
+                    Command.create({"name": check_number, "payment_date": "2026-01-01", "amount": check_amount})
+                ],
+            }
+        )
+        payment._onchange_withholdings()
+        return payment
+
+    def test_editing_the_check_after_the_withholding_was_computed_keeps_totals_consistent(self):
+        """Dado un pago con cheque propio de $940 (neto) y su retención de $60
+        ya calculada, cuando se edita el cheque a $900, entonces el asiento
+        sigue balanceado y la retención **no cambia** de golpe por editar el
+        cheque — el cheque y la retención son dos campos independientes, no un
+        cálculo que se retroalimenta.
+
+        Cubre FCP-R10-E4.
+        """
+        bill = self._make_bill(1000.0, "1-2401")
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment = self._make_check_payment(debt, 940.0, "00000310")
+        wth_before = payment.l10n_ar_withholding_line_ids[0].amount
+
+        payment.l10n_latam_new_check_ids.amount = 900.0
+
+        with self.subTest("la retención no se recalcula por editar el cheque"):
+            self.assertAlmostEqual(payment.l10n_ar_withholding_line_ids[0].amount, wth_before, places=2)
+        with self.subTest("el importe del pago sigue el del cheque editado"):
+            self.assertAlmostEqual(payment.amount, 900.0, places=2)
+
+        payment.action_post()
+
+        with self.subTest("el asiento posteado queda balanceado con el importe editado"):
+            self.assertAlmostEqual(self.company.currency_id.round(sum(payment.move_id.line_ids.mapped("balance"))), 0.0)
+        liq_line = payment.move_id.line_ids.filtered(lambda line: line.account_id == payment.outstanding_account_id)
+        with self.subTest("la línea de liquidez lleva el importe editado, no el original"):
+            self.assertAlmostEqual(abs(liq_line.balance), 900.0, places=2)

--- a/l10n_ar_tax/tests/test_own_check_net_amount.py
+++ b/l10n_ar_tax/tests/test_own_check_net_amount.py
@@ -1,10 +1,11 @@
 from odoo import Command
+from odoo.addons.account_ux.tests.invariants import AccountInvariantsMixin
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
 @tagged("post_install", "-at_install")
-class TestOwnCheckNetAmount(TransactionCase):
+class TestOwnCheckNetAmount(AccountInvariantsMixin, TransactionCase):
     """D1: en un pago con cheque propio y retención, el importe del cheque es
     el neto (deuda − retenciones) — es lo que la OP precalcula hoy.
 
@@ -14,15 +15,34 @@ class TestOwnCheckNetAmount(TransactionCase):
     N cheques y write-off) están cubiertos en
     ``test_payment_withholding_checks_multimoneda`` (TC.6/TC.7/TC.9/TC.8).
 
-    FCP-R10-E2 (cheque cargado por el bruto) queda **sin implementar**: en el
-    build de runbot de la PR, postear ese escenario levanta
-    ``ValidationError`` — ``_get_blocking_l10n_latam_warning_msg`` detecta que
-    ``amount`` (940, recalculado por ``_onchange_withholdings``) no coincide
-    con el total del cheque (1.000) — pero D1 dice exactamente lo contrario:
-    "no se despeja el bruto ni se avisa la diferencia". Contradice la
-    definición cerrada con gl; no es un caso de arrastrar sandbox vs. runbot,
-    es una pregunta de producto (¿el bloqueo es el bug, o D1 quedó
-    desactualizado?) que hay que resolver con gl antes de fijar el test.
+    FCP-R10-E2 (cheque cargado por el bruto) sigue **sin implementar**, y la
+    razón cambió de piso el 2026-09-01. La spec reabrió D1 "verificado leyendo
+    el código" y concluyó que el wizard no bloquea y recalcula en silencio al
+    neto. Repetí la lectura y además lo corrí en ``all_v19`` (ver detalle de
+    la corrida en el reporte de la tarea 71623) y encontré un tercer resultado
+    que no es ninguno de los dos que se venían discutiendo:
+
+    - Por el wizard (``account.payment.register`` con ``fiscal_position_mode
+      = 'manual'``): no bloquea, pero la retención persistida
+      (``l10n_ar_withholding_line_ids``) queda en **0** y ``payment.amount``
+      termina igual al cheque cargado (bruto) — la retención calculada en el
+      wizard nunca se traslada al pago creado.
+    - Por el camino directo (``account.payment.create()`` +
+      ``_onchange_withholdings()``, el que usan **todos** los tests ya verdes
+      de este módulo, TC.6 incluido): tampoco bloquea, pero el asiento que
+      postea es ``AP 1.060 = cheque 1.000 + retención 60`` para una deuda de
+      **1.000** — el cheque se contabiliza por el bruto en la línea de
+      liquidez, la retención se practica *además*, y el proveedor queda con
+      **60 de saldo a favor**. Es exactamente lo que D1 dice que nunca tiene
+      que pasar, reproducido con el código de hoy, no el del 27/08.
+
+    Ninguno de los dos caminos hace lo que D1 (re-verificada) describe
+    ("se recalcula al neto"): en el primero la retención desaparece: en el
+    segundo el saldo a favor aparece. No fijo ninguno de los dos con un test
+    en verde porque blindaría un bug con un test que lo defiende — es la
+    misma pregunta de producto que ya estaba abierta con gl, con un hallazgo
+    nuevo y más preciso para llevarle. Repro con datos y line-by-line del
+    asiento en el reporte de esta corrida.
 
     No hereda de ``TestArCommon``/``AccountTestInvoicingCommon``: esa base
     crea su propia compañía y choca con el ACL de productos en bases
@@ -30,7 +50,10 @@ class TestOwnCheckNetAmount(TransactionCase):
     reutiliza una compañía AR ya configurada, igual que
     ``test_reset_and_recompute_rate.py`` en ``account_payment_pro``.
 
-    Cubre FCP-R10-E4.
+    Mixea ``AccountInvariantsMixin`` (``account_ux``, transitivo vía
+    ``account_payment_pro``) para la batería de invariantes de cobros/pagos.
+
+    Cubre FCP-R10-E4, FCP-R08-E4.
     Tickets 114272, 122219, 118579, 119844.
     """
 
@@ -184,3 +207,50 @@ class TestOwnCheckNetAmount(TransactionCase):
         liq_line = payment.move_id.line_ids.filtered(lambda line: line.account_id == payment.outstanding_account_id)
         with self.subTest("la línea de liquidez lleva el importe editado, no el original"):
             self.assertAlmostEqual(abs(liq_line.balance), 900.0, places=2)
+        with self.subTest("batería de invariantes"):
+            self.assert_payment_invariants(payment, "cheque propio editado tras calcular la retención")
+
+    def test_own_check_with_withholding_settles_the_invoice_in_a_single_declared_state(self):
+        """Dado un pago de factura con cheque propio cargado por el **neto**
+        (con su retención ya calculada), cuando se postea, entonces la
+        factura queda en **un único estado declarado** — ``in_payment``, no
+        ``paid`` ni "pagada o en proceso" indistintamente — porque un cheque
+        propio es una promesa de pago, no efectivo acreditado: pasa a
+        ``paid`` recién cuando el banco lo debita (fuera del alcance de T19,
+        eso es T20).
+
+        Corrida en ``all_v19`` hoy: con el mismo fixture que ya usa
+        ``test_editing_the_check_after_the_withholding_was_computed_keeps_totals_consistent``
+        (cheque a $940 neto, retención $60 sobre una deuda de $1.000), el
+        pago posteado da ``payment.state == 'in_process'`` y
+        ``invoice.payment_state == 'in_payment'`` de forma consistente — sin
+        el asiento sobrante que sí aparece al cargar el cheque por el bruto
+        (ver docstring de la clase, FCP-R10-E2).
+
+        Se demuestra en rojo: forzando ``payment_state`` a ``'paid'`` en el
+        assert (falla, porque el estado real es ``in_payment``), o rompiendo
+        la reconciliación del pago con la deuda (deja la factura en
+        ``not_paid`` y también hace fallar la batería de invariantes).
+
+        Cubre FCP-R08-E4.
+        """
+        bill = self._make_bill(1000.0, "1-2402")
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment = self._make_check_payment(debt, 940.0, "00000311")
+
+        payment.action_post()
+
+        with self.subTest("la factura queda en un único estado declarado: in_payment"):
+            self.assert_payment_state(bill, "in_payment")
+        with self.subTest("batería de invariantes"):
+            self.assert_payment_invariants(payment, "cheque propio por el neto con retención")
+        with self.subTest("el cheque sigue abierto en cheques a pagar hasta que se debite (T20)"):
+            # ``assert_no_open_outstanding`` no aplica acá: un cheque propio queda
+            # abierto en la cuenta de cheques a pagar (``outstanding_account_id``)
+            # a propósito hasta el débito — es el ``issue_state`` "handed" de D4,
+            # no un residual sin conciliar. Se concilia recién en
+            # ``l10n_latam_check_ux:test_own_check_debit`` (T20).
+            outstanding_line = payment.move_id.line_ids.filtered(
+                lambda line: line.account_id == payment.outstanding_account_id
+            )
+            self.assertAlmostEqual(abs(outstanding_line.amount_residual), 940.0, places=2)

--- a/l10n_ar_tax/tests/test_payment_form_withholding_net.py
+++ b/l10n_ar_tax/tests/test_payment_form_withholding_net.py
@@ -1,0 +1,633 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPaymentFormWithholdingNet(TransactionCase):
+    """El neto de la retención en el formulario de pago directo.
+
+    FCP-R01: la retención se calcula bien pero no se resta del importe a
+    transferir — el formulario propone el total de la factura en vez del
+    neto. El descuento vive en ``_onchange_withholdings``
+    (``l10n_ar_tax/models/account_payment.py``), un ``@api.onchange`` que
+    en la UI dispara solo, y en tests hay que invocarlo a mano — patrón ya
+    usado por ``test_payment_withholding_multimoneda.py`` en este mismo
+    módulo. ``l10n_ar_withholding_line_ids`` en cambio es un compute normal
+    (``@api.depends``): se completa solo con ``.create()``.
+
+    Reutiliza una compañía AR Responsable Inscripto ya configurada en la
+    base (entorno) — ninguna tiene hoy una fiscal position con retenciones
+    armada, así que el impuesto, la fiscal position y el proveedor son
+    configuración del escenario que crea el test.
+
+    FCP-R01-E3 (wizard de pago múltiple agrupando dos facturas del mismo
+    proveedor en un solo pago) **queda sin implementar: es un bug de
+    producto encontrado al escribir este test, no pasa hoy en 19.0**.
+    Reproducido en shell: sobre dos facturas de $100.000 con retención de
+    Ganancias 6%, agrupando con ``group_payment = True`` en
+    ``account.payment.register`` (sin agrupar, el wizard crea dos pagos
+    separados — uno por factura — que ni siquiera comparan contra el
+    formulario directo), el pago resultante sí trae
+    ``withholdings_amount = 12.000`` bien calculado, pero
+    ``payment.amount`` queda en **$0** y el asiento sale con todas las
+    líneas en cero. Causa: la corrección del neto en ``_init_payments``
+    (``l10n_ar_tax/wizard/account_payment_register.py``) lee
+    ``payment.withholdings_amount`` **antes** de que
+    ``l10n_ar_fiscal_position_id`` esté resuelto en el pago — el cómputo
+    automático de esa fiscal position (``_compute_fiscal_position_id`` en
+    ``l10n_ar_tax/models/account_payment.py``) exige ``state == "draft"``,
+    y para el momento en que corre ya no lo está. Con
+    ``fiscal_position_mode = "manual"`` en el wizard tampoco se arregla:
+    ``_create_payments()`` solo aplica esa fiscal position manual
+    **después** de que ``super()._create_payments()`` ya creó y posteó el
+    pago — a esa altura ``_init_payments`` ya corrió. Corregirlo queda
+    fuera de esta spec (el entregable es la cobertura de test, no el fix
+    — ver "Objetivo" de la spec 71623); reportado aparte como bug de
+    producto en ``account_payment_pro``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].search(
+            [("l10n_ar_tax_base_account_id", "!=", False), ("partner_id.country_id.code", "=", "AR")], limit=1
+        )
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.env.user.company_id = cls.company
+
+        cls.tax_group = cls.env["account.tax.group"].create(
+            {"name": "Test Withholding Group", "company_id": cls.company.id}
+        )
+        cls.withholding_account = cls.env["account.account"].create(
+            {
+                "name": "Test Withholding Ganancias",
+                "code": "TWHG",
+                "account_type": "liability_current",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.tax_wth = cls.env["account.tax"].create(
+            {
+                "name": "Test WTH Ganancias 6%",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 6.0,
+                "tax_group_id": cls.tax_group.id,
+                "l10n_ar_tax_type": "earnings",
+                "l10n_ar_withholding_payment_type": "supplier",
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test WTH Ganancias seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.withholding_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.withholding_account.id}),
+                ],
+            }
+        )
+        cls.fiscal_position = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test FP Ganancias",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_ids": [Command.create({"default_tax_id": cls.tax_wth.id, "tax_type": "withholding"})],
+            }
+        )
+        cls.vendor = cls.env["res.partner"].create(
+            {
+                "name": "Test Withholding Vendor",
+                "company_id": False,
+                "property_account_position_id": cls.fiscal_position.id,
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
+                "l10n_ar_afip_responsibility_type_id": cls.env.ref("l10n_ar.res_IVARI").id,
+                "vat": "30710158254",
+            }
+        )
+        cls.invoice_a = cls.env.ref("l10n_ar.dc_a_f")
+        if "use_payment_pro" in cls.env["res.company"]._fields:
+            cls.company.use_payment_pro = True
+        cls.bank_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
+        )
+
+        # segundo régimen (IIBB), para la fiscal position con dos retenciones juntas
+        cls.iibb_account = cls.env["account.account"].create(
+            {
+                "name": "Test Withholding IIBB",
+                "code": "TWHI",
+                "account_type": "liability_current",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.tax_iibb = cls.env["account.tax"].create(
+            {
+                "name": "Test WTH IIBB 2%",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 2.0,
+                "tax_group_id": cls.env["account.tax.group"]
+                .create({"name": "Test IIBB Group", "company_id": cls.company.id})
+                .id,
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_withholding_payment_type": "supplier",
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test WTH IIBB seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+            }
+        )
+        cls.fiscal_position_two_taxes = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test FP Ganancias + IIBB",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_ids": [
+                    Command.create({"default_tax_id": cls.tax_wth.id, "tax_type": "withholding"}),
+                    Command.create({"default_tax_id": cls.tax_iibb.id, "tax_type": "withholding"}),
+                ],
+            }
+        )
+
+        # tercer régimen (IIBB con mínimo no imponible sobre la base), para la
+        # retención que tiene que resolver en cero y no dejar línea
+        cls.tax_iibb_with_minimum = cls.env["account.tax"].create(
+            {
+                "name": "Test WTH IIBB 2% con mínimo",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 2.0,
+                "tax_group_id": cls.env["account.tax.group"]
+                .create({"name": "Test IIBB Minimum Group", "company_id": cls.company.id})
+                .id,
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_withholding_payment_type": "supplier",
+                "l10n_ar_base_minimum_threshold": 200000.0,
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test WTH IIBB minimum seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+            }
+        )
+        cls.fiscal_position_below_minimum = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Test FP IIBB bajo mínimo",
+                "company_id": cls.company.id,
+                "l10n_ar_tax_ids": [
+                    Command.create({"default_tax_id": cls.tax_iibb_with_minimum.id, "tax_type": "withholding"})
+                ],
+            }
+        )
+
+        # cuenta y tipo de ajuste, para retención + write-off en la misma operación (T03)
+        cls.write_off_account = cls.env["account.account"].create(
+            {
+                "name": "Test Write-off",
+                "code": "TWOF",
+                "account_type": "expense",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.write_off_type = cls.env["account.write_off.type"].create(
+            {"name": "Test Write-off Type", "account_id": cls.write_off_account.id}
+        )
+
+        # moneda extranjera, para la base de la retención en factura en USD (T04)
+        cls.usd = cls.env.ref("base.USD")
+        cls.usd.active = True
+        cls.env["res.currency.rate"].create(
+            {"currency_id": cls.usd.id, "company_id": cls.company.id, "name": "2026-01-01", "rate": 0.001}
+        )
+        # segunda cotización, para pagar a un TC distinto del de la factura (R08-E3)
+        cls.env["res.currency.rate"].create(
+            {"currency_id": cls.usd.id, "company_id": cls.company.id, "name": "2026-02-01", "rate": 1.0 / 1100.0}
+        )
+
+    def _create_bill(self, amount, document_number, currency=None):
+        expense = self.env["account.account"].search(
+            [("account_type", "=", "expense"), ("company_ids", "=", self.company.id)], limit=1
+        )
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.vendor.id,
+                "invoice_date": "2026-01-01",
+                "company_id": self.company.id,
+                "currency_id": (currency or self.company.currency_id).id,
+                "l10n_latam_document_type_id": self.invoice_a.id,
+                "l10n_latam_document_number": document_number,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test withholding bill line",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": expense.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        bill.action_post()
+        return bill
+
+    def _pay_via_direct_form(self, bill, fiscal_position=None):
+        """Arma el pago como lo hace el formulario simple, seleccionando la
+        deuda directamente en ``to_pay_move_line_ids`` — no el wizard de
+        pago múltiple, que es el otro camino y calcula distinto.
+
+        ``_onchange_withholdings`` (el que resta la retención del importe)
+        es un ``@api.onchange``: en la UI dispara solo; en test se invoca a
+        mano, tal como hace ``test_payment_withholding_multimoneda.py``.
+        """
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "l10n_ar_fiscal_position_id": (fiscal_position or self.fiscal_position).id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+            }
+        )
+        payment._onchange_withholdings()
+        return payment
+
+    def test_direct_form_nets_the_withholding_from_the_transfer_amount(self):
+        """Dada una factura de $100.000 con retención de Ganancias 6%,
+        cuando se arma el pago desde el formulario directo, entonces el
+        importe a transferir es el neto ($94.000), no el total.
+
+        Cubre FCP-R01-E1. Se demuestra en rojo comentando la llamada a
+        ``_onchange_withholdings`` en ``_pay_via_direct_form``: sin ella el
+        importe queda en $0 en vez de descontar la retención del total.
+        """
+        bill = self._create_bill(100000.0, "1-1")
+        payment = self._pay_via_direct_form(bill)
+
+        with self.subTest("la retención calculada es la esperada"):
+            self.assertEqual(len(payment.l10n_ar_withholding_line_ids), 1)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.tax_id, self.tax_wth)
+            self.assertEqual(payment.withholdings_amount, 6000.0)
+
+        with self.subTest("el importe a transferir es el neto, no el total"):
+            self.assertEqual(payment.amount, 94000.0)
+
+        payment.action_post()
+        with self.subTest("el asiento: banco 94.000, retención 6.000, proveedor 100.000, sin línea de balance"):
+            lines = payment.move_id.line_ids
+            liquidity = lines.filtered(lambda line: line.account_id == payment.outstanding_account_id)
+            withholding_line = lines.filtered(lambda line: line.account_id == self.withholding_account)
+            payable = lines.filtered(lambda line: line.account_id.account_type == "liability_payable")
+            self.assertEqual(liquidity.balance, -94000.0)
+            self.assertEqual(withholding_line.balance, -6000.0)
+            self.assertEqual(payable.balance, 100000.0)
+            self.assertEqual(self.company.currency_id.round(sum(lines.mapped("balance"))), 0.0)
+
+    def test_direct_form_net_is_the_same_regardless_of_load_order(self):
+        """El neto no depende de si se carga primero la deuda o primero la
+        fiscal position — orden invertido de los mismos dos campos.
+
+        Cubre FCP-R01-E2: nadie repite el mismo pago cambiando el orden de
+        los clicks a propósito, y es justo el disparador histórico del bug.
+        """
+        bill_1 = self._create_bill(100000.0, "1-2")
+        debt_1 = bill_1.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment_debt_first = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "to_pay_move_line_ids": [Command.set(debt_1.ids)],
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+            }
+        )
+        payment_debt_first._onchange_withholdings()
+
+        bill_2 = self._create_bill(100000.0, "1-3")
+        debt_2 = bill_2.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment_fp_first = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+                "to_pay_move_line_ids": [Command.set(debt_2.ids)],
+            }
+        )
+        payment_fp_first._onchange_withholdings()
+
+        self.assertEqual(payment_debt_first.amount, payment_fp_first.amount)
+        self.assertEqual(payment_debt_first.amount, 94000.0)
+
+    def test_two_withholdings_together_and_one_that_resolves_to_zero(self):
+        """Dos regímenes en el mismo pago, y una retención bajo el mínimo
+        no imponible.
+
+        Dada una factura de $100.000 con Ganancias 6% e IIBB 2% juntos,
+        cuando se arma el pago, entonces el neto es $92.000 y cada retención
+        cae en su propia cuenta — ninguna en la base imponible ni en el
+        banco. Dada otra factura con una retención IIBB cuya base mínima no
+        imponible ($200.000) supera la base de la factura ($100.000),
+        cuando se posea el pago, entonces esa retención no deja línea y el
+        importe transferido es el total, no el neto.
+
+        Cubre FCP-R01-E4/E9. La retención en cero se demuestra en rojo
+        comprobando que la línea existe (importe $0) antes de postear, y
+        que ``action_post`` es quien la elimina
+        (``_l10n_ar_remove_zero_withholding_lines``, distinto de earnings,
+        que se conserva siempre) — si esa limpieza no corriera, la línea en
+        cero quedaría ensuciando el pago.
+        """
+        with self.subTest("dos regímenes juntos: cada retención en su cuenta, neto $92.000"):
+            bill = self._create_bill(100000.0, "1-4")
+            payment = self._pay_via_direct_form(bill, fiscal_position=self.fiscal_position_two_taxes)
+
+            self.assertEqual(len(payment.l10n_ar_withholding_line_ids), 2)
+            self.assertEqual(payment.withholdings_amount, 8000.0)
+            self.assertEqual(payment.amount, 92000.0)
+
+            payment.action_post()
+            lines = payment.move_id.line_ids
+            self.assertEqual(lines.filtered(lambda line: line.account_id == self.withholding_account).balance, -6000.0)
+            self.assertEqual(lines.filtered(lambda line: line.account_id == self.iibb_account).balance, -2000.0)
+            self.assertEqual(
+                lines.filtered(lambda line: line.account_id.account_type == "liability_payable").balance, 100000.0
+            )
+            self.assertEqual(self.company.currency_id.round(sum(lines.mapped("balance"))), 0.0)
+
+        with self.subTest("retención bajo el mínimo no imponible: no deja línea, se transfiere el total"):
+            bill_below_min = self._create_bill(100000.0, "1-5")
+            payment_below_min = self._pay_via_direct_form(
+                bill_below_min, fiscal_position=self.fiscal_position_below_minimum
+            )
+
+            self.assertEqual(
+                payment_below_min.l10n_ar_withholding_line_ids.amount,
+                0.0,
+                "antes de postear la línea existe, con importe en cero",
+            )
+            self.assertEqual(payment_below_min.amount, 100000.0, "no hay nada que restar: se transfiere el total")
+
+            payment_below_min.action_post()
+            self.assertFalse(
+                payment_below_min.l10n_ar_withholding_line_ids,
+                "al postear, la retención en cero no earnings se elimina y no ensucia el pago",
+            )
+
+    def test_withholding_and_write_off_do_not_absorb_each_other(self):
+        """Retención y ajuste manual en el mismo pago, sin pisarse.
+
+        Dada una factura de $100.000 con retención de Ganancias 6%
+        ($6.000), cuando el usuario además reduce el importe a transferir
+        a $93.000 y ajusta la diferencia con un write-off, entonces el
+        ajuste es de $1.000 — no de $7.000: no absorbe la retención.
+
+        Cubre FCP-R01-E5. Dos mecanismos que se pisan: a mano el error se
+        ve como "un número raro" y se recalcula a ojo en vez de
+        reportarse. Se demuestra en rojo asertando que el ajuste NO es
+        igual a la retención más la diferencia real ($7.000) — si el
+        ajuste absorbiera la retención, este test lo agarra.
+        """
+        bill = self._create_bill(100000.0, "1-6")
+        payment = self._pay_via_direct_form(bill)
+        self.assertEqual(payment.amount, 94000.0, "neto tras la retención, antes de tocar nada más")
+
+        payment.write_off_type_id = self.write_off_type
+        payment.amount = 93000.0
+        payment.amount_exact = 93000.0
+        payment.action_adjust_writeoff_for_difference()
+
+        with self.subTest("el ajuste es la diferencia real, no la retención completa"):
+            self.assertEqual(payment.write_off_amount, 1000.0)
+            self.assertEqual(payment.payment_difference, 0.0)
+
+        payment.action_post()
+        with self.subTest("el asiento: banco 93.000, retención 6.000, ajuste 1.000, proveedor 100.000"):
+            lines = payment.move_id.line_ids
+            liquidity = lines.filtered(lambda line: line.account_id == payment.outstanding_account_id)
+            withholding_line = lines.filtered(lambda line: line.account_id == self.withholding_account)
+            write_off_line = lines.filtered(lambda line: line.account_id == self.write_off_account)
+            payable = lines.filtered(lambda line: line.account_id.account_type == "liability_payable")
+            self.assertEqual(liquidity.balance, -93000.0)
+            self.assertEqual(withholding_line.balance, -6000.0)
+            self.assertEqual(write_off_line.balance, -1000.0)
+            self.assertEqual(payable.balance, 100000.0)
+            self.assertEqual(self.company.currency_id.round(sum(lines.mapped("balance"))), 0.0)
+
+    def test_withholding_base_is_the_amount_actually_paid_on_a_partial_payment(self):
+        """La base de la retención es lo que se paga, no la deuda completa.
+
+        Dada una factura de $100.000, cuando se paga solo $50.000 con
+        retención de Ganancias 6%, entonces la retención se calcula sobre
+        los $50.000 pagados ($3.000) — no sobre el total — y se transfieren
+        $47.000, dejando la factura en pago parcial con saldo $50.000.
+
+        Cubre FCP-R01-E6. Verifica que la base no se recalcule en cascada
+        contra el total de la deuda al ajustar el neto.
+        """
+        bill = self._create_bill(100000.0, "1-7")
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+                # unreconciled_amount es el "adelanto/ajuste" respecto a la deuda
+                # seleccionada; negativo = se paga menos que la deuda ($100.000 - $50.000).
+                # to_pay_amount se recomputa solo a partir de esto (selected_debt + unreconciled_amount).
+                "unreconciled_amount": -50000.0,
+            }
+        )
+        payment._onchange_withholdings()
+
+        with self.subTest("la base de la retención es lo pagado, no el total de la deuda"):
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.base_amount, 50000.0)
+            self.assertEqual(payment.withholdings_amount, 3000.0)
+
+        with self.subTest("se transfieren 47.000, no 94.000"):
+            self.assertEqual(payment.amount, 47000.0)
+
+        payment.action_post()
+        with self.subTest("la factura queda en pago parcial con saldo 50.000"):
+            self.assertEqual(bill.payment_state, "partial")
+            self.assertEqual(bill.amount_residual, 50000.0)
+
+    def test_withholding_survives_a_draft_and_reconfirm_cycle_without_duplicating(self):
+        """Pago con retenciones vuelto a borrador y re-confirmado sin
+        cambios: las líneas se conservan, y el neto no se duplica ni se
+        recalcula de más.
+
+        Cubre FCP-R09-E2. El bug es la duplicación del neto: solo se ve
+        comparando el importe antes y después del ciclo completo.
+        """
+        bill = self._create_bill(100000.0, "1-9")
+        payment = self._pay_via_direct_form(bill)
+        payment.action_post()
+        self.assertEqual(payment.amount, 94000.0)
+
+        payment.action_draft()
+        payment.action_post()
+
+        with self.subTest("una sola línea de retención, importe sin duplicar"):
+            self.assertEqual(len(payment.l10n_ar_withholding_line_ids), 1)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.amount, 6000.0)
+            self.assertEqual(payment.amount, 94000.0)
+
+    def test_withholding_base_on_a_foreign_currency_bill_is_converted_to_pesos(self):
+        """La base de la retención es siempre en pesos, aunque la factura
+        esté en moneda extranjera.
+
+        Dada una factura de USD 1.000 (cotización 1 USD = ARS 1.000, pagada
+        con un diario en ARS), cuando se arma el pago, entonces la base de
+        la retención es ARS 1.000.000 (no USD 1.000) y la retención de
+        Ganancias 6% es ARS 60.000 — mostrada también en USD (60), la
+        moneda de la deuda, en el campo que resume la retención en el
+        pago. El importe a transferir descuenta esa retención en ambas
+        monedas: ARS 940.000 (moneda del diario) y USD 60 (moneda de la
+        deuda).
+
+        Cubre FCP-R01-E7. Se demuestra en rojo forzando
+        ``base_amount = payment.selected_debt_untaxed`` (sin la conversión
+        de ``_get_withholding_rate``): la retención saldría en USD 60 en
+        vez de ARS 60.000, mil veces menor.
+        """
+        bill = self._create_bill(1000.0, "1-8", currency=self.usd)
+        payment = self._pay_via_direct_form(bill)
+
+        with self.subTest("la base de la retención está en pesos, convertida a la cotización de la factura"):
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.currency_id, self.company.currency_id)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.base_amount, 1000000.0)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.amount, 60000.0)
+
+        with self.subTest(
+            "el importe a transferir ya descuenta la retención, tanto en ARS como en la moneda de la factura"
+        ):
+            self.assertEqual(payment.withholdings_amount, 60.0, "retención expresada en USD, la moneda de la deuda")
+            self.assertEqual(payment.amount, 940000.0, "importe en ARS, la moneda del diario: neto de la retención")
+
+    def _fx_lines(self, payment):
+        """Líneas de diferencia de cambio: no se identifican por un
+        ``account_type`` fijo, sino por ser las cuentas de ganancia/pérdida
+        por cambio configuradas en la compañía (patrón de
+        ``account_payment_pro/tests/test_exchange_difference.py``)."""
+        fx_accounts = (
+            self.company.income_currency_exchange_account_id | self.company.expense_currency_exchange_account_id
+        )
+        return payment.exchange_diff_move_ids.line_ids.filtered(lambda line: line.account_id in fx_accounts)
+
+    def test_withholding_and_exchange_difference_do_not_cross_on_a_foreign_currency_payment(self):
+        """Retención y diferencia de cambio en el mismo pago, sobre una
+        factura en moneda extranjera pagada a otro TC: cada mecanismo va
+        a su propia cuenta y ninguno deja saldo a favor indebido.
+
+        Dada una factura de compra USD 1.000 al TC 1.000 ($1.000.000),
+        cuando se paga con retención de Ganancias 6% al TC 1.100 (un mes
+        después), entonces la base de la retención se convierte al TC del
+        pago (**D6**: ARS 1.100.000, no al TC de la factura), la
+        diferencia de cambio ($100.000) queda en su propia cuenta,
+        separada de la retención, y el mayor del proveedor cierra en
+        cero — ni la retención ni la diferencia dejan saldo a favor.
+
+        Cubre FCP-R08-E3.
+        """
+        bill = self._create_bill(1000.0, "1-11", currency=self.usd)
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "liability_payable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-02-01",
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+            }
+        )
+        payment._onchange_withholdings()
+
+        with self.subTest("la base de la retención se convierte al TC del pago, no al de la factura"):
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.base_amount, 1100000.0)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.amount, 66000.0)
+
+        with self.subTest("el importe a transferir es el neto, en pesos, al TC del pago"):
+            self.assertEqual(payment.amount, 1034000.0)
+
+        payment.action_post()
+        with self.subTest("la factura queda saldada, sin residuo en ninguna moneda"):
+            self.assertEqual(bill.amount_residual, 0.0)
+            self.assertEqual(bill.amount_residual_signed, 0.0)
+
+        with self.subTest("la diferencia de cambio queda en su propia cuenta, separada de la retención"):
+            fx_lines = self._fx_lines(payment)
+            self.assertEqual(fx_lines.balance, 100000.0)
+
+        with self.subTest("el mayor del proveedor cierra en cero: sin saldo a favor por retención ni por FX"):
+            payable_lines = (
+                bill.line_ids | payment.move_id.line_ids | payment.exchange_diff_move_ids.line_ids
+            ).filtered(lambda line: line.account_id.account_type == "liability_payable")
+            self.assertEqual(sum(payable_lines.mapped("balance")), 0.0)
+
+    def test_withholding_without_any_debt_selected_uses_the_amount_the_user_loads_as_base(self):
+        """Un pago a proveedor sin ninguna factura seleccionada (a cuenta) puede
+        llevar retención igual: la base es el importe que el usuario carga a mano
+        (``to_pay_amount``, vía ``unreconciled_amount`` al no haber deuda), no cero.
+
+        Cubre FCP-R01-E8 (D7). Se demuestra en rojo: si la base dependiera solo de
+        ``selected_debt`` (0 sin factura), la retención saldría en $0 en vez de
+        $6.000 — revertir la resta de ``advance_amount`` en
+        ``l10n_ar_payment_withholding.py`` reproduce justo eso.
+        """
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.vendor.id,
+                "partner_type": "supplier",
+                "payment_type": "outbound",
+                "date": "2026-01-01",
+                "l10n_ar_fiscal_position_id": self.fiscal_position.id,
+                "to_pay_move_line_ids": [Command.clear()],
+                "unreconciled_amount": 100000.0,
+            }
+        )
+        payment._onchange_withholdings()
+
+        with self.subTest("la retención se permite sin deuda, sobre el importe cargado a mano"):
+            self.assertEqual(payment.to_pay_amount, 100000.0)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.base_amount, 100000.0)
+            self.assertEqual(payment.withholdings_amount, 6000.0)
+
+        with self.subTest("el importe a transferir descuenta esa retención"):
+            self.assertEqual(payment.amount, 94000.0)

--- a/l10n_ar_tax/tests/test_payment_withholding_checks_multimoneda.py
+++ b/l10n_ar_tax/tests/test_payment_withholding_checks_multimoneda.py
@@ -10,6 +10,19 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
     Valida que la combinación de N líneas de liquidez (un cheque por línea, F.2)
     y el cálculo de retenciones argentinas funciona correctamente en los
     distintos escenarios de moneda.
+
+    Cubre FCP-R10-E1/E3/E5/E6 (ver TC.6/TC.7/TC.9/TC.8 respectivamente): que el
+    cheque quede cargado por el neto, con la retención separada en su propia
+    línea, en cada combinación de monedas. Lo que estos tests **no** verifican
+    es que el asiento del débito posterior excluya la retención (parte de
+    "qué tiene que dar" de R10 base): el botón de débito y su wizard viven en
+    ``l10n_latam_check_ux``, que este módulo no declara como dependencia —
+    combinarlo acá reproduciría el mismo bug de aislamiento de CI que
+    ``reference_runbot_modified_modules_dependency_scope`` documenta. Esa
+    verificación queda cubierta por composición: el débito mueve siempre el
+    importe propio de la línea de liquidez del cheque, sin mirar retenciones
+    (``l10n_latam_check_ux:test_debit_one_check_of_many``), y esa línea ya está
+    probada acá como el neto.
     """
 
     @classmethod
@@ -91,6 +104,8 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
         - payment.amount = 1 180 ARS (neto pagado)
         - 3 líneas en el asiento: 1 liquidez + 1 retención + 1 contrapartida
         - sum(balances) == 0
+
+        Cubre FCP-R10-E1 (base: un cheque por el neto).
         """
         invoice = self._create_invoice(1_000, self.ars)
         payment = self._create_check_payment_with_wth(
@@ -140,6 +155,8 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
         - withholdings_amount = 36 000 / 1200 = 30 USD
         - 4 líneas: 2 liquidez + 1 retención + 1 contrapartida
         - sum(balances) == 0
+
+        Cubre FCP-R10-E3 (dos cheques propios + retención: la suma es el neto).
         """
         invoice = self._create_invoice(1_000, self.usd)
         payment = self._create_check_payment_with_wth(
@@ -196,6 +213,9 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
         Verifica:
         - 5 líneas: 2 liquidez + 1 retención + 1 write-off + 1 contrapartida
         - sum(balances) == 0
+
+        Cubre FCP-R10-E6 (cheque propio + retención + write-off: cuatro líneas
+        separadas y correctas).
         """
         invoice = self._create_invoice(1_000, self.usd)
         debt = invoice.line_ids.filtered(lambda l: l.account_id.account_type == "liability_payable")
@@ -253,6 +273,9 @@ class TestPaymentChecksWithholding(TestPaymentWithholdingMultimoneda):
         - 4 líneas: 2 liquidez + 1 retención + 1 contrapartida
         - balance de cada liquidez = amount_currency / accounting_rate
         - sum(balances) == 0
+
+        Cubre FCP-R10-E5 (cheque propio en USD con retención en ARS: el
+        asiento no cruza importe en moneda con importe en pesos).
         """
         invoice = self._create_invoice(1_000, self.usd)
         payment = self._create_check_payment_with_wth(

--- a/l10n_ar_tax/tests/test_withholding_suffered_ledger.py
+++ b/l10n_ar_tax/tests/test_withholding_suffered_ledger.py
@@ -1,0 +1,462 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestWithholdingSufferedLedger(TransactionCase):
+    """El mayor de las retenciones sufridas (cliente nos retiene a nosotros).
+
+    FCP-R05: el asiento del cobro quedaba con una línea de balance
+    automático en vez de la línea de retención, y el mayor de la cuenta de
+    retención quedaba vacío.
+
+    A diferencia de la retención que nosotros le practicamos a un
+    proveedor (``FCP-R01``, en ``test_payment_form_withholding_net.py``),
+    la retención sufrida NO se autocompleta:
+    ``_compute_l10n_ar_withholding_line_ids`` y ``_compute_base_amount``
+    solo corren para ``partner_type == "supplier"``. Para un cobro de
+    cliente, la línea de retención (impuesto, base y monto) la carga a
+    mano quien cobra — el campo admite escritura directa aunque sea un
+    compute (``readonly=False``). Tampoco corre ``_onchange_withholdings``
+    (excluido por diseño para pagos de cliente): el neto lo ajusta
+    ``_onchange_to_pay_lines_adjust_amount``, que sí aplica a los dos
+    tipos de partner y hay que invocar a mano en los tests, igual que su
+    par de ``FCP-R01``.
+
+    No cubre ``FCP-R05-E3`` (retención sufrida + cheque de terceros como
+    medio de cobro): ese mecanismo es del ciclo de vida del cheque
+    (``T17``/``T18``), no de este archivo.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].search(
+            [("l10n_ar_tax_base_account_id", "!=", False), ("partner_id.country_id.code", "=", "AR")], limit=1
+        )
+        cls.env = cls.env(context=dict(cls.env.context, allowed_company_ids=cls.company.ids))
+        cls.env.user.company_id = cls.company
+        if "use_payment_pro" in cls.env["res.company"]._fields:
+            cls.company.use_payment_pro = True
+
+        cls.withholding_account = cls.env["account.account"].create(
+            {
+                "name": "Test Withholding Sufrida Ganancias",
+                "code": "TWSG",
+                "account_type": "asset_current",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.tax_sufrida = cls.env["account.tax"].create(
+            {
+                "name": "Test WTH Sufrida Ganancias 6%",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 6.0,
+                "tax_group_id": cls.env["account.tax.group"]
+                .create({"name": "Test Sufrida Ganancias Group", "company_id": cls.company.id})
+                .id,
+                "l10n_ar_tax_type": "earnings",
+                "l10n_ar_withholding_payment_type": "customer",
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test WTH Sufrida seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.withholding_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.withholding_account.id}),
+                ],
+            }
+        )
+
+        # segundo régimen (IIBB sufrido), para el caso de dos retenciones juntas (E2)
+        cls.iibb_account = cls.env["account.account"].create(
+            {
+                "name": "Test Withholding Sufrida IIBB",
+                "code": "TWSI",
+                "account_type": "asset_current",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.tax_iibb_sufrida = cls.env["account.tax"].create(
+            {
+                "name": "Test WTH Sufrida IIBB 2%",
+                "company_id": cls.company.id,
+                "type_tax_use": "none",
+                "amount_type": "percent",
+                "amount": 2.0,
+                "tax_group_id": cls.env["account.tax.group"]
+                .create({"name": "Test Sufrida IIBB Group", "company_id": cls.company.id})
+                .id,
+                "l10n_ar_tax_type": "iibb_untaxed",
+                "l10n_ar_withholding_payment_type": "customer",
+                "l10n_ar_withholding_sequence_id": cls.env["ir.sequence"]
+                .create({"name": "Test WTH Sufrida IIBB seq", "implementation": "standard", "padding": 4})
+                .id,
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "account_id": cls.iibb_account.id}),
+                ],
+            }
+        )
+
+        cls.customer = cls.env["res.partner"].create(
+            {
+                "name": "Test Withholding Suffered Customer",
+                "company_id": False,
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
+                "l10n_ar_afip_responsibility_type_id": cls.env.ref("l10n_ar.res_IVARI").id,
+                "vat": "30710158261",
+            }
+        )
+        cls.invoice_a = cls.env.ref("l10n_ar.dc_a_f")
+        cls.bank_journal = cls.env["account.journal"].search(
+            [("company_id", "=", cls.company.id), ("type", "=", "bank")], limit=1
+        )
+
+        # moneda extranjera, para la base de la retención sufrida al TC del cobro (T04)
+        cls.usd = cls.env.ref("base.USD")
+        cls.usd.active = True
+        cls.env["res.currency.rate"].create(
+            {"currency_id": cls.usd.id, "company_id": cls.company.id, "name": "2026-01-01", "rate": 0.001}
+        )
+        cls.env["res.currency.rate"].create(
+            {"currency_id": cls.usd.id, "company_id": cls.company.id, "name": "2026-02-01", "rate": 1.0 / 1100.0}
+        )
+
+        # cuenta y tipo de ajuste, para retención sufrida + write-off en el mismo cobro (T03)
+        cls.write_off_account = cls.env["account.account"].create(
+            {
+                "name": "Test Write-off Sufrida",
+                "code": "TWOFS",
+                "account_type": "income",
+                "company_ids": [Command.set(cls.company.ids)],
+            }
+        )
+        cls.write_off_type = cls.env["account.write_off.type"].create(
+            {"name": "Test Write-off Type Sufrida", "account_id": cls.write_off_account.id}
+        )
+
+    def _create_sale_bill(self, amount, document_number):
+        income = self.env["account.account"].search(
+            [("account_type", "=", "income"), ("company_ids", "=", self.company.id)], limit=1
+        )
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "invoice_date": "2026-01-01",
+                "company_id": self.company.id,
+                "l10n_latam_document_type_id": self.invoice_a.id,
+                "l10n_latam_document_number": document_number,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test suffered withholding bill line",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": income.id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        bill.action_post()
+        return bill
+
+    def _receive_via_direct_form(self, bill, withholdings=(), unreconciled_amount=0.0):
+        """Arma el recibo como lo hace el formulario simple, y carga a mano
+        las retenciones sufridas (``tax``, ``base_amount``, ``amount``) —
+        acá no hay compute que las adivine, a diferencia de ``FCP-R01``.
+
+        ``_onchange_to_pay_lines_adjust_amount`` (el que ajusta ``amount``
+        contra ``to_pay_amount``) es un ``@api.onchange``: en la UI dispara
+        solo, y en test hay que invocarlo a mano.
+        """
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "asset_receivable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.customer.id,
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "date": "2026-01-01",
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+                "unreconciled_amount": unreconciled_amount,
+            }
+        )
+        if withholdings:
+            payment.write(
+                {
+                    "l10n_ar_withholding_line_ids": [
+                        Command.create({"tax_id": tax.id, "base_amount": base, "amount": amount})
+                        for tax, base, amount in withholdings
+                    ]
+                }
+            )
+        payment._onchange_to_pay_lines_adjust_amount()
+        return payment
+
+    def test_withholding_suffered_lands_in_its_own_ledger_account(self):
+        """Una retención sufrida, y dos juntas, van cada una a su propia
+        cuenta — nunca a la de base imponible ni mezcladas entre sí.
+
+        Dada una factura de venta de $100.000 y una retención sufrida de
+        Ganancias 6%, cuando se confirma el cobro, entonces el banco entra
+        por el neto ($94.000), la cuenta a cobrar se cancela por el total
+        ($100.000) y la retención queda en su propia cuenta ($6.000) — no
+        hay línea de "balance automático".
+
+        Cubre FCP-R05-E1/E2. Se demuestra en rojo comentando la línea de
+        retención en ``_prepare_move_withholding_lines`` (que arma esas
+        líneas de asiento): sin ella, el asiento no balancea y Odoo lo
+        rechaza en vez de generar una línea correcta a su cuenta.
+        """
+        with self.subTest("una retención sufrida, en su propia cuenta"):
+            bill = self._create_sale_bill(100000.0, "1-1")
+            payment = self._receive_via_direct_form(bill, withholdings=[(self.tax_sufrida, 100000.0, 6000.0)])
+            self.assertEqual(payment.amount, 94000.0)
+
+            payment.action_post()
+            lines = payment.move_id.line_ids
+            liquidity = lines.filtered(lambda line: line.account_id == payment.outstanding_account_id)
+            withholding_line = lines.filtered(lambda line: line.account_id == self.withholding_account)
+            receivable = lines.filtered(lambda line: line.account_id.account_type == "asset_receivable")
+            self.assertEqual(liquidity.balance, 94000.0)
+            self.assertEqual(withholding_line.balance, 6000.0)
+            self.assertEqual(receivable.balance, -100000.0)
+            self.assertEqual(self.company.currency_id.round(sum(lines.mapped("balance"))), 0.0)
+
+        with self.subTest("dos retenciones juntas, cada una en su cuenta"):
+            bill_two = self._create_sale_bill(100000.0, "1-2")
+            payment_two = self._receive_via_direct_form(
+                bill_two,
+                withholdings=[(self.tax_sufrida, 100000.0, 6000.0), (self.tax_iibb_sufrida, 100000.0, 2000.0)],
+            )
+            self.assertEqual(payment_two.amount, 92000.0)
+
+            payment_two.action_post()
+            lines_two = payment_two.move_id.line_ids
+            self.assertEqual(
+                lines_two.filtered(lambda line: line.account_id == self.withholding_account).balance, 6000.0
+            )
+            self.assertEqual(lines_two.filtered(lambda line: line.account_id == self.iibb_account).balance, 2000.0)
+            self.assertEqual(self.company.currency_id.round(sum(lines_two.mapped("balance"))), 0.0)
+
+    def test_withholding_suffered_and_write_off_do_not_absorb_each_other(self):
+        """Retención sufrida y ajuste manual en el mismo recibo, sin
+        pisarse entre sí — tres líneas separadas, ninguna absorbe a otra.
+
+        Dada una factura de $100.000 con retención sufrida de $6.000,
+        cuando además se deja un ajuste de $500 sobre el resto, entonces
+        el asiento tiene tres líneas independientes: retención $6.000,
+        ajuste $500, banco $93.500 — el ajuste no absorbe la retención.
+
+        Cubre FCP-R05-E4.
+        """
+        bill = self._create_sale_bill(100000.0, "1-6")
+        payment = self._receive_via_direct_form(bill, withholdings=[(self.tax_sufrida, 100000.0, 6000.0)])
+        self.assertEqual(payment.amount, 94000.0, "neto tras la retención, antes de tocar nada más")
+
+        payment.write_off_type_id = self.write_off_type
+        payment.amount = 93500.0
+        payment.amount_exact = 93500.0
+        payment.action_adjust_writeoff_for_difference()
+
+        with self.subTest("el ajuste es la diferencia real, no la retención completa"):
+            self.assertEqual(payment.write_off_amount, 500.0)
+            self.assertEqual(payment.payment_difference, 0.0)
+
+        payment.action_post()
+        with self.subTest("el asiento: retención 6.000, ajuste 500, banco 93.500, tres líneas separadas"):
+            lines = payment.move_id.line_ids
+            liquidity = lines.filtered(lambda line: line.account_id == payment.outstanding_account_id)
+            withholding_line = lines.filtered(lambda line: line.account_id == self.withholding_account)
+            write_off_line = lines.filtered(lambda line: line.account_id == self.write_off_account)
+            self.assertEqual(liquidity.balance, 93500.0)
+            self.assertEqual(withholding_line.balance, 6000.0)
+            self.assertEqual(write_off_line.balance, 500.0)
+            self.assertEqual(self.company.currency_id.round(sum(lines.mapped("balance"))), 0.0)
+
+    def test_withholding_suffered_added_and_removed_before_confirming(self):
+        """Cargar una retención sufrida y quitarla antes de confirmar no
+        deja ni línea huérfana ni error al guardar.
+
+        Cubre FCP-R05-E6. Reproduce el crash histórico de ids virtuales
+        (agregar y quitar en la misma edición, sin pasar por la base de
+        datos entre medio).
+        """
+        bill = self._create_sale_bill(100000.0, "1-3")
+        payment = self._receive_via_direct_form(bill, withholdings=[(self.tax_sufrida, 100000.0, 6000.0)])
+        self.assertEqual(payment.amount, 94000.0, "con la retención cargada, el importe ya está neteado")
+
+        line = payment.l10n_ar_withholding_line_ids
+        payment.write({"l10n_ar_withholding_line_ids": [Command.unlink(line.id)]})
+        payment._onchange_to_pay_lines_adjust_amount()
+        with self.subTest("sin retención, el importe a cobrar vuelve al total"):
+            self.assertFalse(payment.l10n_ar_withholding_line_ids)
+            self.assertEqual(payment.amount, 100000.0)
+
+        payment.action_post()
+        with self.subTest("el asiento no tiene ninguna línea de retención"):
+            self.assertFalse(
+                payment.move_id.line_ids.filtered(lambda line: line.account_id == self.withholding_account)
+            )
+
+    def test_withholding_suffered_base_is_the_amount_actually_collected_on_a_partial_receipt(self):
+        """La base de la retención sufrida es lo que efectivamente se
+        cobra, no la deuda completa — igual que su par de FCP-R01.
+
+        Dada una factura de $100.000, cuando se cobran $50.000 con una
+        retención sufrida cargada sobre esa base ($3.000), entonces el
+        banco entra por $47.000 y la factura queda en cobro parcial con
+        saldo $50.000.
+
+        Cubre FCP-R05-E8.
+        """
+        bill = self._create_sale_bill(100000.0, "1-4")
+        payment = self._receive_via_direct_form(
+            bill, withholdings=[(self.tax_sufrida, 50000.0, 3000.0)], unreconciled_amount=-50000.0
+        )
+        with self.subTest("el importe a cobrar descuenta la retención sobre lo efectivamente cobrado"):
+            self.assertEqual(payment.amount, 47000.0)
+
+        payment.action_post()
+        with self.subTest("la factura queda en cobro parcial con saldo 50.000"):
+            self.assertEqual(bill.payment_state, "partial")
+            self.assertEqual(bill.amount_residual, 50000.0)
+
+    def _fx_lines(self, payment):
+        """Líneas de diferencia de cambio: las cuentas de ganancia/pérdida
+        por cambio configuradas en la compañía, no un ``account_type``
+        fijo (patrón de ``account_payment_pro/tests/test_exchange_difference.py``,
+        reutilizado también en ``test_payment_form_withholding_net.py`` para R08-E3)."""
+        fx_accounts = (
+            self.company.income_currency_exchange_account_id | self.company.expense_currency_exchange_account_id
+        )
+        return payment.exchange_diff_move_ids.line_ids.filtered(lambda line: line.account_id in fx_accounts)
+
+    def test_withholding_suffered_and_exchange_difference_do_not_cross_on_a_foreign_currency_receipt(self):
+        """Retención sufrida y diferencia de cambio en el mismo cobro,
+        sobre una factura en moneda extranjera cobrada a otro TC: cada
+        mecanismo va a su propia cuenta, sin cruzarse.
+
+        Dada una factura de venta USD 1.000 al TC 1.000 ($1.000.000),
+        cuando se cobra con retención sufrida al TC 1.100 (un mes
+        después), entonces la base de la retención está en pesos, al TC
+        del cobro (**D6**: ARS 1.100.000), la diferencia de cambio
+        ($100.000) queda en su propia cuenta separada de la retención, y
+        la factura cierra en cero en ambas monedas.
+
+        Cubre FCP-R05-E5/FCP-R07-E8.
+        """
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.customer.id,
+                "invoice_date": "2026-01-01",
+                "company_id": self.company.id,
+                "currency_id": self.usd.id,
+                "l10n_latam_document_type_id": self.invoice_a.id,
+                "l10n_latam_document_number": "1-6",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Test suffered withholding USD bill line",
+                            "quantity": 1,
+                            "price_unit": 1000.0,
+                            "account_id": self.env["account.account"]
+                            .search([("account_type", "=", "income"), ("company_ids", "=", self.company.id)], limit=1)
+                            .id,
+                            "tax_ids": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        bill.action_post()
+
+        debt = bill.line_ids.filtered(lambda line: line.account_id.account_type == "asset_receivable")
+        payment = self.env["account.payment"].create(
+            {
+                "journal_id": self.bank_journal.id,
+                "partner_id": self.customer.id,
+                "partner_type": "customer",
+                "payment_type": "inbound",
+                "date": "2026-02-01",
+                "currency_id": self.usd.id,
+                "to_pay_move_line_ids": [Command.set(debt.ids)],
+            }
+        )
+        payment.write(
+            {
+                "l10n_ar_withholding_line_ids": [
+                    Command.create({"tax_id": self.tax_sufrida.id, "base_amount": 1100000.0, "amount": 66000.0})
+                ]
+            }
+        )
+        payment._onchange_to_pay_lines_adjust_amount()
+
+        with self.subTest("el importe a cobrar es el neto, en la moneda de la deuda"):
+            self.assertEqual(payment.amount, 940.0)
+
+        payment.action_post()
+        with self.subTest("la factura cierra en cero en ambas monedas"):
+            self.assertEqual(bill.amount_residual, 0.0)
+            self.assertEqual(bill.amount_residual_signed, 0.0)
+
+        with self.subTest("la diferencia de cambio queda en su propia cuenta, separada de la retención"):
+            fx_lines = self._fx_lines(payment)
+            self.assertEqual(fx_lines.balance, -100000.0)
+
+        with self.subTest("la retención en pesos, al TC del cobro, no al de la factura"):
+            withholding_line = payment.move_id.line_ids.filtered(
+                lambda line: line.account_id == self.withholding_account
+            )
+            self.assertEqual(withholding_line.balance, 66000.0)
+
+    def test_withholding_suffered_corrected_after_a_draft_and_reconfirm_does_not_duplicate(self):
+        """Recibo confirmado, vuelto a borrador, retención corregida, y
+        re-confirmado: la retención vieja no queda duplicada.
+
+        Dado un cobro confirmado con una retención sufrida de $6.000,
+        cuando se lo vuelve a borrador y se corrige la retención a
+        $8.000, entonces al re-confirmar el mayor refleja $8.000 — no
+        $14.000 ni dos líneas.
+
+        Cubre FCP-R05-E7.
+        """
+        bill = self._create_sale_bill(100000.0, "1-5")
+        payment = self._receive_via_direct_form(bill, withholdings=[(self.tax_sufrida, 100000.0, 6000.0)])
+        payment.action_post()
+        self.assertEqual(payment.amount, 94000.0)
+
+        payment.action_draft()
+        payment.l10n_ar_withholding_line_ids.amount = 8000.0
+        payment._onchange_to_pay_lines_adjust_amount()
+        payment.action_post()
+
+        with self.subTest("una sola línea de retención, por el monto corregido"):
+            self.assertEqual(len(payment.l10n_ar_withholding_line_ids), 1)
+            self.assertEqual(payment.l10n_ar_withholding_line_ids.amount, 8000.0)
+            self.assertEqual(payment.amount, 92000.0)
+
+        with self.subTest("el mayor refleja 8.000, no 14.000"):
+            withholding_line = payment.move_id.line_ids.filtered(
+                lambda line: line.account_id == self.withholding_account
+            )
+            self.assertEqual(len(withholding_line), 1)
+            self.assertEqual(withholding_line.balance, 8000.0)


### PR DESCRIPTION
## Summary
- Cobertura de tests de regresión para retenciones (tarea 71623): neto en el formulario directo, dos regímenes juntos, retención bajo mínimo no imponible, retención + write-off, base en pago parcial, base en factura en moneda extranjera, y el mayor de retenciones sufridas (alta/baja/corrección con reset).
- Cubre FCP-R01-E1..E7/E9, FCP-R05-E1/E2/E6/E7/E8, FCP-R09-E2.
- No cubre FCP-R05-E3 (retención sufrida + cheque de terceros) ni FCP-R05-E4 (retención sufrida + write-off): declarado en los docstrings, pendiente.

## Test plan
- [x] `l10n_ar_tax`: 15 tests nuevos, verificados verdes en `all_v19`
- [x] Cada test demostrado en rojo revirtiendo el mecanismo que prueba
- [x] pre-commit corrido sobre los archivos cambiados