### PR TITLE
[FIX] l10n_ar_tax_backward_compatibility: match withholdings of migrated branches

### DIFF
--- a/l10n_ar_tax_backward_compatibility/README.rst
+++ b/l10n_ar_tax_backward_compatibility/README.rst
@@ -40,6 +40,8 @@ If the source installation is Odoo 17:
 
 * You only need to update the ``account.payment`` data by mapping the ``codigo_regimen`` to the new ``regime_code`` field, mark those payments as ``is_backward_withholding_payment``, and recalculate the ``regime_tax_id`` field.
 
+Additionally, on databases with branches the migration unified the taxes of the child companies into the parent one: for each regime one ``account.tax`` stays active and its duplicate ends up archived. The journal items of the withholdings point to the surviving tax, while the payment withholding lines (``l10n_ar_withholding_line_ids``) may still point to the archived duplicate, so the strict match of ``account.move.line.withholding_id`` (from ``l10n_ar_tax``) finds nothing and every report reading that field breaks (SIFERE, SICORE, SIRCAR, Misiones, Santa Fe and PBA TXT files). This module adds a fallback: when the strict match fails, the withholding line is looked up by the identity of the regime (withholding payment type, tax type, jurisdiction and code, within the same company tree). It only applies to migrated data -one of the two taxes archived- and when there is a single candidate, so that a wrongly built new payment keeps failing visibly instead of being silently guessed.
+
 -------------------------------------
 
 La manera en que Odoo calcula las retenciones de ganancias ha variado sustancialmente entre las versiones 16, 17 y 18. Este módulo es un módulo técnico. Su objetivo es permitir seguir calculando retenciones acumuladas en instalaciones que migran en medio de un período, o realizar el cálculo de acumulados en los meses anteriores a la migración cuando se agrega un pago en ese período.
@@ -69,6 +71,7 @@ Si la instalación de origen es de Odoo 17:
 
 *   Solo debe actualizar los datos de ``account.payment`` mapeando el ``codigo_regimen`` al nuevo campo ``regime_code``, marcar esos pagos como ``is_backward_withholding_payment`` y recalcular el campo ``regime_tax_id``.
 
+Adicionalmente, en bases con sucursales la migración unificó los impuestos de las compañías hijas en la compañía padre: de cada régimen queda un ``account.tax`` activo y su duplicado archivado. Los apuntes contables de las retenciones quedan apuntando al impuesto superviviente, mientras que las líneas de retención del pago (``l10n_ar_withholding_line_ids``) pueden seguir apuntando al duplicado archivado, con lo cual el match estricto de ``account.move.line.withholding_id`` (de ``l10n_ar_tax``) no encuentra nada y se rompen todos los reportes que leen ese campo (los TXT de SIFERE, SICORE, SIRCAR, Misiones, Santa Fe y PBA). Este módulo agrega un fallback: cuando el match estricto falla, la línea de retención se busca por la identidad del régimen (tipo de pago de la retención, tipo de impuesto, jurisdicción y código, dentro del mismo árbol de compañías). Solo aplica a data migrada -alguno de los dos impuestos archivado- y si hay una única candidata, para que un pago nuevo mal armado siga fallando de forma visible en vez de resolverse por adivinanza.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/l10n_ar_tax_backward_compatibility/models/__init__.py
+++ b/l10n_ar_tax_backward_compatibility/models/__init__.py
@@ -1,3 +1,5 @@
 from . import account_payment
+from . import account_tax
+from . import account_move_line
 from . import l10n_ar_payment_withholding
 from . import account_move

--- a/l10n_ar_tax_backward_compatibility/models/account_move_line.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_move_line.py
@@ -1,0 +1,54 @@
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _compute_withholding(self):
+        """Fallback de matching para pagos de bases migradas con sucursales.
+
+        La migración unificó los impuestos de las compañías hijas en la compañía padre y
+        archivó los duplicados: el apunte contable quedó apuntando al impuesto
+        superviviente y la línea de retención del pago al duplicado archivado, con lo cual
+        el match por identidad de registro del compute de ``l10n_ar_tax`` no encuentra
+        nada. Cuando falla, buscamos la retención por identidad de régimen. El caso y las
+        guardas están documentados en el README.
+        """
+        super()._compute_withholding()
+        todo = self.filtered(lambda x: not x.withholding_id and x.tax_line_id and x.payment_id)
+        if not todo:
+            return
+
+        regime_keys = {}  # tax.id -> clave de régimen, memo del batch del compute
+
+        def regime_key(tax):
+            if tax.id not in regime_keys:
+                regime_keys[tax.id] = tax._l10n_ar_withholding_regime_key()
+            return regime_keys[tax.id]
+
+        for rec in todo:
+            tax = rec.tax_line_id
+            key = regime_key(tax)
+            if not key:
+                continue
+            # Solo reconciliamos data migrada (alguno de los dos impuestos archivado) y
+            # solo si no hay ambigüedad: un pago nuevo mal armado tiene que seguir
+            # fallando de forma visible en vez de resolverse por adivinanza.
+            candidates = rec.payment_id.l10n_ar_withholding_line_ids.filtered(
+                lambda x: not (x.tax_id.active and tax.active) and regime_key(x.tax_id) == key
+            )
+            if len(candidates) == 1:
+                rec.withholding_id = candidates
+            elif candidates:
+                _logger.warning(
+                    "No se pudo resolver la retención del apunte %s: %s líneas del pago %s comparten el "
+                    "régimen del impuesto %s.",
+                    rec.id,
+                    len(candidates),
+                    rec.payment_id.id,
+                    tax.id,
+                )

