### PR TITLE
[FIX] l10n_ar_tax: guard rentascordoba non-JSON answers

### DIFF
--- a/l10n_ar_tax/i18n/es.po
+++ b/l10n_ar_tax/i18n/es.po
@@ -755,6 +755,12 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "HTTP %s error."
+msgstr "Error HTTP %s."
+
+#. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_account_fiscal_position_l10n_ar_tax__id
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_l10n_ar_payment_withholding__id
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__id
@@ -1088,8 +1094,14 @@ msgstr "El código del estado."
 #. module: l10n_ar_tax
 #. odoo-python
 #: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
-msgid "Timeout error when getting data from rentascordoba.gob.ar"
-msgstr ""
+msgid "The webservice answered a non-JSON response."
+msgstr "El webservice respondió algo que no es JSON."
+
+#. module: l10n_ar_tax
+#. odoo-python
+#: code:addons/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py:0
+msgid "Timeout error when getting data."
+msgstr "Error de timeout al obtener los datos."
 
 #. module: l10n_ar_tax
 #: model:ir.model.fields,field_description:l10n_ar_tax.field_res_company_jurisdiction_padron__l10n_ar_padron_to_date

--- a/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
+++ b/l10n_ar_tax/models/account_fiscal_position_l10n_ar_tax.py
@@ -311,16 +311,22 @@ class AccountFiscalPositionL10nArTax(models.Model):
         try:
             r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=10)
         except requests.exceptions.Timeout as e:
-            msg = self.env._(error_msg + "Timeout error when getting data.")
             _logger.warning("%s" % str(e))
-            raise UserError("%s" % msg)
+            raise UserError(error_msg + self.env._("Timeout error when getting data.")) from e
         except requests.exceptions.RequestException as e:
             _logger.warning("%s" % str(e))
-            raise UserError("%s" % error_msg)
-        if r.status_code == 404:
-            msg = _(error_msg + "404 Not Found error.")
-            raise UserError("%s" % msg)
-        json_body = r.json()
+            raise UserError(error_msg) from e
+        if not r.ok:
+            _logger.warning("rentascordoba answered HTTP %s: %s", r.status_code, r.text[:500])
+            raise UserError(error_msg + self.env._("HTTP %s error.") % r.status_code)
+        # el webservice contesta HTML (pagina de error, mantenimiento) o un body vacio cuando esta
+        # caido, y con un status que no siempre es de error: sin esta guarda el JSONDecodeError sale
+        # crudo al usuario en vez del instructivo de arriba (tickets 108553, 122532, 126698)
+        try:
+            json_body = r.json()
+        except requests.exceptions.JSONDecodeError as e:
+            _logger.warning("rentascordoba answered a non-JSON body: %s", r.text[:500])
+            raise UserError(error_msg + self.env._("The webservice answered a non-JSON response.")) from e
         code = json_body.get("errorCod")
         ref = json_body.get("message")
 

--- a/l10n_ar_tax/tests/__init__.py
+++ b/l10n_ar_tax/tests/__init__.py
@@ -4,5 +4,6 @@ from . import test_padron_tmp_dir
 from . import test_payment_receiptbook_and_withholding
 from . import test_payment_withholding_kept_on_post
 from . import test_payment_withholding_validation
+from . import test_rentas_cordoba_ws_errors
 from . import test_withholding_certificates_mail
 from . import test_withholding_thresholds

