### PR TITLE
[FIX] l10n_ar_tax: withholdings with checks left the payment entry unbalanced

### DIFF
--- a/l10n_ar_tax/models/account_payment.py
+++ b/l10n_ar_tax/models/account_payment.py
@@ -306,8 +306,17 @@ class AccountPayment(models.Model):
             foreign_journal = self.currency_id != self.company_id.currency_id
 
             liquidity_lines = res.get("liquidity_lines", [])
-            has_checks = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
-            if not has_checks and liquidity_lines:
+            # ¿La liquidez ya viene dividida en una línea por cheque?  Con el PR odoo#248741
+            # (`l10n_latam_check._prepare_move_liquidity_lines`) sí, y ahí `l10n_latam_check_ux` ya
+            # dejó liquidez y contrapartida al bruto: los ajustes de abajo duplicarían la retención.
+            # Sin ese PR la liquidez llega en UNA línea y neta —el core le resta las retenciones en
+            # `account/models/account_payment.py`— y `l10n_latam_check_ux` se abstiene por falta de
+            # líneas por cheque, así que los ajustes son imprescindibles: si no, el asiento del pago
+            # cierra con liquidez y contrapartida netas y `_l10n_latam_check_split_move` revienta con
+            # "El asiento no está balanceado" por el importe de la retención.  Preguntar por los
+            # cheques del pago, en vez de por la forma de la liquidez, dejaba ese caso sin dueño.
+            liquidity_split_by_check = bool(liquidity_lines and liquidity_lines[0].get("l10n_latam_check_ids"))
+            if not liquidity_split_by_check and liquidity_lines:
                 if foreign_journal:
                     # A≠C: base Odoo sumó withholding amount_currency (ARS) dentro de la
                     # liquidez en USD, mezclando monedas.  payment_pro luego recalculó el
@@ -329,8 +338,8 @@ class AccountPayment(models.Model):
                     res["liquidity_lines"] = []
             counterpart_lines = res.get("counterpart_lines", [])
             if counterpart_lines:
-                if not has_checks:
-                    # When has_checks, account_payment_pro already computed counterpart correctly
+                if not liquidity_split_by_check:
+                    # When liquidity_split_by_check, account_payment_pro already computed counterpart correctly
                     # using the sum of ALL liq lines (one per check) plus wth total. Touching it
                     # here would either double-count wth (non-foreign case) or overwrite the correct
                     # multi-check sum with a single-line value (foreign case). Both produce an
@@ -352,7 +361,7 @@ class AccountPayment(models.Model):
                     # lo que produciría sumar ARS a un amount_currency en USD.
                     wth_amount_in_b = self.counterpart_currency_id.round(wth_balance * (self.counterpart_rate or 1.0))
                     counterpart_lines[0]["amount_currency"] -= wth_amount_in_b
