### PR TITLE
[ADD] l10n_ar_tax: acción para armar la NC de una factura con percepciones manuales

### DIFF
--- a/l10n_ar_tax/__manifest__.py
+++ b/l10n_ar_tax/__manifest__.py
@@ -27,6 +27,7 @@
     "data": [
         "security/ir.model.access.csv",
         "data/ir_cron_data.xml",
+        "data/ir_actions_server_data.xml",
         "views/report_withholding_certificate_templates.xml",
         "views/account_payment_view.xml",
         "views/res_company_jurisdiction_padron_view.xml",

--- a/l10n_ar_tax/data/ir_actions_server_data.xml
+++ b/l10n_ar_tax/data/ir_actions_server_data.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Queda en el menú Acción (la "tuerquita") y no como botón en el formulario: es un camino
+         alternativo para un caso de borde, no algo que la mayoría necesite ver.
+
+         `base.group_no_one` la deja visible SOLO en modo debug: `ir.actions.actions.get_bindings`
+         filtra por `has_group`, y para ese grupo `has_group` devuelve True únicamente si la sesión
+         está en debug. Tiene que ser el único grupo del campo: `get_bindings` evalúa los grupos con
+         un `any`, así que sumar otro (por ejemplo Asesor contable) haría que ese rol la vea siempre
+         y anularía la restricción. -->
+    <record id="action_create_refund_with_perceptions" model="ir.actions.server">
+        <field name="name">NC con percepción negativa</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="binding_type">action</field>
+        <field name="binding_view_types">form</field>
+        <field name="groups_id" eval="[(6, 0, [ref('base.group_no_one')])]"/>
+        <field name="state">code</field>
+        <field name="code">
+if record:
+    action = record.action_l10n_ar_create_refund_with_perceptions()
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_ar_tax/models/account_move.py
+++ b/l10n_ar_tax/models/account_move.py
@@ -1,4 +1,5 @@
-from odoo import api, fields, models
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -115,3 +116,103 @@ class AccountMove(models.Model):
         if wth_moves:
             super(AccountMove, wth_moves.with_context(skip_invoice_sync=True)).button_draft()
         return super(AccountMove, self - wth_moves).button_draft()
+
+    def _l10n_ar_manual_fixed_perception_lines(self):
+        """Líneas de impuesto AR ``fixed`` de este comprobante, con importe cargado.
+
+        Son las percepciones/otros impuestos AR (Perc IVA, Decreto 1008/2001) cuyo importe tipea a
+        mano el operador: el ``amount`` del impuesto es un placeholder y el motor de impuestos no
+        puede derivar el importe real. Ver ``action_l10n_ar_create_refund_with_perceptions``.
+        """
+        self.ensure_one()
+        return self.line_ids.filtered(
+            lambda line: line.tax_line_id.amount_type == "fixed"
+            and line.tax_line_id.country_id.code == "AR"
+            and line.balance
+        )
+
+    def action_l10n_ar_create_refund_with_perceptions(self):
+        """Crea la nota de crédito de una factura con percepciones de importe manual.
+
+        El problema que evita: al usar "Agregar nota de crédito", la percepción queda del mismo
+        lado que en la factura en vez de invertirse -su importe no es derivable del cómputo del
+        impuesto, así que la reversión lo copia tal cual-, y la NC le acredita al proveedor de más,
+        por el doble del importe.
+
+        Corregir eso después no funciona: en borrador cualquier guardado que incluya
+        ``invoice_line_ids`` -y el cliente web las manda al guardar antes de confirmar- hace que
+        ``_sync_tax_lines`` vuelva a derivar el signo desde la dirección del documento; y una vez
+        confirmada, la reversión ya concilió la NC contra la factura y
+        ``account.move.line._check_reconciliation`` bloquea modificar esas líneas.
+
+        Por eso acá no revertimos: creamos la NC como un ``in_refund`` nuevo, con las mismas líneas
+        y la percepción ya del lado que corresponde. Al no haber ``reversed_entry_id`` no hay copia
+        con el signo mal ni conciliación automática, el asiento coincide con lo que calcula el
+        motor de impuestos y la corrección se sostiene tanto en borrador como al confirmar.
+
+        Contrapartida de no revertir: la NC no queda vinculada a la factura, así que hay que
+        conciliarla a mano. Dejamos la referencia en ``ref`` para la trazabilidad.
+        """
+        self.ensure_one()
+        # in_invoice y no is_purchase_document(): ese ultimo tambien da True para una NC, y crear
+        # la NC de una NC no tiene sentido.
+        if self.state != "posted" or self.move_type != "in_invoice":
+            raise UserError(_("Esta acción solo aplica a facturas de proveedor confirmadas."))
+        if not self._l10n_ar_manual_fixed_perception_lines():
+            raise UserError(
+                _(
+                    "%s no tiene percepciones de importe manual, así que no hace falta esta acción: "
+                    "use “Agregar nota de crédito”.",
+                    self.display_name,
+                )
+            )
+
+        refund = self.env["account.move"].create(
+            {
+                "move_type": "in_refund",
+                "partner_id": self.partner_id.id,
+                "journal_id": self.journal_id.id,
+                "company_id": self.company_id.id,
+                "currency_id": self.currency_id.id,
+                "invoice_date": fields.Date.context_today(self),
+                "fiscal_position_id": self.fiscal_position_id.id,
+                "invoice_payment_term_id": self.invoice_payment_term_id.id,
+                "ref": _("NC de: %s", self.name),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": line.product_id.id,
+                            "name": line.name,
+                            "quantity": line.quantity,
+                            "price_unit": line.price_unit,
+                            "discount": line.discount,
+                            "account_id": line.account_id.id,
+                            "tax_ids": [Command.set(line.tax_ids.ids)],
+                        }
+                    )
+                    for line in self.invoice_line_ids
+                ],
+            }
+        )
+
+        # La NC nace con la percepcion en el valor de la formula (un placeholder); la dejamos con
+        # el importe de la factura y el signo invertido, que es lo que el operador espera.
+        updates = {}
+        for original in self._l10n_ar_manual_fixed_perception_lines():
+            line = refund.line_ids.filtered(lambda l: l.tax_line_id == original.tax_line_id)[:1]
+            if line:
+                updates[line.id] = {
+                    "balance": -original.balance,
+                    "amount_currency": -original.amount_currency,
+                }
+        if updates:
+            refund.write({"line_ids": [Command.update(line_id, vals) for line_id, vals in updates.items()]})
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Nota de crédito"),
+            "res_model": "account.move",
+            "res_id": refund.id,
+            "view_mode": "form",
+            "context": dict(self.env.context, default_move_type="in_refund"),
+        }