--- a/l10n_ar_tax_backward_compatibility/models/account_tax.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_tax.py
@@ -1,0 +1,29 @@
+from odoo import models
+
+
+class AccountTax(models.Model):
+    _inherit = "account.tax"
+
+    def _l10n_ar_withholding_regime_key(self):
+        """Clave de identidad del régimen, o False si el impuesto no es una retención.
+
+        Dos registros de ``account.tax`` con la misma clave son el mismo régimen. Es lo
+        que permite reconciliar los duplicados que dejó la migración de bases con
+        sucursales: el régimen existía en la compañía padre y en la hija, y al unificar
+        quedó uno activo y el otro archivado.
+
+        No entran ni el nombre ni la alícuota (la migración pudo renombrar el impuesto y
+        las alícuotas cambian con el tiempo) ni ``tax_group_id`` (los grupos también se
+        unificaron, así que el duplicado archivado puede apuntar a otro registro).
+        """
+        self.ensure_one()
+        if not self.l10n_ar_withholding_payment_type:
+            return False
+        return (
+            self.company_id.root_id.id,
+            self.l10n_ar_withholding_payment_type,
+            self.l10n_ar_tax_type or False,
+            self.l10n_ar_state_id.id,
+            # normalizamos a False para que un código vacío ('') no difiera de uno sin cargar
+            self.l10n_ar_code or False,
+        )


### PR DESCRIPTION
## Problema

En bases migradas con sucursales, el compute `account.move.line.withholding_id`
(`l10n_ar_tax/models/account_move_line.py`) no encuentra la retención del pago y
queda en `False`.

Causa: la migración unificó los impuestos de las compañías hijas en la compañía
padre — de cada régimen queda un `account.tax` activo y el duplicado archivado.
El apunte contable de la retención quedó apuntando al impuesto superviviente
(`tax_line_id`), mientras que la línea de retención del pago
(`l10n_ar_withholding_line_ids.tax_id`) sigue apuntando al duplicado archivado.
El match estricto `x.tax_id == rec.tax_line_id` compara dos registros distintos
del mismo régimen y devuelve vacío.

Consecuencia: se rompen todos los reportes que leen `withholding_id`. El caso
reportado es la descarga del TXT de retenciones sufridas de SIFERE, que explota
en `get_pos_and_number(line.withholding_id.name)`
(`l10n_ar_account_reports/models/sifere_report.py`) porque `name` es `False`.
Mismo riesgo en SICORE, SIRCAR, Misiones, Santa Fe y PBA, que leen
`withholding_id.name` / `.base_amount`.

## Solución

Fallback en `l10n_ar_tax_backward_compatibility` (el módulo que ya concentra las
compatibilidades de data migrada, igual que
`l10n_ar_account_reports_backward_comp._get_settlement_tax`):

- `account.tax._l10n_ar_same_withholding_regime()`: compara dos impuestos por la
  identidad del régimen (`l10n_ar_withholding_payment_type`, `l10n_ar_tax_type`,
  `l10n_ar_state_id`, `l10n_ar_code`) dentro del mismo árbol de compañías
  (`company_id.root_id`). No compara nombre ni alícuota: la migración pudo
  renombrar el impuesto y las alícuotas cambian con el tiempo.
- `account.move.line._compute_withholding()`: cuando el match estricto del super
  falla, busca la retención por régimen.

Dos guardas para no adivinar de más:

- solo aplica si alguno de los dos impuestos está archivado (o sea, es data
  migrada); si los dos están activos el problema sigue siendo visible;
- solo aplica si hay exactamente una candidata.

No toca `l10n_ar_tax`: sin este módulo instalado el comportamiento es el de hoy.

## Test plan

Sin tests automatizados en este PR: reproducir el caso pide simular por SQL el
repunte de impuestos que hizo el script de migración (duplicado archivado).

Verificación manual, sobre una base migrada con sucursales: descargar el TXT de
retenciones sufridas de SIFERE. Antes explota en
`get_pos_and_number(line.withholding_id.name)`; con el fix baja sin error y con
el número de retención.

El README del módulo (bloque en inglés y bloque en español, como ya venía)
resume el caso, el fallback y las dos guardas.

Sin migration script → `nobump`.
