### PR TITLE
[FIX] l10n_ar_tax_backward_compatibility: only replace tax totals on invoices

### DIFF
--- a/l10n_ar_tax_backward_compatibility/models/account_move.py
+++ b/l10n_ar_tax_backward_compatibility/models/account_move.py
@@ -8,7 +8,10 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         super()._compute_tax_totals()
 
-        for move in self.filtered(lambda x: x.state == "posted"):
+        # tax_totals solo se llena en facturas: para el resto de los asientos el compute de
+        # account deja None (se lee como False), así que un asiento que no es factura -el
+        # asiento de un pago con retenciones, por ejemplo- no tiene nada que reemplazar.
+        for move in self.filtered(lambda x: x.state == "posted" and x.is_invoice(include_receipts=True)):
             base_lines, _tax_lines = move._get_rounded_base_and_tax_lines()
 
             # Detectar si hay impuestos inactivos en las líneas de impuestos


### PR DESCRIPTION
## Problema

`account.move.tax_totals` solo se llena en facturas. El compute de `account`
(`account/models/account_move.py`) es explícito:

```python
for move in self:
    if move.is_invoice(include_receipts=True):
        move.tax_totals = ..._get_tax_totals_summary(...)
    else:
        # Non-invoice moves don't support that field
        move.tax_totals = None
```

Como `tax_totals` es un `fields.Binary`, ese `None` se lee de vuelta como `False`.

El override de `_compute_tax_totals` de este módulo, en cambio, iteraba **todos** los
asientos posteados sin filtrar por factura. Entonces un asiento que no es factura —el
asiento de un pago con retenciones, o un asiento de liquidación— con alguna línea de
impuesto apuntando a un `account.tax` archivado entraba a `_replace_inactive_tax_amounts`
con `tax_totals = False` y rompía:

```
File ".../l10n_ar_tax_backward_compatibility/models/account_move.py", line 27, in _replace_inactive_tax_amounts
    subtotal = tax_totals["subtotals"][0]
               ~~~~~~~~~~^^^^^^^^^^^^^
TypeError: 'bool' object is not subscriptable
```

Se dispara en bases migradas con sucursales, donde la migración unificó los impuestos de
las compañías hijas en la padre y archivó los duplicados: abrir cualquier pago posteado
que tenga una retención con impuesto archivado revienta.

## Solución

Espejar el filtro del super y saltear los asientos que no son facturas. De paso se evita
el `_get_rounded_base_and_tax_lines()` en asientos donde no había nada que reemplazar.

## Test plan

Sin tests automatizados: el escenario pide un impuesto de retención archivado sobre un
asiento de pago ya posteado.

Verificación manual, sobre una base migrada con sucursales:

1. Buscar un pago posteado con una retención cuyo `tax_line_id` esté archivado.
2. Abrir el asiento del pago (o leer `move.tax_totals`). Antes rompe con el `TypeError`
   de arriba; con el fix abre normal.
3. Abrir una factura con un impuesto archivado y confirmar que el reemplazo de montos
   por grupo sigue funcionando igual que antes (el caso que el módulo ya cubría).

Sin migration script → `nobump`.

## Observación fuera de alcance

`_replace_inactive_tax_amounts` toma `tax_totals["subtotals"][0]` y recalcula
`tax_amount` / `total_amount` solo con los grupos de ese primer subtotal. Si algún
`account.tax.group` tiene `preceding_subtotal` cargado hay más de un subtotal y los
totales quedarían incompletos. No es el default de la localización, así que queda
señalado y no tocado en este PR.
