### PR TITLE
[FIX] l10n_ar_tax_backward_compatibility: skip non-invoice moves on tax_totals

### DIFF
--- a/l10n_ar_tax_backward_compatibility/models/account_move.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_move.py
@@ -8,7 +8,7 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         super()._compute_tax_totals()
 
-        for move in self.filtered(lambda x: x.state == "posted"):
+        for move in self.filtered(lambda x: x.state == "posted" and x.is_invoice(include_receipts=True)):
             base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
 
             # Detectar si hay impuestos inactivos en las líneas de impuestos
@@ -24,6 +24,10 @@ class AccountMove(models.Model):
 
     def _replace_inactive_tax_amounts(self, move, _tax_lines, inactive_trl_ids):
         tax_totals = move.tax_totals
+        # Los asientos que no son facturas no tienen tax_totals (el compute nativo lo deja
+        # en None) y una factura sin lineas gravadas no tiene subtotals.
+        if not tax_totals or not tax_totals.get("subtotals"):
+            return tax_totals
         subtotal = tax_totals["subtotals"][0]
         tax_groups = subtotal["tax_groups"]
 


### PR DESCRIPTION
## Problema

`account.move._compute_tax_totals()` nativo solo llena `tax_totals` en facturas; para el resto de los tipos de asiento lo deja en `None`:

```python
if move.is_invoice(include_receipts=True):
    move.tax_totals = ...
else:
    move.tax_totals = None
```

El override de este módulo iteraba sobre **todos** los asientos posteados. Al abrir el asiento contable de un pago que arrastra retenciones/percepciones cuyo impuesto está archivado, entra a `_replace_inactive_tax_amounts` y explota al subscriptear `tax_totals["subtotals"]`:

```
TypeError: 'bool' object is not subscriptable
```

## Solución

- Restringir el loop a facturas (`is_invoice(include_receipts=True)`), que es el único caso donde el compute nativo deja el dict.
- Guarda defensiva en `_replace_inactive_tax_amounts`: si `tax_totals` viene vacío o sin `subtotals`, devolverlo tal cual. Cubre además la factura sin líneas gravadas, que daría `IndexError` por el mismo camino.

## Test plan

1. Base con retenciones/percepciones cuyo impuesto está archivado.
2. Abrir el asiento contable de un pago de cliente que las tenga → antes tiraba RPC_ERROR, ahora abre normal.
3. Abrir una factura con impuestos archivados → los montos por grupo de impuesto siguen mostrándose con los valores de las líneas inactivas (comportamiento del módulo, sin cambios).