--- a/l10n_ar_tax/tests/test_rentas_cordoba_ws_errors.py
+++ b/l10n_ar_tax/tests/test_rentas_cordoba_ws_errors.py
@@ -1,0 +1,164 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import requests
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.exceptions import UserError
+from odoo.fields import Command
+from odoo.tests import common, tagged
+from odoo.tools import mute_logger
+
+WS_LOGGER = "odoo.addons.l10n_ar_tax.models.account_fiscal_position_l10n_ar_tax"
+
+NON_JSON_BODY = "<html><body>Servicio no disponible</body></html>"
+
+
+class RentasCordobaWsMixin:
+    """Helpers para simular respuestas del webservice de Rentas Córdoba sin salir a la provincia."""
+
+    @contextmanager
+    def _without_demo_shortcut(self):
+        """Los métodos del webservice devuelven alícuotas dummy si existe `base.user_demo`.
+
+        Las bases de test lo tienen, así que sin esto no se llega nunca al request. Neutralizamos
+        solo ese xmlid, sin tocar datos ni cachés: cualquier otro `env.ref` sigue igual.
+        """
+        model_data = type(self.env["ir.model.data"])
+        original = model_data._xmlid_to_res_model_res_id
+
+        def _fake(self, xmlid, raise_if_not_found=False):
+            if xmlid == "base.user_demo":
+                return (False, False)
+            return original(self, xmlid, raise_if_not_found=raise_if_not_found)
+
+        with patch.object(model_data, "_xmlid_to_res_model_res_id", _fake):
+            self.assertFalse(self.env.ref("base.user_demo", raise_if_not_found=False))
+            yield
+
+    @contextmanager
+    def _ws_answers(self, status_code=200, body="", exception=None):
+        response = requests.Response()
+        response.status_code = status_code
+        response._content = body.encode()
+
+        def _fake_post(*args, **kwargs):
+            if exception:
+                raise exception
+            return response
+
+        with self._without_demo_shortcut(), patch.object(requests, "post", _fake_post):
+            yield
+
+
+class TestRentasCordobaWsErrors(RentasCordobaWsMixin, common.TransactionCase):
+    """Una respuesta rota del webservice de Rentas Córdoba llega al usuario como UserError.
+
+    Los registros van con `new()` porque el método solo lee `self.tax_type` y `partner.vat`: así el
+    test no depende del plan de cuentas ni de las restricciones de la posición fiscal.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.fp_tax = cls.env["account.fiscal.position.l10n_ar_tax"].new(
+            {"webservice": "rentas_cordoba", "tax_type": "perception"}
+        )
+        cls.partner = cls.env["res.partner"].new({"name": "Rentas Cordoba Test", "vat": "30697130841"})
+        cls.date = cls.env.cr.now().date()
+
+    def _get_data(self):
+        return self.fp_tax._get_rentas_cordoba_data(self.partner, self.date, self.date)
+
+    @mute_logger(WS_LOGGER)
+    def test_non_json_body_raises_user_error(self):
+        """Ticket 126698: el webservice caído contesta HTML con status 200 y `r.json()` explotaba."""
+        with self._ws_answers(status_code=200, body=NON_JSON_BODY):
+            with self.assertRaises(UserError):
+                self._get_data()
+
+    @mute_logger(WS_LOGGER)
+    def test_empty_body_raises_user_error(self):
+        """Un body vacío también rompe el decode: es el otro modo de falla que vimos en producción."""
+        with self._ws_answers(status_code=200, body=""):
+            with self.assertRaises(UserError):
+                self._get_data()
+
+    @mute_logger(WS_LOGGER)
+    def test_http_error_raises_user_error(self):
+        """Cualquier status de error corta antes del decode, no solo el 404 que se chequeaba antes."""
+        with self._ws_answers(status_code=503, body="<html>maintenance</html>"):
+            with self.assertRaises(UserError):
+                self._get_data()
+
+    @mute_logger(WS_LOGGER)
+    def test_timeout_raises_user_error(self):
+        with self._ws_answers(exception=requests.exceptions.Timeout("timed out")):
+            with self.assertRaises(UserError):
+                self._get_data()
+
+    def test_valid_json_is_still_read(self):
+        """El camino feliz no cambia: un no inscripto sigue devolviendo alícuota vacía y su mensaje."""
+        message = "La CUIT ingresada no es correcta o no se encuentra registrada"
+        with self._ws_answers(status_code=200, body='{"errorCod": 3, "message": "%s"}' % message):
+            aliquot, ref = self._get_data()
+
+        self.assertIsNone(aliquot, "Un no inscripto no tiene alícuota")
+        self.assertEqual(ref, message)
+
+
+@tagged("post_install", "-at_install")
+class TestRentasCordobaFiscalPosition(RentasCordobaWsMixin, TestArCommon):
+    """La falla del webservice viaja como UserError por la cadena de la posición fiscal.
+
+    Los tests de arriba llaman al método del webservice directo. Acá entramos por
+    `_l10n_ar_add_taxes`, que es el punto por el que lo consultan los comprobantes y el onchange de
+    la orden de venta: se verifica que el UserError propague hasta el llamador y no se transforme en
+    otra excepción en el camino.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # la percepcion del plan viene con alicuota 0, y _l10n_ar_add_taxes descarta las que valen 0:
+        # copiamos con una alicuota real para que el impuesto por defecto sea observable en el retorno
+        cls.perception_tax = cls.tax_perc_iibb.copy(
+            {"name": "Percepcion IIBB Cordoba Test 3%", "amount": 3.0, "active": True}
+        )
+        cls.fiscal_position = cls.env["account.fiscal.position"].create(
+            {
+                "name": "Percepcion Cordoba por webservice",
+                "company_id": cls.company_ri.id,
+                "l10n_ar_tax_ids": [
+                    Command.create(
+                        {
+                            "webservice": "rentas_cordoba",
+                            "tax_type": "perception",
+                            "default_tax_id": cls.perception_tax.id,
+                        }
+                    )
+                ],
+            }
+        )
+        # el partner no tiene percepciones cargadas, así que la cadena sale a consultar el webservice
+        cls.partner = cls.res_partner_adhoc
+        cls.date = cls.env.cr.now().date()
+
+    def _add_taxes(self):
+        return self.fiscal_position._l10n_ar_add_taxes(self.partner, self.company_ri, self.date, "perception")
+
+    @mute_logger(WS_LOGGER)
+    def test_broken_ws_reaches_the_caller_as_user_error(self):
+        with self._ws_answers(status_code=200, body=NON_JSON_BODY):
+            with self.assertRaises(UserError):
+                self._add_taxes()
+
+    def test_partner_without_aliquot_falls_back_to_default_tax(self):
+        """Con el webservice respondiendo, un no inscripto deja la percepción por defecto."""
+        with self._ws_answers(status_code=200, body='{"errorCod": 3, "message": "No inscripto"}'):
+            taxes = self._add_taxes()
+
+        self.assertEqual(taxes, self.perception_tax)


