### PR TITLE
[FIX] l10n_ar_ux: apply refund sign once and keep core report totals logic

### DIFF
--- a/l10n_ar_ux/models/account_move.py
+++ b/l10n_ar_ux/models/account_move.py
@@ -114,7 +114,7 @@ class AccountMove(models.Model):
         return super()._get_l10n_ar_codes_used_for_inv_and_ref() + ["33", "331"]
 
     # NOTE: the following three methods port odoo/odoo#234040 (merged in Odoo master, not in 19.0).
-    # They must be dropped when migrating to a version that already includes it.
+    # They must be dropped when migrating to a version that already includes it (see also odoo/odoo#212153).
 
     def _l10n_ar_is_refund_invoice(self):
         """Check if the document type is in the list of document types that can be used as an invoice and
@@ -143,46 +143,17 @@ class AccountMove(models.Model):
                             tax_group[field] *= -1
 
     def _l10n_ar_get_invoice_totals_for_report(self):
-        """If the invoice document type indicates that vat should not be detailed in the printed report (result of
-        _l10n_ar_include_vat()) then we overwrite tax_totals field so that includes taxes in the total amount,
-        otherwise it would be showing amount_untaxed in the amount_total.
-        Also, if the invoice is a refund and shares the same ARCA code as the invoice it is reversing, we apply
-        adjustments to the tax totals to reflect the amounts in negative.
+        """Show the totals in negative for refunds that share the ARCA document code with the invoice they
+        reverse (port of odoo/odoo#234040).
 
-        Full override of l10n_ar (no super call) mirroring odoo/odoo#234040. We deepcopy tax_totals so the
-        adjustments do not mutate the computed field cache."""
-        self.ensure_one()
-        tax_totals = copy.deepcopy(self.tax_totals)
+        The sign is applied once on the result of super(): `_exclude_tax_groups_from_tax_totals_summary` only
+        adds and subtracts amounts, so flipping the sign after it is equivalent to flipping it before, and the
+        core logic is kept untouched."""
+        tax_totals = super()._l10n_ar_get_invoice_totals_for_report()
         if self._l10n_ar_is_refund_invoice():
+            # super() may return the cached dict of the computed field: never mutate it in place
+            tax_totals = copy.deepcopy(tax_totals)
             self._apply_refund_adjustments(tax_totals)
-        include_vat = self._l10n_ar_include_vat()
-        if not include_vat:
-            return tax_totals
-
-        tax_group_ids = {
-            tax_group["id"] for subtotal in tax_totals["subtotals"] for tax_group in subtotal["tax_groups"]
-        }
-        tax_group_ids_to_exclude = (
-            self.env["account.tax.group"]
-            .browse(tax_group_ids)
-            .filtered(
-                lambda tax_group: (
-                    self._l10n_ar_is_tax_group_other_national_ind_tax(tax_group)
-                    or self._l10n_ar_is_tax_group_vat(tax_group)
-                    or (
-                        self._l10n_ar_is_transparency_document()
-                        and self._l10n_ar_is_tax_group_iibb_perception(tax_group)
-                    )
-                )
-            )
-            .ids
-        )
-        if tax_group_ids_to_exclude:
-            if self._l10n_ar_is_refund_invoice():
-                self._apply_refund_adjustments(tax_totals)
-            tax_totals = self.env["account.tax"]._exclude_tax_groups_from_tax_totals_summary(
-                tax_totals, tax_group_ids_to_exclude
-            )
         return tax_totals
 
     def _get_l10n_latam_documents_domain(self):

--- a/l10n_ar_ux/tests/test_refund_report.py
+++ b/l10n_ar_ux/tests/test_refund_report.py
@@ -11,10 +11,11 @@ class TestRefundReport(TestArCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.doc_60_lp_a = cls.env.ref("l10n_ar.dc_a_cvl")
+        cls.doc_188_lp_b = cls.env.ref("l10n_ar.dc_liq_cd_sp_b")
 
-    def _create_credit_note_60(self):
+    def _create_credit_note(self, document_type):
         credit_note = self._create_invoice_ar(
-            ref="Credit note with document type 60 for refund test",
+            ref="Credit note with a document type used both for invoices and refunds",
             move_type="out_refund",
             partner_id=self.res_partner_adhoc,
             company_id=self.company_ri,
@@ -25,11 +26,11 @@ class TestRefundReport(TestArCommon):
                 ),
             ],
         )
-        credit_note.l10n_latam_document_type_id = self.doc_60_lp_a
+        credit_note.l10n_latam_document_type_id = document_type
         return credit_note
 
     def test_get_invoice_totals_for_report_refund_with_same_code(self):
-        credit_note = self._create_credit_note_60()
+        credit_note = self._create_credit_note(self.doc_60_lp_a)
         self.assertTrue(credit_note._l10n_ar_is_refund_invoice())
 
         self._assert_tax_totals_summary(
@@ -60,8 +61,21 @@ class TestRefundReport(TestArCommon):
         # The computed field cache must not be altered by the report adjustments
         self.assertEqual(credit_note.tax_totals["total_amount_currency"], 121.0)
 
+    def test_get_invoice_totals_for_report_refund_with_same_code_vat_included(self):
+        """Document 188 is letter B: VAT is not detailed on the report and gets folded into the base amount.
+        The sign must be applied only once, so the totals stay negative on this path too."""
+        credit_note = self._create_credit_note(self.doc_188_lp_b)
+        self.assertTrue(credit_note._l10n_ar_is_refund_invoice())
+        self.assertTrue(credit_note._l10n_ar_include_vat())
+
+        tax_totals = credit_note._l10n_ar_get_invoice_totals_for_report()
+        self.assertEqual(tax_totals["base_amount_currency"], -121.0)
+        self.assertEqual(tax_totals["tax_amount_currency"], 0.0)
+        self.assertEqual(tax_totals["total_amount_currency"], -121.0)
+        self.assertEqual(credit_note.tax_totals["total_amount_currency"], 121.0)
+
     def test_prices_and_taxes_refund_with_same_code(self):
-        credit_note = self._create_credit_note_60()
+        credit_note = self._create_credit_note(self.doc_60_lp_a)
         values = credit_note.invoice_line_ids._l10n_ar_prices_and_taxes()
         self.assertEqual(values["price_unit"], -100.0)
         self.assertEqual(values["price_net"], -100.0)


### PR DESCRIPTION
Follow-up of #1556 (port of odoo/odoo#234040), addressing the technical review.

**Fix 1: sign applied once.** `_l10n_ar_get_invoice_totals_for_report` applied `_apply_refund_adjustments` twice on the same dict (at the beginning and again before excluding the VAT groups). For document types where VAT is not detailed on the report (letters B, C, X, R, e.g. codes 188 and 189) the second call undid the first one: totals printed in positive while the lines printed in negative.

**Fix 2: no full override.** The method now calls `super()` and flips the sign once on a deep copy of the result, instead of copying the whole core method. `_exclude_tax_groups_from_tax_totals_summary` only adds and subtracts amounts, so applying the sign after it is equivalent to applying it before, and future changes in the core method are kept.

Tests: new case for document type 188 (VAT-included path), plus the existing ones. Run locally against `l10n_ar` 19.0 without the image patch: 4 tests, 0 failures.

Same fix proposed upstream for master: odoo/odoo (PR link in the task).

Task: https://www.adhoc.inc/odoo/project.task/59134