-                elif not has_checks and not (
+                elif not liquidity_split_by_check and not (
                     self.counterpart_currency_id and self.counterpart_currency_id != self.currency_id
                 ):
                     # Solo ajustamos amount_currency de la contrapartida si B1 == A (misma moneda).
@@ -360,7 +369,7 @@ class AccountPayment(models.Model):
                     # refleja el total en B1 y no hay que restarle el equivalente en A de las retenciones.
                     # Usamos el equivalente en moneda del pago (no la suma raw) para que el
                     # amount_currency de la contrapartida quede correctamente en la moneda del pago.
-                    # Mismo razonamiento que para balance: has_checks implica que account_payment_pro
+                    # Mismo razonamiento que para balance: liquidity_split_by_check implica que account_payment_pro
                     # ya computó amount_currency correctamente.
                     counterpart_lines[0]["amount_currency"] -= wth_amount_currency_pay
 
@@ -369,7 +378,7 @@ class AccountPayment(models.Model):
                 # amount_currency quedó en el valor corrupto de base Odoo (p.ej. 980 vs 1010),
                 # Odoo puede usar amount_currency como autoridad y reescribir el balance, dejando
                 # el asiento desbalanceado en la diferencia → "Automatic Balancing Line".
-                # Esto ocurre con has_checks porque l10n_ar_tax no ajusta amount_currency en ese caso.
+                # Esto ocurre con liquidity_split_by_check porque l10n_ar_tax no ajusta amount_currency en ese caso.
                 if counterpart_lines[0].get("currency_id") == self.company_currency_id.id:
                     counterpart_lines[0]["amount_currency"] = counterpart_lines[0]["balance"]
 


### PR DESCRIPTION
## El problema

En `odoo/odoo` 19.0 upstream (sin el PR odoo#248741), un pago a proveedor que tiene
**cheques propios y retenciones a la vez** no se puede confirmar: falla con **"El asiento no
está balanceado"**, desbalanceado exactamente por el importe retenido.

### Ejemplo

Factura de proveedor de **1.210** (1.000 neto + 210 de IVA), con retención de IIBB del 3%
sobre el neto = **30**. Se paga con **dos cheques propios** de 600 y 580, que suman
**1.180** (= 1.210 − 30).

El asiento que corresponde es este, y es el que sale **con este cambio**:

| Cuenta | Debe | Haber |
|---|---:|---:|
| Cheques propios (pendiente de pago) | | 1.180,00 |
| Proveedor | 1.210,00 | |
| Retención IIBB a pagar | | 30,00 |
| Base retención + contrapartida | 1.000,00 | 1.000,00 |

Lo que arma el código hoy, en cambio, es esto:

| Cuenta | Debe | Haber | |
|---|---:|---:|---|
| Cheques propios | | **1.150,00** | ← se entregaron cheques por 1.180 |
| Proveedor | **1.180,00** | | ← se cancela deuda por 1.210 |
| Retención IIBB | | 30,00 | |

Cierra en cero, pero con las dos cifras mal: a la liquidez y a la contrapartida les falta la
misma retención de 30, y los dos errores se compensan entre sí.

### Por qué termina fallando

Con dos o más cheques, `_l10n_latam_check_split_move` arma un segundo asiento con una línea
por cheque. Pone `amount_currency` al importe **bruto** de cada cheque, pero prorratea
`debit`/`credit` sobre el balance de liquidez **neto** que quedó en el asiento del pago:

```
cheque  600,00 -> balance  -584,75   amount_currency  -600,00
cheque  580,00 -> balance  -565,25   amount_currency  -580,00
cancelación    -> balance  1150,00   amount_currency  1150,00
SUMA balance         =     0,00   (cierra)
SUMA amount_currency =   -30,00   <- desbalance
```

Como todo está en moneda de compañía, `_inverse_amount_currency`
(`account/models/account_move_line.py`) descarta el balance prorrateado y lo reescribe desde
`amount_currency`. El asiento queda desbalanceado en los 30 de retención y el posteo aborta.

Con **un solo cheque** el split no se arma (`len(l10n_latam_new_check_ids) == 1` sale por
`continue`), así que no hay error: el pago se postea igual, con el asiento equivocado de la
segunda tabla. La retención nunca reduce la deuda del proveedor y el saldo queda mal en
silencio.

## La causa

`l10n_ar_tax/models/account_payment.py:309` saltea el ajuste que devuelve la retención a la
liquidez en cuanto el pago tiene cheques:

```python
has_checks = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
if not has_checks and liquidity_lines:
```

El razonamiento de los comentarios es que `l10n_latam_check_ux` ya rearmó liquidez y
contrapartida al bruto a partir de una línea de liquidez por cheque. Eso vale **solo con
odoo#248741 mergeado**. Sin ese PR:

1. el core de `account` netea la liquidez (`liquidity_balance -= withholding_balance`),
2. la liquidez llega en **una sola línea**,
3. `l10n_latam_check_ux._prepare_move_lines_per_type` se abstiene, porque esa línea no trae
   `l10n_latam_check_ids`,
4. y entonces nadie ajusta nada.

Los dos módulos se corren esperando que el otro se ocupe, y el caso queda sin dueño.

## El cambio

Preguntar lo que el código realmente necesita saber —¿alguien ya dividió la liquidez por
cheque?— en lugar de si el pago tiene cheques:

```diff
             liquidity_lines = res.get("liquidity_lines", [])
-            has_checks = self.l10n_latam_new_check_ids | self.l10n_latam_move_check_ids
-            if not has_checks and liquidity_lines:
+            liquidity_split_by_check = bool(liquidity_lines and liquidity_lines[0].get("l10n_latam_check_ids"))
+            if not liquidity_split_by_check and liquidity_lines:
```

Más el renombre de la variable en sus otros tres usos (`:332` y `:355`), porque con la nueva
definición el nombre `has_checks` diría algo que la variable ya no significa.

**Con odoo#248741 aplicado no cambia nada**: ahí las líneas sí traen `l10n_latam_check_ids`,
el gate sigue dando `True` y el camino es el mismo de hoy.

**Y no puede romper ningún caso que hoy funcione**, por dos razones:

- Todo este bloque vive dentro de `if wth_lines:`, así que un pago sin retenciones no lo
  alcanza nunca.
- El gate solo puede pasar de `True` a `False`, nunca al revés, porque una línea de liquidez
  trae `l10n_latam_check_ids` únicamente si el pago tiene cheques. O sea: el cambio puede
  agregar ajustes que antes se omitían, pero no puede quitar ninguno que hoy se aplique.

## Dos casos más que el mismo gate rompía

- **Cheques de terceros + retención**: posteaba *en silencio* con el asiento mal. Se
  acreditaban 2.441.598,46 en la cuenta pendiente contra 2.491.427,00 de cheques realmente
  entregados, y la retención no reducía la deuda (residual de la factura −24.312.664,18 en
  lugar de −24.262.835,64). Sin error visible.
- **Diario en moneda extranjera + cheques + retención**: la liquidez quedaba con `balance` y
  `amount_currency` de signos opuestos (−14.885.000 / +190.000) y el posteo chocaba contra
  `account_move_line_check_amount_currency_balance_sign`.

Los dos postean bien con este cambio.

## Una pregunta

¿El caso de cheques de terceros les falla también a ustedes? Con odoo#248741 la división por
cheque parece cubrir `l10n_latam_new_check_ids`, así que un pago que use
`l10n_latam_move_check_ids` seguiría cayendo en el gate viejo como `True`, con una única línea
de liquidez neta — el asiento mal en silencio que describo arriba. No pude verificarlo porque
no tengo ese PR aplicado.