### PR DESCRIPTION
Reading the Cordoba aliquot of a partner hits the rentascordoba webservice and `r.json()` was decoding its answer outside of any guard, with the only status check being a `404`. When the webservice is down it answers HTML (an error or maintenance page) or an empty body, often with a status that is not an error: the `JSONDecodeError` escaped raw and the user got a traceback instead of the message that explains how to load the aliquot by hand.

The webservice is consulted from a sale order onchange (`_l10n_ar_recompute_fiscal_position_taxes` in `l10n_ar_sale`, triggered when the partner changes), so the raw traceback blocked editing the quotation altogether.

### Why it broke

This is a regression from 4580986 *[IMP] l10n_ar_tax: Webservice Cordoba caido* (#1163). Before that commit `json_body = r.json()` was **inside** the try block, and since `requests.exceptions.JSONDecodeError` subclasses `RequestException` the existing handler already turned it into a `UserError`. Adding the `404` check moved the decode out of the try and left that path uncovered — which is exactly the failure mode the commit set out to handle.

### What changes

- Decode inside a `try`, answering with the same instructions plus the detail.
- Reject any non-ok status instead of only `404`: a 500/502/503 from the province used to reach the decode and fail there.
- Log the body that could not be decoded, to tell an outage apart from a change in the webservice contract.
- Stop wrapping the already translated instructions in a second translation call on the timeout branch, and chain the original exception on every `raise`.
- New English strings translated in `i18n/es.po`. The stale `"Timeout error when getting data from rentascordoba.gob.ar"` entry had an empty `msgstr` and its msgid no longer existed, so it is replaced by the new one.

### Test plan

`l10n_ar_tax/tests/test_rentas_cordoba_ws_errors.py` covers the four broken answers (non-JSON body, empty body, HTTP error, timeout) plus the happy path, mocking `requests.post` so the suite never reaches the province.

Two notes for the reviewer:

- The method returns dummy aliquots when `base.user_demo` exists, and test databases have demo data, so the tests neutralize just that xmlid on `ir.model.data._xmlid_to_res_model_res_id`. No data or cache is touched and every other `env.ref` behaves normally. Deleting the `ir.model.data` row was the obvious alternative, but `_xmlid_lookup` is `ormcache`d and relying on in-transaction invalidation seemed fragile.
- Records are built with `new()`: the method only reads `self.tax_type` and `partner.vat`, so the tests do not depend on the chart of accounts or on the fiscal position constraints.

Warnings are muted per test so the runbot build stays clean.

Full module suite green locally on an 18.0 database: `0 failed, 0 error(s) of 33 tests` (51 tests counting post_install).

Tickets 126698, 122532, 108553.