### PR DESCRIPTION
## Qué soluciona

Las percepciones/otros impuestos AR de tipo `fixed` (Perc IVA, Decreto 1008/2001) llevan el
importe tipeado a mano por el operador: el `amount` del impuesto es un placeholder y el motor
de impuestos no puede derivar el importe real.

Al usar "Agregar nota de crédito" sobre una factura así, la percepción queda del mismo lado que
en la factura en vez de invertirse. Visto desde el total, la NC le acredita al proveedor de más
—la diferencia es el doble de la percepción— y al conciliarla contra la factura queda esa
diferencia como residual.

La causa está en cómo `account.move._sync_tax_lines` vuelve a derivar el signo del impuesto
desde la dirección del documento. **Es un problema de Odoo**; esto no lo arregla, lo esquiva.

## Cómo lo resuelve

En vez de corregir la reversión, la evita: la acción crea la NC como un `in_refund` nuevo, con
las mismas líneas y la percepción ya del lado que corresponde.

Al no haber `reversed_entry_id` no hay copia con el signo mal ni conciliación automática, el
asiento coincide con lo que calcula el motor de impuestos, y la NC queda bien tanto en borrador
—el operador la revisa antes de confirmar— como después de confirmar.

## Por qué no se corrige la reversión

Se probaron las cuatro alternativas y cada una falla en un lugar distinto. Queda acá porque es
lo que evita que se reintente:

| Alternativa | Qué le pasa |
|---|---|
| Corregir en borrador | Cualquier guardado que incluya `invoice_line_ids` —y el cliente web las manda al guardar antes de confirmar, aunque el operador no las haya tocado— hace que `_sync_tax_lines` vuelva a derivar el signo. Un `write` de `invoice_line_ids` **sin cambiar ningún valor** alcanza. Además varía según la base. |
| Cargar el importe en el cuadro de totales | Muestra el importe ya con el signo correcto sin importar cómo esté el asiento, así que no hay valor que el operador pueda tipear y el widget descarta la edición por no haber cambio. |
| Corregir con la NC ya confirmada | La reversión concilia la NC contra la factura y `account.move.line._check_reconciliation` bloquea modificar esas líneas. |
| Intervenir el cálculo (`_prepare_tax_line_for_taxes_computation`) | Pierde el importe manual: la percepción queda en el valor de la fórmula y el total da mal. Además tocaría el cálculo de todos los comprobantes AR. |

## Huella

La acción vive en el menú Acción (la "tuerquita") y **solo visible en modo debug**, vía
`base.group_no_one`: `get_bindings` filtra por `has_group` y para ese grupo `has_group` solo
devuelve True si la sesión está en debug. Tiene que ser el único grupo del campo, porque
`get_bindings` los evalúa con un `any` —con otro grupo más, ese rol la vería siempre—.

No hay override de `action_post`, `button_draft`, `_reverse_moves` ni del cálculo de impuestos:
nada de lo que hoy existe cambia de comportamiento.

## Contrapartida

La NC no queda vinculada a la factura, así que no se auto-concilia y hay que conciliarla a
mano. La trazabilidad queda en `ref`.

## Test plan

- [ ] Factura de proveedor con Perc IVA de importe manual, confirmada. Con **modo debug**
      activado, tuerquita → "NC con percepción negativa".
- [ ] Se abre la NC en borrador, con la percepción del lado opuesto al de la factura y el total
      de la NC igual al de la factura.
- [ ] Confirmar: la percepción tiene que seguir bien y el asiento balanceado.
- [ ] Conciliar la NC contra la factura a mano.
- [ ] Sin modo debug, la opción no tiene que aparecer en la tuerquita.
- [ ] Sobre una NC, o sobre una factura sin percepciones de importe manual, la acción tiene que
      cortar con un mensaje.