### PR TITLE
[IMP] l10n_ar_ux: show report amounts in negative for special refund invoices

### DIFF
--- a/l10n_ar_ux/README.rst
+++ b/l10n_ar_ux/README.rst
@@ -55,6 +55,7 @@ Reporting & Documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **Invoice Reports**: Implements "duplicado/triplicado" functionality on invoices (extends to delivery slips with l10n_ar_stock)
+* **Negative amounts on special refunds**: Credit notes that share the ARCA document code with the invoice they reverse (codes 60, 99, 186, 188, 189, 33, 331) print their line amounts and totals in negative (port of odoo/odoo#234040, only needed on 19.0)
 * **Transfer Reports**: Enhanced account transfer reports with Argentinian formatting
 
 Installation

--- a/l10n_ar_ux/models/__init__.py
+++ b/l10n_ar_ux/models/__init__.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from . import account_move
+from . import account_move_line
 from . import account_tax
 from . import res_country_state
 from . import afip_padron

--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -2,6 +2,8 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+import copy
+
 from odoo import _, api, models
 from odoo.exceptions import UserError
 from odoo.fields import Domain
@@ -110,6 +112,78 @@ class AccountMove(models.Model):
     @api.model
     def _get_l10n_ar_codes_used_for_inv_and_ref(self):
         return super()._get_l10n_ar_codes_used_for_inv_and_ref() + ["33", "331"]
+
+    # NOTE: the following three methods port odoo/odoo#234040 (merged in Odoo master, not in 19.0).
+    # They must be dropped when migrating to a version that already includes it.
+
+    def _l10n_ar_is_refund_invoice(self):
+        """Check if the document type is in the list of document types that can be used as an invoice and
+        as a refund and the move type is 'in_refund' or 'out_refund'."""
+        return (
+            self.l10n_latam_document_type_id.code in self._get_l10n_ar_codes_used_for_inv_and_ref()
+            and self.move_type in ["in_refund", "out_refund"]
+        )
+
+    def _apply_refund_adjustments(self, tax_totals):
+        """Adjust tax totals for refund invoices that share the same ARCA codes as the invoice they reverse."""
+        for suffix in ("", "_currency"):
+            for prefix in ("base", "tax", "total"):
+                field = f"{prefix}_amount{suffix}"
+                if tax_totals[field]:
+                    tax_totals[field] *= -1
+            for subtotal in tax_totals["subtotals"]:
+                for prefix in ("base", "tax"):
+                    field = f"{prefix}_amount{suffix}"
+                    if subtotal[field]:
+                        subtotal[field] *= -1
+                for tax_group in subtotal["tax_groups"]:
+                    for prefix in ("display_base", "base", "tax"):
+                        field = f"{prefix}_amount{suffix}"
+                        if tax_group[field]:
+                            tax_group[field] *= -1
+
+    def _l10n_ar_get_invoice_totals_for_report(self):
+        """If the invoice document type indicates that vat should not be detailed in the printed report (result of
+        _l10n_ar_include_vat()) then we overwrite tax_totals field so that includes taxes in the total amount,
+        otherwise it would be showing amount_untaxed in the amount_total.
+        Also, if the invoice is a refund and shares the same ARCA code as the invoice it is reversing, we apply
+        adjustments to the tax totals to reflect the amounts in negative.
+
+        Full override of l10n_ar (no super call) mirroring odoo/odoo#234040. We deepcopy tax_totals so the
+        adjustments do not mutate the computed field cache."""
+        self.ensure_one()
+        tax_totals = copy.deepcopy(self.tax_totals)
+        if self._l10n_ar_is_refund_invoice():
+            self._apply_refund_adjustments(tax_totals)
+        include_vat = self._l10n_ar_include_vat()
+        if not include_vat:
+            return tax_totals
+
+        tax_group_ids = {
+            tax_group["id"] for subtotal in tax_totals["subtotals"] for tax_group in subtotal["tax_groups"]
+        }
+        tax_group_ids_to_exclude = (
+            self.env["account.tax.group"]
+            .browse(tax_group_ids)
+            .filtered(
+                lambda tax_group: (
+                    self._l10n_ar_is_tax_group_other_national_ind_tax(tax_group)
+                    or self._l10n_ar_is_tax_group_vat(tax_group)
+                    or (
+                        self._l10n_ar_is_transparency_document()
+                        and self._l10n_ar_is_tax_group_iibb_perception(tax_group)
+                    )
+                )
+            )
+            .ids
+        )
+        if tax_group_ids_to_exclude:
+            if self._l10n_ar_is_refund_invoice():
+                self._apply_refund_adjustments(tax_totals)
+            tax_totals = self.env["account.tax"]._exclude_tax_groups_from_tax_totals_summary(
+                tax_totals, tax_group_ids_to_exclude
+            )
+        return tax_totals
 
     def _get_l10n_latam_documents_domain(self):
         self.ensure_one()

--- a/l10n_ar_ux/models/account_move_line.py
+++ b/l10n_ar_ux/models/account_move_line.py
@@ -1,0 +1,20 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _l10n_ar_prices_and_taxes(self):
+        """Port of odoo/odoo#234040 (merged in Odoo master, not in 19.0): show line amounts in negative on
+        refunds that share the same ARCA document code as the invoice they reverse.
+        Drop when migrating to a version that already includes it."""
+        res = super()._l10n_ar_prices_and_taxes()
+        if self.move_id._l10n_ar_is_refund_invoice():
+            for key in ("price_unit", "price_subtotal", "price_net"):
+                if res[key]:
+                    res[key] *= -1
+        return res

--- a/l10n_ar_ux/tests/__init__.py
+++ b/l10n_ar_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_refund_report

--- a/l10n_ar_ux/tests/test_refund_report.py
+++ b/l10n_ar_ux/tests/test_refund_report.py
@@ -1,0 +1,85 @@
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestRefundReport(TestArCommon):
+    """Refunds that share the ARCA document code with the invoice they reverse (e.g. code 60) must show
+    their amounts in negative on the printed report (port of odoo/odoo#234040)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.doc_60_lp_a = cls.env.ref("l10n_ar.dc_a_cvl")
+
+    def _create_credit_note_60(self):
+        credit_note = self._create_invoice_ar(
+            ref="Credit note with document type 60 for refund test",
+            move_type="out_refund",
+            partner_id=self.res_partner_adhoc,
+            company_id=self.company_ri,
+            invoice_date="2021-03-20",
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_iva_21, price_unit=100.0, quantity=1, tax_ids=self.tax_21
+                ),
+            ],
+        )
+        credit_note.l10n_latam_document_type_id = self.doc_60_lp_a
+        return credit_note
+
+    def test_get_invoice_totals_for_report_refund_with_same_code(self):
+        credit_note = self._create_credit_note_60()
+        self.assertTrue(credit_note._l10n_ar_is_refund_invoice())
+
+        self._assert_tax_totals_summary(
+            credit_note._l10n_ar_get_invoice_totals_for_report(),
+            {
+                "same_tax_base": True,
+                "currency_id": credit_note.currency_id.id,
+                "base_amount_currency": -100.0,
+                "tax_amount_currency": -21.0,
+                "total_amount_currency": -121.0,
+                "subtotals": [
+                    {
+                        "name": "Untaxed Amount",
+                        "base_amount_currency": -100.0,
+                        "tax_amount_currency": -21.0,
+                        "tax_groups": [
+                            {
+                                "id": self.tax_21.tax_group_id.id,
+                                "base_amount_currency": -100.0,
+                                "tax_amount_currency": -21.0,
+                                "display_base_amount_currency": -100.0,
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        # The computed field cache must not be altered by the report adjustments
+        self.assertEqual(credit_note.tax_totals["total_amount_currency"], 121.0)
+
+    def test_prices_and_taxes_refund_with_same_code(self):
+        credit_note = self._create_credit_note_60()
+        values = credit_note.invoice_line_ids._l10n_ar_prices_and_taxes()
+        self.assertEqual(values["price_unit"], -100.0)
+        self.assertEqual(values["price_net"], -100.0)
+        self.assertEqual(values["price_subtotal"], -100.0)
+
+    def test_regular_refund_keeps_positive_amounts(self):
+        """A regular credit note (its own document code) keeps positive amounts on the report."""
+        credit_note = self._create_invoice_ar(
+            move_type="out_refund",
+            partner_id=self.res_partner_adhoc,
+            company_id=self.company_ri,
+            invoice_date="2021-03-20",
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_iva_21, price_unit=100.0, quantity=1, tax_ids=self.tax_21
+                ),
+            ],
+        )
+        self.assertFalse(credit_note._l10n_ar_is_refund_invoice())
+        self.assertEqual(credit_note._l10n_ar_get_invoice_totals_for_report()["total_amount_currency"], 121.0)
+        self.assertEqual(credit_note.invoice_line_ids._l10n_ar_prices_and_taxes()["price_subtotal"], 100.0)


### PR DESCRIPTION
Port of odoo/odoo#234040 (19.0 backport of odoo/odoo#212153, merged in Odoo master but not in 19.0) into `l10n_ar_ux`, so we stop carrying it as a patch on the Odoo 19 image.

**What changes**

Credit notes whose ARCA document type is also used for invoices (codes 60, 99, 186, 188, 189 in `l10n_ar`, plus 33 and 331 added by this module) now print their line amounts and tax totals in negative, so the PDF can be told apart from the invoice they reverse.

**Implementation**

- `account.move`: `_l10n_ar_is_refund_invoice`, `_apply_refund_adjustments` and a full override of `_l10n_ar_get_invoice_totals_for_report` mirroring the Odoo PR. `tax_totals` is deep-copied before adjusting so the computed field cache is not mutated.
- `account.move.line`: `_l10n_ar_prices_and_taxes` calls super and flips the sign of `price_unit`, `price_net` and `price_subtotal`.
- Tests: the one from the Odoo PR plus a line-level case and a regular credit note case.

These methods are only needed on 19.0 and must be dropped on a version whose `l10n_ar` already includes odoo/odoo#212153. Not to be forward-ported.

Tests run locally against `l10n_ar` 19.0 without the image patch: 3 tests, 0 failures.

Task: https://www.adhoc.inc/odoo/project.task/59134
