### PR TITLE
[FIX] l10n_ar_tax: do not deduct VAT from the withholding base when the document reports none

### DIFF
--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -34,13 +34,7 @@ class AccountMove(models.Model):
 
     def _get_tax_factor(self):
         self.ensure_one()
-        tax_factor = self.amount_total and (self.amount_untaxed / self.amount_total) or 1.0
-        doc_letter = self.l10n_latam_document_type_id.l10n_ar_letter
-        # if we receive B invoices, then we take out 21 of vat
-        # this use of case if when company is except on vat for eg.
-        if tax_factor == 1.0 and doc_letter == "B":
-            tax_factor = 1.0 / 1.21
-        return tax_factor
+        return self.amount_total and (self.amount_untaxed / self.amount_total) or 1.0
 
     def write(self, vals):
         res = super().write(vals)


### PR DESCRIPTION
## Qué cambia

`account.move._get_tax_factor()` deja de descontar un 21% de IVA a los comprobantes que no informan IVA.

El factor salía bien del propio comprobante (`amount_untaxed / amount_total`, que da `1.0` cuando no hay IVA computable) y a continuación se lo pisaba con un `1.0 / 1.21` hardcodeado para todo comprobante letra B cuyo factor fuera `1.0`:

```python
doc_letter = self.l10n_latam_document_type_id.l10n_ar_letter
# if we receive B invoices, then we take out 21 of vat
# this use of case if when company is except on vat for eg.
if tax_factor == 1.0 and doc_letter == "B":
    tax_factor = 1.0 / 1.21
```

El override asume que todo comprobante B sin IVA discriminado lleva IVA del 21% incluido en el precio. Un comprobante B puede ser exento, no gravado o llevar una alícuota distinta del 21%, así que en esos casos la deducción baja la base de la retención —y el importe retenido— sin fundamento, y la base informada en el txt de SICORE deja de coincidir con la operación.

El factor se consume desde `account.payment._compute_selected_debt_untaxed()` y `_compute_matched_amount_untaxed()`, que son los que arman la base de la retención.

## Por qué así

Cuando el comprobante no informa el impuesto, el sistema no tiene con qué deducirlo: adivinar una alícuota es exactamente lo que produce el error, y lo hace en silencio. El caso que el override intentaba cubrir (compañía exenta de IVA que recibe un comprobante B con IVA incluido en el precio) se resuelve ajustando la base en el pago, que es el mecanismo previsto para eso.
